### PR TITLE
Run gen command from the root path

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ Unlike other Kafka protocol implementations, this project uses code generation t
 including different protocol versions. See [Kafka's repo](https://github.com/apache/kafka/blob/trunk/clients/src/main/resources/common/message)
 for an example of protocol schema.
 
+The code generator fetch the Kafka [repo](https://github.com/apache/kafka), and use the default branch to generate codes.
+
+## For Developers
+
+Run `cargo run -p protocol_codegen` in the root path of this repo to generate/update the Rust codes via the latest Kafka
+protocol schema.
 
 Originally implemented by
 [@Diggsey](https://github.com/Diggsey) in a minimal Kafka client implementation [Franz](https://github.com/Diggsey/franz)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Rust implementation of the [Kafka wire protocol](https://kafka.apache.org/protocol.html).
 
-Unlike other Kafka protocol implementations, this project uses code generation to cover the entire Kafka API surface, 
+Unlike other Kafka protocol implementations, this project uses code generation to cover the entire Kafka API surface,
 including different protocol versions. See [Kafka's repo](https://github.com/apache/kafka/blob/trunk/clients/src/main/resources/common/message)
 for an example of protocol schema.
 

--- a/protocol_codegen/src/generate_messages.rs
+++ b/protocol_codegen/src/generate_messages.rs
@@ -99,6 +99,7 @@ pub fn run() -> Result<(), Error> {
     }
 
     writeln!(module_file, "/// Valid API keys in the Kafka protocol.")?;
+    writeln!(module_file, "#[derive(Debug, Clone, Copy, PartialEq, Eq)]")?;
     writeln!(module_file, "pub enum ApiKey {{")?;
     for (api_key, request_type) in request_types.iter() {
         writeln!(module_file, "    /// API key for request {}", request_type)?;
@@ -130,7 +131,7 @@ pub fn run() -> Result<(), Error> {
     writeln!(module_file)?;
 
     writeln!(module_file, "/// Wrapping enum for all requests in the Kafka protocol.")?;
-    writeln!(module_file, "#[derive(Debug)]")?;
+    writeln!(module_file, "#[derive(Debug, Clone, PartialEq)]")?;
     writeln!(module_file, "pub enum RequestKind {{")?;
     for (_, request_type) in request_types.iter() {
         writeln!(module_file, "    /// {},", request_type)?;
@@ -140,7 +141,7 @@ pub fn run() -> Result<(), Error> {
     writeln!(module_file)?;
 
     writeln!(module_file, "/// Wrapping enum for all responses in the Kafka protocol.")?;
-    writeln!(module_file, "#[derive(Debug)]")?;
+    writeln!(module_file, "#[derive(Debug, Clone, PartialEq)]")?;
     writeln!(module_file, "pub enum ResponseKind {{")?;
     for (_, response_type) in response_types.iter() {
         writeln!(module_file, "    /// {},", response_type)?;
@@ -150,7 +151,7 @@ pub fn run() -> Result<(), Error> {
     writeln!(module_file)?;
 
     for entity_type in entity_types {
-        let mut derives = vec!["Debug", "Clone", "Eq", "PartialEq", "Ord", "PartialOrd", "Hash", "Default", "derive_builder::Builder"];
+        let mut derives = vec!["Debug", "Clone", "Eq", "PartialEq", "Ord", "PartialOrd", "Hash", "Default"];
         if entity_type.inner.is_copy() {
             derives.push("Copy");
         }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -36,17 +36,17 @@ pub use alter_configs_request::AlterConfigsRequest;
 pub mod alter_configs_response;
 pub use alter_configs_response::AlterConfigsResponse;
 
-pub mod alter_isr_request;
-pub use alter_isr_request::AlterIsrRequest;
-
-pub mod alter_isr_response;
-pub use alter_isr_response::AlterIsrResponse;
-
 pub mod alter_partition_reassignments_request;
 pub use alter_partition_reassignments_request::AlterPartitionReassignmentsRequest;
 
 pub mod alter_partition_reassignments_response;
 pub use alter_partition_reassignments_response::AlterPartitionReassignmentsResponse;
+
+pub mod alter_partition_request;
+pub use alter_partition_request::AlterPartitionRequest;
+
+pub mod alter_partition_response;
+pub use alter_partition_response::AlterPartitionResponse;
 
 pub mod alter_replica_log_dirs_request;
 pub use alter_replica_log_dirs_request::AlterReplicaLogDirsRequest;
@@ -718,9 +718,9 @@ impl Request for DescribeQuorumRequest {
     type Response = DescribeQuorumResponse;
 }
 
-impl Request for AlterIsrRequest {
+impl Request for AlterPartitionRequest {
     const KEY: i16 = 56;
-    type Response = AlterIsrResponse;
+    type Response = AlterPartitionResponse;
 }
 
 impl Request for UpdateFeaturesRequest {
@@ -779,6 +779,7 @@ impl Request for AllocateProducerIdsRequest {
 }
 
 /// Valid API keys in the Kafka protocol.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ApiKey {
     /// API key for request ProduceRequest
     ProduceKey = 0,
@@ -892,8 +893,8 @@ pub enum ApiKey {
     EndQuorumEpochKey = 54,
     /// API key for request DescribeQuorumRequest
     DescribeQuorumKey = 55,
-    /// API key for request AlterIsrRequest
-    AlterIsrKey = 56,
+    /// API key for request AlterPartitionRequest
+    AlterPartitionKey = 56,
     /// API key for request UpdateFeaturesRequest
     UpdateFeaturesKey = 57,
     /// API key for request EnvelopeRequest
@@ -979,7 +980,7 @@ impl TryFrom<i16> for ApiKey {
             x if x == ApiKey::BeginQuorumEpochKey as i16 => Ok(ApiKey::BeginQuorumEpochKey),
             x if x == ApiKey::EndQuorumEpochKey as i16 => Ok(ApiKey::EndQuorumEpochKey),
             x if x == ApiKey::DescribeQuorumKey as i16 => Ok(ApiKey::DescribeQuorumKey),
-            x if x == ApiKey::AlterIsrKey as i16 => Ok(ApiKey::AlterIsrKey),
+            x if x == ApiKey::AlterPartitionKey as i16 => Ok(ApiKey::AlterPartitionKey),
             x if x == ApiKey::UpdateFeaturesKey as i16 => Ok(ApiKey::UpdateFeaturesKey),
             x if x == ApiKey::EnvelopeKey as i16 => Ok(ApiKey::EnvelopeKey),
             x if x == ApiKey::FetchSnapshotKey as i16 => Ok(ApiKey::FetchSnapshotKey),
@@ -997,7 +998,7 @@ impl TryFrom<i16> for ApiKey {
 }
 
 /// Wrapping enum for all requests in the Kafka protocol.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum RequestKind {
     /// ProduceRequest,
     ProduceRequest(ProduceRequest),
@@ -1111,8 +1112,8 @@ pub enum RequestKind {
     EndQuorumEpochRequest(EndQuorumEpochRequest),
     /// DescribeQuorumRequest,
     DescribeQuorumRequest(DescribeQuorumRequest),
-    /// AlterIsrRequest,
-    AlterIsrRequest(AlterIsrRequest),
+    /// AlterPartitionRequest,
+    AlterPartitionRequest(AlterPartitionRequest),
     /// UpdateFeaturesRequest,
     UpdateFeaturesRequest(UpdateFeaturesRequest),
     /// EnvelopeRequest,
@@ -1138,7 +1139,7 @@ pub enum RequestKind {
 }
 
 /// Wrapping enum for all responses in the Kafka protocol.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum ResponseKind {
     /// ProduceResponse,
     ProduceResponse(ProduceResponse),
@@ -1252,8 +1253,8 @@ pub enum ResponseKind {
     EndQuorumEpochResponse(EndQuorumEpochResponse),
     /// DescribeQuorumResponse,
     DescribeQuorumResponse(DescribeQuorumResponse),
-    /// AlterIsrResponse,
-    AlterIsrResponse(AlterIsrResponse),
+    /// AlterPartitionResponse,
+    AlterPartitionResponse(AlterPartitionResponse),
     /// UpdateFeaturesResponse,
     UpdateFeaturesResponse(UpdateFeaturesResponse),
     /// EnvelopeResponse,

--- a/src/messages/alter_partition_request.rs
+++ b/src/messages/alter_partition_request.rs
@@ -1,6 +1,6 @@
-//! AlterIsrRequest
+//! AlterPartitionRequest
 //!
-//! See the schema for this message [here](https://github.com/apache/kafka/blob/trunk/clients/src/main/resources/common/message/AlterIsrRequest.json).
+//! See the schema for this message [here](https://github.com/apache/kafka/blob/trunk/clients/src/main/resources/common/message/AlterPartitionRequest.json).
 // WARNING: the items of this module are generated and should not be edited directly
 #![allow(unused)]
 
@@ -17,28 +17,33 @@ use crate::protocol::{
 };
 
 
-/// Valid versions: 0
+/// Valid versions: 0-1
 #[derive(Debug, Clone, PartialEq, derive_builder::Builder)]
 pub struct PartitionData {
     /// The partition index
     /// 
-    /// Supported API versions: 0
+    /// Supported API versions: 0-1
     pub partition_index: i32,
 
     /// The leader epoch of this partition
     /// 
-    /// Supported API versions: 0
+    /// Supported API versions: 0-1
     pub leader_epoch: i32,
 
     /// The ISR for this partition
     /// 
-    /// Supported API versions: 0
+    /// Supported API versions: 0-1
     pub new_isr: Vec<super::BrokerId>,
 
-    /// The expected version of ISR which is being updated
+    /// 1 if the partition is recovering from an unclean leader election; 0 otherwise.
     /// 
-    /// Supported API versions: 0
-    pub current_isr_version: i32,
+    /// Supported API versions: 1
+    pub leader_recovery_state: i8,
+
+    /// The expected epoch of the partition which is being updated. For legacy cluster this is the ZkVersion in the LeaderAndIsr request.
+    /// 
+    /// Supported API versions: 0-1
+    pub partition_epoch: i32,
 
     /// Other tagged fields
     pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
@@ -49,7 +54,14 @@ impl Encodable for PartitionData {
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int32.encode(buf, &self.leader_epoch)?;
         types::CompactArray(types::Int32).encode(buf, &self.new_isr)?;
-        types::Int32.encode(buf, &self.current_isr_version)?;
+        if version >= 1 {
+            types::Int8.encode(buf, &self.leader_recovery_state)?;
+        } else {
+            if self.leader_recovery_state != 0 {
+                return Err(EncodeError)
+            }
+        }
+        types::Int32.encode(buf, &self.partition_epoch)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
@@ -65,7 +77,14 @@ impl Encodable for PartitionData {
         total_size += types::Int32.compute_size(&self.partition_index)?;
         total_size += types::Int32.compute_size(&self.leader_epoch)?;
         total_size += types::CompactArray(types::Int32).compute_size(&self.new_isr)?;
-        total_size += types::Int32.compute_size(&self.current_isr_version)?;
+        if version >= 1 {
+            total_size += types::Int8.compute_size(&self.leader_recovery_state)?;
+        } else {
+            if self.leader_recovery_state != 0 {
+                return Err(EncodeError)
+            }
+        }
+        total_size += types::Int32.compute_size(&self.partition_epoch)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
@@ -83,7 +102,12 @@ impl Decodable for PartitionData {
         let partition_index = types::Int32.decode(buf)?;
         let leader_epoch = types::Int32.decode(buf)?;
         let new_isr = types::CompactArray(types::Int32).decode(buf)?;
-        let current_isr_version = types::Int32.decode(buf)?;
+        let leader_recovery_state = if version >= 1 {
+            types::Int8.decode(buf)?
+        } else {
+            0
+        };
+        let partition_epoch = types::Int32.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
         let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
         for _ in 0..num_tagged_fields {
@@ -97,7 +121,8 @@ impl Decodable for PartitionData {
             partition_index,
             leader_epoch,
             new_isr,
-            current_isr_version,
+            leader_recovery_state,
+            partition_epoch,
             unknown_tagged_fields,
         })
     }
@@ -109,27 +134,28 @@ impl Default for PartitionData {
             partition_index: 0,
             leader_epoch: 0,
             new_isr: Default::default(),
-            current_isr_version: 0,
+            leader_recovery_state: 0,
+            partition_epoch: 0,
             unknown_tagged_fields: BTreeMap::new(),
         }
     }
 }
 
 impl Message for PartitionData {
-    const VERSIONS: VersionRange = VersionRange { min: 0, max: 0 };
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 1 };
 }
 
-/// Valid versions: 0
+/// Valid versions: 0-1
 #[derive(Debug, Clone, PartialEq, derive_builder::Builder)]
 pub struct TopicData {
     /// The name of the topic to alter ISRs for
     /// 
-    /// Supported API versions: 0
+    /// Supported API versions: 0-1
     pub name: super::TopicName,
 
     /// 
     /// 
-    /// Supported API versions: 0
+    /// Supported API versions: 0-1
     pub partitions: Vec<PartitionData>,
 
     /// Other tagged fields
@@ -198,32 +224,32 @@ impl Default for TopicData {
 }
 
 impl Message for TopicData {
-    const VERSIONS: VersionRange = VersionRange { min: 0, max: 0 };
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 1 };
 }
 
-/// Valid versions: 0
+/// Valid versions: 0-1
 #[derive(Debug, Clone, PartialEq, derive_builder::Builder)]
-pub struct AlterIsrRequest {
+pub struct AlterPartitionRequest {
     /// The ID of the requesting broker
     /// 
-    /// Supported API versions: 0
+    /// Supported API versions: 0-1
     pub broker_id: super::BrokerId,
 
     /// The epoch of the requesting broker
     /// 
-    /// Supported API versions: 0
+    /// Supported API versions: 0-1
     pub broker_epoch: i64,
 
     /// 
     /// 
-    /// Supported API versions: 0
+    /// Supported API versions: 0-1
     pub topics: Vec<TopicData>,
 
     /// Other tagged fields
     pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
 }
 
-impl Encodable for AlterIsrRequest {
+impl Encodable for AlterPartitionRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
         types::Int32.encode(buf, &self.broker_id)?;
         types::Int64.encode(buf, &self.broker_epoch)?;
@@ -255,7 +281,7 @@ impl Encodable for AlterIsrRequest {
     }
 }
 
-impl Decodable for AlterIsrRequest {
+impl Decodable for AlterPartitionRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
         let broker_id = types::Int32.decode(buf)?;
         let broker_epoch = types::Int64.decode(buf)?;
@@ -278,7 +304,7 @@ impl Decodable for AlterIsrRequest {
     }
 }
 
-impl Default for AlterIsrRequest {
+impl Default for AlterPartitionRequest {
     fn default() -> Self {
         Self {
             broker_id: (0).into(),
@@ -289,11 +315,11 @@ impl Default for AlterIsrRequest {
     }
 }
 
-impl Message for AlterIsrRequest {
-    const VERSIONS: VersionRange = VersionRange { min: 0, max: 0 };
+impl Message for AlterPartitionRequest {
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 1 };
 }
 
-impl HeaderVersion for AlterIsrRequest {
+impl HeaderVersion for AlterPartitionRequest {
     fn header_version(version: i16) -> i16 {
         2
     }

--- a/src/messages/describe_log_dirs_response.rs
+++ b/src/messages/describe_log_dirs_response.rs
@@ -386,10 +386,6 @@ impl Encodable for DescribeLogDirsResponse {
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         if version >= 3 {
             types::Int16.encode(buf, &self.error_code)?;
-        } else {
-            if self.error_code != 0 {
-                return Err(EncodeError)
-            }
         }
         if version >= 2 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.results)?;
@@ -413,10 +409,6 @@ impl Encodable for DescribeLogDirsResponse {
         total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
         if version >= 3 {
             total_size += types::Int16.compute_size(&self.error_code)?;
-        } else {
-            if self.error_code != 0 {
-                return Err(EncodeError)
-            }
         }
         if version >= 2 {
             total_size += types::CompactArray(types::Struct { version }).compute_size(&self.results)?;

--- a/src/messages/fetch_request.rs
+++ b/src/messages/fetch_request.rs
@@ -318,7 +318,7 @@ impl Message for FetchTopic {
 /// Valid versions: 0-13
 #[derive(Debug, Clone, PartialEq, derive_builder::Builder)]
 pub struct ForgottenTopic {
-    /// The partition name.
+    /// The topic name.
     /// 
     /// Supported API versions: 7-12
     pub topic: super::TopicName,

--- a/src/messages/leader_and_isr_response.rs
+++ b/src/messages/leader_and_isr_response.rs
@@ -17,7 +17,7 @@ use crate::protocol::{
 };
 
 
-/// Valid versions: 0-5
+/// Valid versions: 0-6
 #[derive(Debug, Clone, PartialEq, derive_builder::Builder)]
 pub struct LeaderAndIsrPartitionError {
     /// The topic name.
@@ -27,12 +27,12 @@ pub struct LeaderAndIsrPartitionError {
 
     /// The partition index.
     /// 
-    /// Supported API versions: 0-5
+    /// Supported API versions: 0-6
     pub partition_index: i32,
 
     /// The partition error code, or 0 if there was no error.
     /// 
-    /// Supported API versions: 0-5
+    /// Supported API versions: 0-6
     pub error_code: i16,
 
     /// Other tagged fields
@@ -132,15 +132,15 @@ impl Default for LeaderAndIsrPartitionError {
 }
 
 impl Message for LeaderAndIsrPartitionError {
-    const VERSIONS: VersionRange = VersionRange { min: 0, max: 5 };
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 6 };
 }
 
-/// Valid versions: 0-5
+/// Valid versions: 0-6
 #[derive(Debug, Clone, PartialEq, derive_builder::Builder)]
 pub struct LeaderAndIsrTopicError {
     /// Each partition.
     /// 
-    /// Supported API versions: 5
+    /// Supported API versions: 5-6
     pub partition_errors: Vec<LeaderAndIsrPartitionError>,
 
     /// Other tagged fields
@@ -247,15 +247,15 @@ impl Default for LeaderAndIsrTopicError {
 }
 
 impl Message for LeaderAndIsrTopicError {
-    const VERSIONS: VersionRange = VersionRange { min: 0, max: 5 };
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 6 };
 }
 
-/// Valid versions: 0-5
+/// Valid versions: 0-6
 #[derive(Debug, Clone, PartialEq, derive_builder::Builder)]
 pub struct LeaderAndIsrResponse {
     /// The error code, or 0 if there was no error.
     /// 
-    /// Supported API versions: 0-5
+    /// Supported API versions: 0-6
     pub error_code: i16,
 
     /// Each partition in v0 to v4 message.
@@ -265,7 +265,7 @@ pub struct LeaderAndIsrResponse {
 
     /// Each topic
     /// 
-    /// Supported API versions: 5
+    /// Supported API versions: 5-6
     pub topics: indexmap::IndexMap<Uuid, LeaderAndIsrTopicError>,
 
     /// Other tagged fields
@@ -389,7 +389,7 @@ impl Default for LeaderAndIsrResponse {
 }
 
 impl Message for LeaderAndIsrResponse {
-    const VERSIONS: VersionRange = VersionRange { min: 0, max: 5 };
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 6 };
 }
 
 impl HeaderVersion for LeaderAndIsrResponse {

--- a/src/records.rs
+++ b/src/records.rs
@@ -73,8 +73,11 @@ pub enum TimestampType {
 /// Options for encoding and compressing a batch of records. Note, not all compression algorithms
 /// are currently implemented by this library.
 pub struct RecordEncodeOptions {
-    version: i8,
-    compression: Compression,
+    /// Record version, 0, 1, or 2.
+    pub version: i8,
+
+    /// The compression algorithm to use.
+    pub compression: Compression,
 }
 
 /// Value to indicate missing producer id.


### PR DESCRIPTION
Run gen command from the root path, instead of `cd` the sub directory to run it. This also prevent to generate a redundant `target` dir inside the `protocol_codegen` dir.

Fix the README file type to UNIX text file, BTW.

Further more, maybe we could specify a explicit release version or latest of the Kafka, to generate, by accepting a version tag of its repo.