### PR TITLE
Fix destination directory computation

### DIFF
--- a/protocol_codegen/src/generate_messages.rs
+++ b/protocol_codegen/src/generate_messages.rs
@@ -16,8 +16,8 @@ use tempfile::tempdir;
 pub fn run() -> Result<(), Error> {
     let input_tmpdir = tempdir()?.into_path();
 
-    let mut dir = std::fs::canonicalize(std::file!())?;
-    dir.push("../../../src/messages");
+    let mut dir = std::fs::canonicalize(std::file!().rsplit_once("/").unwrap().0)?;
+    dir.push("../../src/messages");
     let output_path = std::fs::canonicalize(dir)?;
     let output_path = output_path.to_str().unwrap();
 


### PR DESCRIPTION
The generator fails to compute the destination path since std won't normalize "file.rs/../directory". This patch only removes the "file.rs" before normalization.