### PR TITLE
Keep kafka repo instead of throwing it away every regen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 Cargo.lock
 /xtask/target
 .idea/
+kafka_repo

--- a/protocol_codegen/Cargo.toml
+++ b/protocol_codegen/Cargo.toml
@@ -16,5 +16,4 @@ parse-display = "0.1.1"
 json_comments = "0.2.0"
 assert-json-diff = "1.0.1"
 git2 = "0.16"
-tempfile = "3.2.0"
 uuid = { version = "0.8.2", features = ["v4", "serde" ] }


### PR DESCRIPTION
Having to redownload the large kafka repository every time I test the generator is impractical.

I made no attempt to handle running outside of the project root because running outside of the project root is already broken.
I can make a follow up PR to fix running outside of the project root if desired.