### PR TITLE
Expose protocol::buf::gap module

### DIFF
--- a/src/protocol/buf.rs
+++ b/src/protocol/buf.rs
@@ -199,7 +199,8 @@ pub struct TypedGap<T> {
 
 macro_rules! define_gap_types {
     {$($n:ident => $f:ident($t:ty)),*$(,)*} => {
-        pub(crate) mod gap {
+        /// Types which implement `GapType`.
+        pub mod gap {
             use super::*;
             $(
                 #[derive(Copy, Clone, Debug)]


### PR DESCRIPTION
This is useful as one of the primary pain points of working with the Kafka API is needing to manually encode the length delimiters. Often times it is nice to first reserve the necessary slot, continue to encode header & response body, then go back and fill the slot.

This pattern is used quite a lot internal to this crate. It is a useful pattern outside of this crate as well.