### PR TITLE
Improve tagged fields

### DIFF
--- a/protocol_codegen/src/generate_messages/generate.rs
+++ b/protocol_codegen/src/generate_messages/generate.rs
@@ -796,8 +796,7 @@ fn write_decode_tag_buffer<W: Write>(
                 writeln!(w, "let size: u32 = types::UnsignedVarInt.decode(buf)?;")?;
 
                 if sorted_tagged_fields.is_empty() {
-                    writeln!(w, "let mut unknown_value = vec![0; size as usize];")?;
-                    writeln!(w, "buf.try_copy_to_slice(&mut unknown_value)?;")?;
+                    writeln!(w, "let unknown_value = buf.try_get_bytes(size as usize)?;")?;
                     write!(
                         w,
                         "unknown_tagged_fields.insert(tag as i32, unknown_value);"
@@ -876,8 +875,7 @@ fn write_decode_tag_buffer<W: Write>(
                         }
                         write!(w, "_ => ")?;
                         w.block(|w| {
-                            writeln!(w, "let mut unknown_value = vec![0; size as usize];")?;
-                            writeln!(w, "buf.try_copy_to_slice(&mut unknown_value)?;")?;
+                            writeln!(w, "let unknown_value = buf.try_get_bytes(size as usize)?;")?;
                             write!(
                                 w,
                                 "unknown_tagged_fields.insert(tag as i32, unknown_value);"
@@ -1026,7 +1024,7 @@ fn write_struct_def<W: Write>(
 
         if !flexible_msg_versions.is_none() {
             writeln!(w, "/// Other tagged fields")?;
-            writeln!(w, "pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,")?;
+            writeln!(w, "pub unknown_tagged_fields: BTreeMap<i32, Bytes>,")?;
         }
 
         Ok(())

--- a/src/messages/add_offsets_to_txn_request.rs
+++ b/src/messages/add_offsets_to_txn_request.rs
@@ -43,7 +43,7 @@ pub struct AddOffsetsToTxnRequest {
     pub group_id: super::GroupId,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for AddOffsetsToTxnRequest {
@@ -128,8 +128,7 @@ impl Decodable for AddOffsetsToTxnRequest {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/add_offsets_to_txn_response.rs
+++ b/src/messages/add_offsets_to_txn_response.rs
@@ -33,7 +33,7 @@ pub struct AddOffsetsToTxnResponse {
     pub error_code: i16,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for AddOffsetsToTxnResponse {
@@ -88,8 +88,7 @@ impl Decodable for AddOffsetsToTxnResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/add_partitions_to_txn_request.rs
+++ b/src/messages/add_partitions_to_txn_request.rs
@@ -28,7 +28,7 @@ pub struct AddPartitionsToTxnTopic {
     pub partitions: Vec<i32>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for AddPartitionsToTxnTopic {
@@ -109,8 +109,7 @@ impl MapDecodable for AddPartitionsToTxnTopic {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -160,7 +159,7 @@ pub struct AddPartitionsToTxnRequest {
     pub topics: indexmap::IndexMap<super::TopicName, AddPartitionsToTxnTopic>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for AddPartitionsToTxnRequest {
@@ -245,8 +244,7 @@ impl Decodable for AddPartitionsToTxnRequest {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/add_partitions_to_txn_response.rs
+++ b/src/messages/add_partitions_to_txn_response.rs
@@ -28,7 +28,7 @@ pub struct AddPartitionsToTxnPartitionResult {
     pub error_code: i16,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for AddPartitionsToTxnPartitionResult {
@@ -85,8 +85,7 @@ impl MapDecodable for AddPartitionsToTxnPartitionResult {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -121,7 +120,7 @@ pub struct AddPartitionsToTxnTopicResult {
     pub results: indexmap::IndexMap<i32, AddPartitionsToTxnPartitionResult>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for AddPartitionsToTxnTopicResult {
@@ -202,8 +201,7 @@ impl MapDecodable for AddPartitionsToTxnTopicResult {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -243,7 +241,7 @@ pub struct AddPartitionsToTxnResponse {
     pub results: indexmap::IndexMap<super::TopicName, AddPartitionsToTxnTopicResult>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for AddPartitionsToTxnResponse {
@@ -310,8 +308,7 @@ impl Decodable for AddPartitionsToTxnResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/allocate_producer_ids_request.rs
+++ b/src/messages/allocate_producer_ids_request.rs
@@ -33,7 +33,7 @@ pub struct AllocateProducerIdsRequest {
     pub broker_epoch: i64,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for AllocateProducerIdsRequest {
@@ -83,8 +83,7 @@ impl Decodable for AllocateProducerIdsRequest {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {

--- a/src/messages/allocate_producer_ids_response.rs
+++ b/src/messages/allocate_producer_ids_response.rs
@@ -43,7 +43,7 @@ pub struct AllocateProducerIdsResponse {
     pub producer_id_len: i32,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for AllocateProducerIdsResponse {
@@ -99,8 +99,7 @@ impl Decodable for AllocateProducerIdsResponse {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {

--- a/src/messages/alter_client_quotas_request.rs
+++ b/src/messages/alter_client_quotas_request.rs
@@ -33,7 +33,7 @@ pub struct EntityData {
     pub entity_name: Option<StrBytes>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for EntityData {
@@ -112,8 +112,7 @@ impl Decodable for EntityData {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -160,7 +159,7 @@ pub struct OpData {
     pub remove: bool,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for OpData {
@@ -230,8 +229,7 @@ impl Decodable for OpData {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -275,7 +273,7 @@ pub struct EntryData {
     pub ops: Vec<OpData>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for EntryData {
@@ -354,8 +352,7 @@ impl Decodable for EntryData {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -397,7 +394,7 @@ pub struct AlterClientQuotasRequest {
     pub validate_only: bool,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for AlterClientQuotasRequest {
@@ -464,8 +461,7 @@ impl Decodable for AlterClientQuotasRequest {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/alter_client_quotas_response.rs
+++ b/src/messages/alter_client_quotas_response.rs
@@ -33,7 +33,7 @@ pub struct EntityData {
     pub entity_name: Option<StrBytes>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for EntityData {
@@ -112,8 +112,7 @@ impl Decodable for EntityData {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -160,7 +159,7 @@ pub struct EntryData {
     pub entity: Vec<EntityData>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for EntryData {
@@ -242,8 +241,7 @@ impl Decodable for EntryData {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -287,7 +285,7 @@ pub struct AlterClientQuotasResponse {
     pub entries: Vec<EntryData>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for AlterClientQuotasResponse {
@@ -354,8 +352,7 @@ impl Decodable for AlterClientQuotasResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/alter_configs_request.rs
+++ b/src/messages/alter_configs_request.rs
@@ -28,7 +28,7 @@ pub struct AlterableConfig {
     pub value: Option<StrBytes>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for AlterableConfig {
@@ -109,8 +109,7 @@ impl MapDecodable for AlterableConfig {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -155,7 +154,7 @@ pub struct AlterConfigsResource {
     pub configs: indexmap::IndexMap<StrBytes, AlterableConfig>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for AlterConfigsResource {
@@ -237,8 +236,7 @@ impl Decodable for AlterConfigsResource {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -282,7 +280,7 @@ pub struct AlterConfigsRequest {
     pub validate_only: bool,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for AlterConfigsRequest {
@@ -349,8 +347,7 @@ impl Decodable for AlterConfigsRequest {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/alter_configs_response.rs
+++ b/src/messages/alter_configs_response.rs
@@ -43,7 +43,7 @@ pub struct AlterConfigsResourceResponse {
     pub resource_name: StrBytes,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for AlterConfigsResourceResponse {
@@ -128,8 +128,7 @@ impl Decodable for AlterConfigsResourceResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -175,7 +174,7 @@ pub struct AlterConfigsResponse {
     pub responses: Vec<AlterConfigsResourceResponse>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for AlterConfigsResponse {
@@ -242,8 +241,7 @@ impl Decodable for AlterConfigsResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/alter_partition_reassignments_request.rs
+++ b/src/messages/alter_partition_reassignments_request.rs
@@ -33,7 +33,7 @@ pub struct ReassignablePartition {
     pub replicas: Option<Vec<super::BrokerId>>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for ReassignablePartition {
@@ -83,8 +83,7 @@ impl Decodable for ReassignablePartition {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {
@@ -125,7 +124,7 @@ pub struct ReassignableTopic {
     pub partitions: Vec<ReassignablePartition>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for ReassignableTopic {
@@ -175,8 +174,7 @@ impl Decodable for ReassignableTopic {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {
@@ -217,7 +215,7 @@ pub struct AlterPartitionReassignmentsRequest {
     pub topics: Vec<ReassignableTopic>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for AlterPartitionReassignmentsRequest {
@@ -267,8 +265,7 @@ impl Decodable for AlterPartitionReassignmentsRequest {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {

--- a/src/messages/alter_partition_reassignments_response.rs
+++ b/src/messages/alter_partition_reassignments_response.rs
@@ -38,7 +38,7 @@ pub struct ReassignablePartitionResponse {
     pub error_message: Option<StrBytes>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for ReassignablePartitionResponse {
@@ -91,8 +91,7 @@ impl Decodable for ReassignablePartitionResponse {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {
@@ -135,7 +134,7 @@ pub struct ReassignableTopicResponse {
     pub partitions: Vec<ReassignablePartitionResponse>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for ReassignableTopicResponse {
@@ -185,8 +184,7 @@ impl Decodable for ReassignableTopicResponse {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {
@@ -237,7 +235,7 @@ pub struct AlterPartitionReassignmentsResponse {
     pub responses: Vec<ReassignableTopicResponse>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for AlterPartitionReassignmentsResponse {
@@ -293,8 +291,7 @@ impl Decodable for AlterPartitionReassignmentsResponse {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {

--- a/src/messages/alter_partition_request.rs
+++ b/src/messages/alter_partition_request.rs
@@ -48,7 +48,7 @@ pub struct PartitionData {
     pub partition_epoch: i32,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for PartitionData {
@@ -123,8 +123,7 @@ impl Decodable for PartitionData {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {
@@ -176,7 +175,7 @@ pub struct TopicData {
     pub partitions: Vec<PartitionData>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for TopicData {
@@ -245,8 +244,7 @@ impl Decodable for TopicData {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {
@@ -294,7 +292,7 @@ pub struct AlterPartitionRequest {
     pub topics: Vec<TopicData>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for AlterPartitionRequest {
@@ -347,8 +345,7 @@ impl Decodable for AlterPartitionRequest {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {

--- a/src/messages/alter_partition_response.rs
+++ b/src/messages/alter_partition_response.rs
@@ -58,7 +58,7 @@ pub struct PartitionData {
     pub partition_epoch: i32,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for PartitionData {
@@ -131,8 +131,7 @@ impl Decodable for PartitionData {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {
@@ -188,7 +187,7 @@ pub struct TopicData {
     pub partitions: Vec<PartitionData>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for TopicData {
@@ -257,8 +256,7 @@ impl Decodable for TopicData {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {
@@ -306,7 +304,7 @@ pub struct AlterPartitionResponse {
     pub topics: Vec<TopicData>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for AlterPartitionResponse {
@@ -359,8 +357,7 @@ impl Decodable for AlterPartitionResponse {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {

--- a/src/messages/alter_replica_log_dirs_request.rs
+++ b/src/messages/alter_replica_log_dirs_request.rs
@@ -28,7 +28,7 @@ pub struct AlterReplicaLogDirTopic {
     pub partitions: Vec<i32>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for AlterReplicaLogDirTopic {
@@ -109,8 +109,7 @@ impl MapDecodable for AlterReplicaLogDirTopic {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -145,7 +144,7 @@ pub struct AlterReplicaLogDir {
     pub topics: indexmap::IndexMap<super::TopicName, AlterReplicaLogDirTopic>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for AlterReplicaLogDir {
@@ -226,8 +225,7 @@ impl MapDecodable for AlterReplicaLogDir {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -262,7 +260,7 @@ pub struct AlterReplicaLogDirsRequest {
     pub dirs: indexmap::IndexMap<StrBytes, AlterReplicaLogDir>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for AlterReplicaLogDirsRequest {
@@ -326,8 +324,7 @@ impl Decodable for AlterReplicaLogDirsRequest {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/alter_replica_log_dirs_response.rs
+++ b/src/messages/alter_replica_log_dirs_response.rs
@@ -33,7 +33,7 @@ pub struct AlterReplicaLogDirPartitionResult {
     pub error_code: i16,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for AlterReplicaLogDirPartitionResult {
@@ -88,8 +88,7 @@ impl Decodable for AlterReplicaLogDirPartitionResult {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -131,7 +130,7 @@ pub struct AlterReplicaLogDirTopicResult {
     pub partitions: Vec<AlterReplicaLogDirPartitionResult>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for AlterReplicaLogDirTopicResult {
@@ -210,8 +209,7 @@ impl Decodable for AlterReplicaLogDirTopicResult {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -253,7 +251,7 @@ pub struct AlterReplicaLogDirsResponse {
     pub results: Vec<AlterReplicaLogDirTopicResult>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for AlterReplicaLogDirsResponse {
@@ -320,8 +318,7 @@ impl Decodable for AlterReplicaLogDirsResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/alter_user_scram_credentials_request.rs
+++ b/src/messages/alter_user_scram_credentials_request.rs
@@ -33,7 +33,7 @@ pub struct ScramCredentialDeletion {
     pub mechanism: i8,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for ScramCredentialDeletion {
@@ -83,8 +83,7 @@ impl Decodable for ScramCredentialDeletion {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {
@@ -140,7 +139,7 @@ pub struct ScramCredentialUpsertion {
     pub salted_password: Bytes,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for ScramCredentialUpsertion {
@@ -199,8 +198,7 @@ impl Decodable for ScramCredentialUpsertion {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {
@@ -247,7 +245,7 @@ pub struct AlterUserScramCredentialsRequest {
     pub upsertions: Vec<ScramCredentialUpsertion>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for AlterUserScramCredentialsRequest {
@@ -297,8 +295,7 @@ impl Decodable for AlterUserScramCredentialsRequest {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {

--- a/src/messages/alter_user_scram_credentials_response.rs
+++ b/src/messages/alter_user_scram_credentials_response.rs
@@ -38,7 +38,7 @@ pub struct AlterUserScramCredentialsResult {
     pub error_message: Option<StrBytes>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for AlterUserScramCredentialsResult {
@@ -91,8 +91,7 @@ impl Decodable for AlterUserScramCredentialsResult {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {
@@ -135,7 +134,7 @@ pub struct AlterUserScramCredentialsResponse {
     pub results: Vec<AlterUserScramCredentialsResult>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for AlterUserScramCredentialsResponse {
@@ -185,8 +184,7 @@ impl Decodable for AlterUserScramCredentialsResponse {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {

--- a/src/messages/api_versions_request.rs
+++ b/src/messages/api_versions_request.rs
@@ -33,7 +33,7 @@ pub struct ApiVersionsRequest {
     pub client_software_version: StrBytes,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for ApiVersionsRequest {
@@ -104,8 +104,7 @@ impl Decodable for ApiVersionsRequest {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/api_versions_response.rs
+++ b/src/messages/api_versions_response.rs
@@ -33,7 +33,7 @@ pub struct ApiVersion {
     pub max_version: i16,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for ApiVersion {
@@ -93,8 +93,7 @@ impl MapDecodable for ApiVersion {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -136,7 +135,7 @@ pub struct SupportedFeatureKey {
     pub max_version: i16,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for SupportedFeatureKey {
@@ -244,8 +243,7 @@ impl MapDecodable for SupportedFeatureKey {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -287,7 +285,7 @@ pub struct FinalizedFeatureKey {
     pub min_version_level: i16,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for FinalizedFeatureKey {
@@ -395,8 +393,7 @@ impl MapDecodable for FinalizedFeatureKey {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -458,7 +455,7 @@ pub struct ApiVersionsResponse {
     pub finalized_features: indexmap::IndexMap<StrBytes, FinalizedFeatureKey>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for ApiVersionsResponse {
@@ -628,8 +625,7 @@ impl Decodable for ApiVersionsResponse {
                         finalized_features = types::CompactArray(types::Struct { version }).decode(buf)?;
                     },
                     _ => {
-                        let mut unknown_value = vec![0; size as usize];
-                        buf.try_copy_to_slice(&mut unknown_value)?;
+                        let unknown_value = buf.try_get_bytes(size as usize)?;
                         unknown_tagged_fields.insert(tag as i32, unknown_value);
                     }
                 }

--- a/src/messages/broker_heartbeat_request.rs
+++ b/src/messages/broker_heartbeat_request.rs
@@ -48,7 +48,7 @@ pub struct BrokerHeartbeatRequest {
     pub want_shut_down: bool,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for BrokerHeartbeatRequest {
@@ -107,8 +107,7 @@ impl Decodable for BrokerHeartbeatRequest {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {

--- a/src/messages/broker_heartbeat_response.rs
+++ b/src/messages/broker_heartbeat_response.rs
@@ -48,7 +48,7 @@ pub struct BrokerHeartbeatResponse {
     pub should_shut_down: bool,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for BrokerHeartbeatResponse {
@@ -107,8 +107,7 @@ impl Decodable for BrokerHeartbeatResponse {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {

--- a/src/messages/broker_registration_request.rs
+++ b/src/messages/broker_registration_request.rs
@@ -38,7 +38,7 @@ pub struct Listener {
     pub security_protocol: i16,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for Listener {
@@ -96,8 +96,7 @@ impl MapDecodable for Listener {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok((key_field, Self {
@@ -140,7 +139,7 @@ pub struct Feature {
     pub max_supported_version: i16,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for Feature {
@@ -195,8 +194,7 @@ impl MapDecodable for Feature {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok((key_field, Self {
@@ -257,7 +255,7 @@ pub struct BrokerRegistrationRequest {
     pub rack: Option<StrBytes>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for BrokerRegistrationRequest {
@@ -319,8 +317,7 @@ impl Decodable for BrokerRegistrationRequest {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {

--- a/src/messages/broker_registration_response.rs
+++ b/src/messages/broker_registration_response.rs
@@ -38,7 +38,7 @@ pub struct BrokerRegistrationResponse {
     pub broker_epoch: i64,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for BrokerRegistrationResponse {
@@ -91,8 +91,7 @@ impl Decodable for BrokerRegistrationResponse {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {

--- a/src/messages/controlled_shutdown_request.rs
+++ b/src/messages/controlled_shutdown_request.rs
@@ -33,7 +33,7 @@ pub struct ControlledShutdownRequest {
     pub broker_epoch: i64,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for ControlledShutdownRequest {
@@ -96,8 +96,7 @@ impl Decodable for ControlledShutdownRequest {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/controlled_shutdown_response.rs
+++ b/src/messages/controlled_shutdown_response.rs
@@ -33,7 +33,7 @@ pub struct RemainingPartition {
     pub partition_index: i32,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for RemainingPartition {
@@ -100,8 +100,7 @@ impl Decodable for RemainingPartition {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -143,7 +142,7 @@ pub struct ControlledShutdownResponse {
     pub remaining_partitions: Vec<RemainingPartition>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for ControlledShutdownResponse {
@@ -210,8 +209,7 @@ impl Decodable for ControlledShutdownResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/create_acls_request.rs
+++ b/src/messages/create_acls_request.rs
@@ -58,7 +58,7 @@ pub struct AclCreation {
     pub permission_type: i8,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for AclCreation {
@@ -180,8 +180,7 @@ impl Decodable for AclCreation {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -228,7 +227,7 @@ pub struct CreateAclsRequest {
     pub creations: Vec<AclCreation>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for CreateAclsRequest {
@@ -292,8 +291,7 @@ impl Decodable for CreateAclsRequest {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/create_acls_response.rs
+++ b/src/messages/create_acls_response.rs
@@ -33,7 +33,7 @@ pub struct AclCreationResult {
     pub error_message: Option<StrBytes>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for AclCreationResult {
@@ -100,8 +100,7 @@ impl Decodable for AclCreationResult {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -143,7 +142,7 @@ pub struct CreateAclsResponse {
     pub results: Vec<AclCreationResult>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for CreateAclsResponse {
@@ -210,8 +209,7 @@ impl Decodable for CreateAclsResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/create_delegation_token_request.rs
+++ b/src/messages/create_delegation_token_request.rs
@@ -33,7 +33,7 @@ pub struct CreatableRenewers {
     pub principal_name: StrBytes,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for CreatableRenewers {
@@ -112,8 +112,7 @@ impl Decodable for CreatableRenewers {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -165,7 +164,7 @@ pub struct CreateDelegationTokenRequest {
     pub max_lifetime_ms: i64,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for CreateDelegationTokenRequest {
@@ -270,8 +269,7 @@ impl Decodable for CreateDelegationTokenRequest {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/create_delegation_token_response.rs
+++ b/src/messages/create_delegation_token_response.rs
@@ -78,7 +78,7 @@ pub struct CreateDelegationTokenResponse {
     pub throttle_time_ms: i32,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for CreateDelegationTokenResponse {
@@ -240,8 +240,7 @@ impl Decodable for CreateDelegationTokenResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/create_partitions_request.rs
+++ b/src/messages/create_partitions_request.rs
@@ -28,7 +28,7 @@ pub struct CreatePartitionsAssignment {
     pub broker_ids: Vec<super::BrokerId>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for CreatePartitionsAssignment {
@@ -92,8 +92,7 @@ impl Decodable for CreatePartitionsAssignment {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -133,7 +132,7 @@ pub struct CreatePartitionsTopic {
     pub assignments: Option<Vec<CreatePartitionsAssignment>>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for CreatePartitionsTopic {
@@ -217,8 +216,7 @@ impl MapDecodable for CreatePartitionsTopic {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -265,7 +263,7 @@ pub struct CreatePartitionsRequest {
     pub validate_only: bool,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for CreatePartitionsRequest {
@@ -335,8 +333,7 @@ impl Decodable for CreatePartitionsRequest {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/create_partitions_response.rs
+++ b/src/messages/create_partitions_response.rs
@@ -38,7 +38,7 @@ pub struct CreatePartitionsTopicResult {
     pub error_message: Option<StrBytes>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for CreatePartitionsTopicResult {
@@ -120,8 +120,7 @@ impl Decodable for CreatePartitionsTopicResult {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -165,7 +164,7 @@ pub struct CreatePartitionsResponse {
     pub results: Vec<CreatePartitionsTopicResult>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for CreatePartitionsResponse {
@@ -232,8 +231,7 @@ impl Decodable for CreatePartitionsResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/create_topics_request.rs
+++ b/src/messages/create_topics_request.rs
@@ -28,7 +28,7 @@ pub struct CreatableReplicaAssignment {
     pub broker_ids: Vec<super::BrokerId>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for CreatableReplicaAssignment {
@@ -97,8 +97,7 @@ impl MapDecodable for CreatableReplicaAssignment {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -133,7 +132,7 @@ pub struct CreateableTopicConfig {
     pub value: Option<StrBytes>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for CreateableTopicConfig {
@@ -214,8 +213,7 @@ impl MapDecodable for CreateableTopicConfig {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -265,7 +263,7 @@ pub struct CreatableTopic {
     pub configs: indexmap::IndexMap<StrBytes, CreateableTopicConfig>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for CreatableTopic {
@@ -367,8 +365,7 @@ impl MapDecodable for CreatableTopic {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -419,7 +416,7 @@ pub struct CreateTopicsRequest {
     pub validate_only: bool,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for CreateTopicsRequest {
@@ -505,8 +502,7 @@ impl Decodable for CreateTopicsRequest {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/create_topics_response.rs
+++ b/src/messages/create_topics_response.rs
@@ -48,7 +48,7 @@ pub struct CreatableTopicConfigs {
     pub is_sensitive: bool,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for CreatableTopicConfigs {
@@ -184,8 +184,7 @@ impl Decodable for CreatableTopicConfigs {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -258,7 +257,7 @@ pub struct CreatableTopicResult {
     pub configs: Option<Vec<CreatableTopicConfigs>>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for CreatableTopicResult {
@@ -426,8 +425,7 @@ impl MapDecodable for CreatableTopicResult {
                         topic_config_error_code = types::Int16.decode(buf)?;
                     },
                     _ => {
-                        let mut unknown_value = vec![0; size as usize];
-                        buf.try_copy_to_slice(&mut unknown_value)?;
+                        let unknown_value = buf.try_get_bytes(size as usize)?;
                         unknown_tagged_fields.insert(tag as i32, unknown_value);
                     }
                 }
@@ -481,7 +479,7 @@ pub struct CreateTopicsResponse {
     pub topics: indexmap::IndexMap<super::TopicName, CreatableTopicResult>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for CreateTopicsResponse {
@@ -556,8 +554,7 @@ impl Decodable for CreateTopicsResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/default_principal_data.rs
+++ b/src/messages/default_principal_data.rs
@@ -38,7 +38,7 @@ pub struct DefaultPrincipalData {
     pub token_authenticated: bool,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DefaultPrincipalData {
@@ -91,8 +91,7 @@ impl Decodable for DefaultPrincipalData {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {

--- a/src/messages/delete_acls_request.rs
+++ b/src/messages/delete_acls_request.rs
@@ -58,7 +58,7 @@ pub struct DeleteAclsFilter {
     pub permission_type: i8,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DeleteAclsFilter {
@@ -180,8 +180,7 @@ impl Decodable for DeleteAclsFilter {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -228,7 +227,7 @@ pub struct DeleteAclsRequest {
     pub filters: Vec<DeleteAclsFilter>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DeleteAclsRequest {
@@ -292,8 +291,7 @@ impl Decodable for DeleteAclsRequest {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/delete_acls_response.rs
+++ b/src/messages/delete_acls_response.rs
@@ -68,7 +68,7 @@ pub struct DeleteAclsMatchingAcl {
     pub permission_type: i8,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DeleteAclsMatchingAcl {
@@ -208,8 +208,7 @@ impl Decodable for DeleteAclsMatchingAcl {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -270,7 +269,7 @@ pub struct DeleteAclsFilterResult {
     pub matching_acls: Vec<DeleteAclsMatchingAcl>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DeleteAclsFilterResult {
@@ -352,8 +351,7 @@ impl Decodable for DeleteAclsFilterResult {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -397,7 +395,7 @@ pub struct DeleteAclsResponse {
     pub filter_results: Vec<DeleteAclsFilterResult>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DeleteAclsResponse {
@@ -464,8 +462,7 @@ impl Decodable for DeleteAclsResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/delete_groups_request.rs
+++ b/src/messages/delete_groups_request.rs
@@ -28,7 +28,7 @@ pub struct DeleteGroupsRequest {
     pub groups_names: Vec<super::GroupId>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DeleteGroupsRequest {
@@ -92,8 +92,7 @@ impl Decodable for DeleteGroupsRequest {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/delete_groups_response.rs
+++ b/src/messages/delete_groups_response.rs
@@ -28,7 +28,7 @@ pub struct DeletableGroupResult {
     pub error_code: i16,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DeletableGroupResult {
@@ -97,8 +97,7 @@ impl MapDecodable for DeletableGroupResult {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -138,7 +137,7 @@ pub struct DeleteGroupsResponse {
     pub results: indexmap::IndexMap<super::GroupId, DeletableGroupResult>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DeleteGroupsResponse {
@@ -205,8 +204,7 @@ impl Decodable for DeleteGroupsResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/delete_records_request.rs
+++ b/src/messages/delete_records_request.rs
@@ -33,7 +33,7 @@ pub struct DeleteRecordsPartition {
     pub offset: i64,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DeleteRecordsPartition {
@@ -88,8 +88,7 @@ impl Decodable for DeleteRecordsPartition {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -131,7 +130,7 @@ pub struct DeleteRecordsTopic {
     pub partitions: Vec<DeleteRecordsPartition>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DeleteRecordsTopic {
@@ -210,8 +209,7 @@ impl Decodable for DeleteRecordsTopic {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -253,7 +251,7 @@ pub struct DeleteRecordsRequest {
     pub timeout_ms: i32,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DeleteRecordsRequest {
@@ -320,8 +318,7 @@ impl Decodable for DeleteRecordsRequest {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/delete_records_response.rs
+++ b/src/messages/delete_records_response.rs
@@ -33,7 +33,7 @@ pub struct DeleteRecordsPartitionResult {
     pub error_code: i16,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DeleteRecordsPartitionResult {
@@ -93,8 +93,7 @@ impl MapDecodable for DeleteRecordsPartitionResult {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -131,7 +130,7 @@ pub struct DeleteRecordsTopicResult {
     pub partitions: indexmap::IndexMap<i32, DeleteRecordsPartitionResult>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DeleteRecordsTopicResult {
@@ -212,8 +211,7 @@ impl MapDecodable for DeleteRecordsTopicResult {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -253,7 +251,7 @@ pub struct DeleteRecordsResponse {
     pub topics: indexmap::IndexMap<super::TopicName, DeleteRecordsTopicResult>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DeleteRecordsResponse {
@@ -320,8 +318,7 @@ impl Decodable for DeleteRecordsResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/delete_topics_request.rs
+++ b/src/messages/delete_topics_request.rs
@@ -33,7 +33,7 @@ pub struct DeleteTopicState {
     pub topic_id: Uuid,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DeleteTopicState {
@@ -120,8 +120,7 @@ impl Decodable for DeleteTopicState {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -168,7 +167,7 @@ pub struct DeleteTopicsRequest {
     pub timeout_ms: i32,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DeleteTopicsRequest {
@@ -262,8 +261,7 @@ impl Decodable for DeleteTopicsRequest {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/delete_topics_response.rs
+++ b/src/messages/delete_topics_response.rs
@@ -38,7 +38,7 @@ pub struct DeletableTopicResult {
     pub error_message: Option<StrBytes>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DeletableTopicResult {
@@ -129,8 +129,7 @@ impl MapDecodable for DeletableTopicResult {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -174,7 +173,7 @@ pub struct DeleteTopicsResponse {
     pub responses: indexmap::IndexMap<super::TopicName, DeletableTopicResult>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DeleteTopicsResponse {
@@ -249,8 +248,7 @@ impl Decodable for DeleteTopicsResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/describe_acls_request.rs
+++ b/src/messages/describe_acls_request.rs
@@ -58,7 +58,7 @@ pub struct DescribeAclsRequest {
     pub permission_type: i8,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DescribeAclsRequest {
@@ -180,8 +180,7 @@ impl Decodable for DescribeAclsRequest {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/describe_acls_response.rs
+++ b/src/messages/describe_acls_response.rs
@@ -43,7 +43,7 @@ pub struct AclDescription {
     pub permission_type: i8,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for AclDescription {
@@ -128,8 +128,7 @@ impl Decodable for AclDescription {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -185,7 +184,7 @@ pub struct DescribeAclsResource {
     pub acls: Vec<AclDescription>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DescribeAclsResource {
@@ -286,8 +285,7 @@ impl Decodable for DescribeAclsResource {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -343,7 +341,7 @@ pub struct DescribeAclsResponse {
     pub resources: Vec<DescribeAclsResource>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DescribeAclsResponse {
@@ -428,8 +426,7 @@ impl Decodable for DescribeAclsResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/describe_client_quotas_request.rs
+++ b/src/messages/describe_client_quotas_request.rs
@@ -38,7 +38,7 @@ pub struct ComponentData {
     pub _match: Option<StrBytes>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for ComponentData {
@@ -120,8 +120,7 @@ impl Decodable for ComponentData {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -165,7 +164,7 @@ pub struct DescribeClientQuotasRequest {
     pub strict: bool,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DescribeClientQuotasRequest {
@@ -232,8 +231,7 @@ impl Decodable for DescribeClientQuotasRequest {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/describe_client_quotas_response.rs
+++ b/src/messages/describe_client_quotas_response.rs
@@ -33,7 +33,7 @@ pub struct EntityData {
     pub entity_name: Option<StrBytes>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for EntityData {
@@ -112,8 +112,7 @@ impl Decodable for EntityData {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -155,7 +154,7 @@ pub struct ValueData {
     pub value: f64,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for ValueData {
@@ -222,8 +221,7 @@ impl Decodable for ValueData {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -265,7 +263,7 @@ pub struct EntryData {
     pub values: Vec<ValueData>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for EntryData {
@@ -344,8 +342,7 @@ impl Decodable for EntryData {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -397,7 +394,7 @@ pub struct DescribeClientQuotasResponse {
     pub entries: Option<Vec<EntryData>>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DescribeClientQuotasResponse {
@@ -482,8 +479,7 @@ impl Decodable for DescribeClientQuotasResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/describe_cluster_request.rs
+++ b/src/messages/describe_cluster_request.rs
@@ -28,7 +28,7 @@ pub struct DescribeClusterRequest {
     pub include_cluster_authorized_operations: bool,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DescribeClusterRequest {
@@ -75,8 +75,7 @@ impl Decodable for DescribeClusterRequest {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {

--- a/src/messages/describe_cluster_response.rs
+++ b/src/messages/describe_cluster_response.rs
@@ -38,7 +38,7 @@ pub struct DescribeClusterBroker {
     pub rack: Option<StrBytes>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DescribeClusterBroker {
@@ -96,8 +96,7 @@ impl MapDecodable for DescribeClusterBroker {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok((key_field, Self {
@@ -165,7 +164,7 @@ pub struct DescribeClusterResponse {
     pub cluster_authorized_operations: i32,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DescribeClusterResponse {
@@ -230,8 +229,7 @@ impl Decodable for DescribeClusterResponse {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {

--- a/src/messages/describe_configs_request.rs
+++ b/src/messages/describe_configs_request.rs
@@ -38,7 +38,7 @@ pub struct DescribeConfigsResource {
     pub configuration_keys: Option<Vec<StrBytes>>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DescribeConfigsResource {
@@ -120,8 +120,7 @@ impl Decodable for DescribeConfigsResource {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -170,7 +169,7 @@ pub struct DescribeConfigsRequest {
     pub include_documentation: bool,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DescribeConfigsRequest {
@@ -272,8 +271,7 @@ impl Decodable for DescribeConfigsRequest {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/describe_configs_response.rs
+++ b/src/messages/describe_configs_response.rs
@@ -38,7 +38,7 @@ pub struct DescribeConfigsSynonym {
     pub source: i8,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DescribeConfigsSynonym {
@@ -168,8 +168,7 @@ impl Decodable for DescribeConfigsSynonym {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -248,7 +247,7 @@ pub struct DescribeConfigsResourceResult {
     pub documentation: Option<StrBytes>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DescribeConfigsResourceResult {
@@ -420,8 +419,7 @@ impl Decodable for DescribeConfigsResourceResult {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -492,7 +490,7 @@ pub struct DescribeConfigsResult {
     pub configs: Vec<DescribeConfigsResourceResult>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DescribeConfigsResult {
@@ -592,8 +590,7 @@ impl Decodable for DescribeConfigsResult {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -641,7 +638,7 @@ pub struct DescribeConfigsResponse {
     pub results: Vec<DescribeConfigsResult>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DescribeConfigsResponse {
@@ -708,8 +705,7 @@ impl Decodable for DescribeConfigsResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/describe_delegation_token_request.rs
+++ b/src/messages/describe_delegation_token_request.rs
@@ -33,7 +33,7 @@ pub struct DescribeDelegationTokenOwner {
     pub principal_name: StrBytes,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DescribeDelegationTokenOwner {
@@ -112,8 +112,7 @@ impl Decodable for DescribeDelegationTokenOwner {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -150,7 +149,7 @@ pub struct DescribeDelegationTokenRequest {
     pub owners: Option<Vec<DescribeDelegationTokenOwner>>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DescribeDelegationTokenRequest {
@@ -214,8 +213,7 @@ impl Decodable for DescribeDelegationTokenRequest {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/describe_delegation_token_response.rs
+++ b/src/messages/describe_delegation_token_response.rs
@@ -33,7 +33,7 @@ pub struct DescribedDelegationTokenRenewer {
     pub principal_name: StrBytes,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DescribedDelegationTokenRenewer {
@@ -112,8 +112,7 @@ impl Decodable for DescribedDelegationTokenRenewer {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -195,7 +194,7 @@ pub struct DescribedDelegationToken {
     pub renewers: Vec<DescribedDelegationTokenRenewer>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DescribedDelegationToken {
@@ -366,8 +365,7 @@ impl Decodable for DescribedDelegationToken {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -430,7 +428,7 @@ pub struct DescribeDelegationTokenResponse {
     pub throttle_time_ms: i32,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DescribeDelegationTokenResponse {
@@ -500,8 +498,7 @@ impl Decodable for DescribeDelegationTokenResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/describe_groups_request.rs
+++ b/src/messages/describe_groups_request.rs
@@ -33,7 +33,7 @@ pub struct DescribeGroupsRequest {
     pub include_authorized_operations: bool,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DescribeGroupsRequest {
@@ -116,8 +116,7 @@ impl Decodable for DescribeGroupsRequest {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/describe_groups_response.rs
+++ b/src/messages/describe_groups_response.rs
@@ -53,7 +53,7 @@ pub struct DescribedGroupMember {
     pub member_assignment: Bytes,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DescribedGroupMember {
@@ -200,8 +200,7 @@ impl Decodable for DescribedGroupMember {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -276,7 +275,7 @@ pub struct DescribedGroup {
     pub authorized_operations: i32,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DescribedGroup {
@@ -422,8 +421,7 @@ impl Decodable for DescribedGroup {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -475,7 +473,7 @@ pub struct DescribeGroupsResponse {
     pub groups: Vec<DescribedGroup>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DescribeGroupsResponse {
@@ -550,8 +548,7 @@ impl Decodable for DescribeGroupsResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/describe_log_dirs_request.rs
+++ b/src/messages/describe_log_dirs_request.rs
@@ -28,7 +28,7 @@ pub struct DescribableLogDirTopic {
     pub partitions: Vec<i32>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DescribableLogDirTopic {
@@ -109,8 +109,7 @@ impl MapDecodable for DescribableLogDirTopic {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -145,7 +144,7 @@ pub struct DescribeLogDirsRequest {
     pub topics: Option<indexmap::IndexMap<super::TopicName, DescribableLogDirTopic>>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DescribeLogDirsRequest {
@@ -209,8 +208,7 @@ impl Decodable for DescribeLogDirsRequest {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/describe_log_dirs_response.rs
+++ b/src/messages/describe_log_dirs_response.rs
@@ -43,7 +43,7 @@ pub struct DescribeLogDirsPartition {
     pub is_future_key: bool,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DescribeLogDirsPartition {
@@ -104,8 +104,7 @@ impl Decodable for DescribeLogDirsPartition {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -151,7 +150,7 @@ pub struct DescribeLogDirsTopic {
     pub partitions: Vec<DescribeLogDirsPartition>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DescribeLogDirsTopic {
@@ -230,8 +229,7 @@ impl Decodable for DescribeLogDirsTopic {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -288,7 +286,7 @@ pub struct DescribeLogDirsResult {
     pub usable_bytes: i64,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DescribeLogDirsResult {
@@ -392,8 +390,7 @@ impl Decodable for DescribeLogDirsResult {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -446,7 +443,7 @@ pub struct DescribeLogDirsResponse {
     pub results: Vec<DescribeLogDirsResult>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DescribeLogDirsResponse {
@@ -524,8 +521,7 @@ impl Decodable for DescribeLogDirsResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/describe_producers_request.rs
+++ b/src/messages/describe_producers_request.rs
@@ -33,7 +33,7 @@ pub struct TopicRequest {
     pub partition_indexes: Vec<i32>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for TopicRequest {
@@ -83,8 +83,7 @@ impl Decodable for TopicRequest {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {
@@ -120,7 +119,7 @@ pub struct DescribeProducersRequest {
     pub topics: Vec<TopicRequest>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DescribeProducersRequest {
@@ -167,8 +166,7 @@ impl Decodable for DescribeProducersRequest {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {

--- a/src/messages/describe_producers_response.rs
+++ b/src/messages/describe_producers_response.rs
@@ -53,7 +53,7 @@ pub struct ProducerState {
     pub current_txn_start_offset: i64,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for ProducerState {
@@ -115,8 +115,7 @@ impl Decodable for ProducerState {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {
@@ -175,7 +174,7 @@ pub struct PartitionResponse {
     pub active_producers: Vec<ProducerState>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for PartitionResponse {
@@ -231,8 +230,7 @@ impl Decodable for PartitionResponse {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {
@@ -277,7 +275,7 @@ pub struct TopicResponse {
     pub partitions: Vec<PartitionResponse>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for TopicResponse {
@@ -327,8 +325,7 @@ impl Decodable for TopicResponse {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {
@@ -369,7 +366,7 @@ pub struct DescribeProducersResponse {
     pub topics: Vec<TopicResponse>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DescribeProducersResponse {
@@ -419,8 +416,7 @@ impl Decodable for DescribeProducersResponse {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {

--- a/src/messages/describe_quorum_request.rs
+++ b/src/messages/describe_quorum_request.rs
@@ -28,7 +28,7 @@ pub struct PartitionData {
     pub partition_index: i32,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for PartitionData {
@@ -75,8 +75,7 @@ impl Decodable for PartitionData {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {
@@ -115,7 +114,7 @@ pub struct TopicData {
     pub partitions: Vec<PartitionData>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for TopicData {
@@ -165,8 +164,7 @@ impl Decodable for TopicData {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {
@@ -202,7 +200,7 @@ pub struct DescribeQuorumRequest {
     pub topics: Vec<TopicData>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DescribeQuorumRequest {
@@ -249,8 +247,7 @@ impl Decodable for DescribeQuorumRequest {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {

--- a/src/messages/describe_quorum_response.rs
+++ b/src/messages/describe_quorum_response.rs
@@ -43,7 +43,7 @@ pub struct ReplicaState {
     pub last_caught_up_timestamp: i64,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for ReplicaState {
@@ -115,8 +115,7 @@ impl Decodable for ReplicaState {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {
@@ -186,7 +185,7 @@ pub struct PartitionData {
     pub observers: Vec<ReplicaState>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for PartitionData {
@@ -251,8 +250,7 @@ impl Decodable for PartitionData {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {
@@ -303,7 +301,7 @@ pub struct TopicData {
     pub partitions: Vec<PartitionData>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for TopicData {
@@ -353,8 +351,7 @@ impl Decodable for TopicData {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {
@@ -395,7 +392,7 @@ pub struct DescribeQuorumResponse {
     pub topics: Vec<TopicData>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DescribeQuorumResponse {
@@ -445,8 +442,7 @@ impl Decodable for DescribeQuorumResponse {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {

--- a/src/messages/describe_transactions_request.rs
+++ b/src/messages/describe_transactions_request.rs
@@ -28,7 +28,7 @@ pub struct DescribeTransactionsRequest {
     pub transactional_ids: Vec<super::TransactionalId>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DescribeTransactionsRequest {
@@ -75,8 +75,7 @@ impl Decodable for DescribeTransactionsRequest {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {

--- a/src/messages/describe_transactions_response.rs
+++ b/src/messages/describe_transactions_response.rs
@@ -28,7 +28,7 @@ pub struct TopicData {
     pub partitions: Vec<i32>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for TopicData {
@@ -80,8 +80,7 @@ impl MapDecodable for TopicData {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok((key_field, Self {
@@ -150,7 +149,7 @@ pub struct TransactionState {
     pub topics: indexmap::IndexMap<super::TopicName, TopicData>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for TransactionState {
@@ -218,8 +217,7 @@ impl Decodable for TransactionState {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {
@@ -272,7 +270,7 @@ pub struct DescribeTransactionsResponse {
     pub transaction_states: Vec<TransactionState>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DescribeTransactionsResponse {
@@ -322,8 +320,7 @@ impl Decodable for DescribeTransactionsResponse {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {

--- a/src/messages/describe_user_scram_credentials_request.rs
+++ b/src/messages/describe_user_scram_credentials_request.rs
@@ -28,7 +28,7 @@ pub struct UserName {
     pub name: StrBytes,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for UserName {
@@ -75,8 +75,7 @@ impl Decodable for UserName {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {
@@ -110,7 +109,7 @@ pub struct DescribeUserScramCredentialsRequest {
     pub users: Option<Vec<UserName>>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DescribeUserScramCredentialsRequest {
@@ -157,8 +156,7 @@ impl Decodable for DescribeUserScramCredentialsRequest {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {

--- a/src/messages/describe_user_scram_credentials_response.rs
+++ b/src/messages/describe_user_scram_credentials_response.rs
@@ -33,7 +33,7 @@ pub struct CredentialInfo {
     pub iterations: i32,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for CredentialInfo {
@@ -83,8 +83,7 @@ impl Decodable for CredentialInfo {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {
@@ -135,7 +134,7 @@ pub struct DescribeUserScramCredentialsResult {
     pub credential_infos: Vec<CredentialInfo>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DescribeUserScramCredentialsResult {
@@ -191,8 +190,7 @@ impl Decodable for DescribeUserScramCredentialsResult {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {
@@ -247,7 +245,7 @@ pub struct DescribeUserScramCredentialsResponse {
     pub results: Vec<DescribeUserScramCredentialsResult>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for DescribeUserScramCredentialsResponse {
@@ -303,8 +301,7 @@ impl Decodable for DescribeUserScramCredentialsResponse {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {

--- a/src/messages/elect_leaders_request.rs
+++ b/src/messages/elect_leaders_request.rs
@@ -28,7 +28,7 @@ pub struct TopicPartitions {
     pub partitions: Vec<i32>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for TopicPartitions {
@@ -109,8 +109,7 @@ impl MapDecodable for TopicPartitions {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -155,7 +154,7 @@ pub struct ElectLeadersRequest {
     pub timeout_ms: i32,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for ElectLeadersRequest {
@@ -241,8 +240,7 @@ impl Decodable for ElectLeadersRequest {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/elect_leaders_response.rs
+++ b/src/messages/elect_leaders_response.rs
@@ -38,7 +38,7 @@ pub struct PartitionResult {
     pub error_message: Option<StrBytes>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for PartitionResult {
@@ -108,8 +108,7 @@ impl Decodable for PartitionResult {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -153,7 +152,7 @@ pub struct ReplicaElectionResult {
     pub partition_result: Vec<PartitionResult>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for ReplicaElectionResult {
@@ -232,8 +231,7 @@ impl Decodable for ReplicaElectionResult {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -280,7 +278,7 @@ pub struct ElectLeadersResponse {
     pub replica_election_results: Vec<ReplicaElectionResult>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for ElectLeadersResponse {
@@ -366,8 +364,7 @@ impl Decodable for ElectLeadersResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/end_txn_request.rs
+++ b/src/messages/end_txn_request.rs
@@ -43,7 +43,7 @@ pub struct EndTxnRequest {
     pub committed: bool,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for EndTxnRequest {
@@ -116,8 +116,7 @@ impl Decodable for EndTxnRequest {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/end_txn_response.rs
+++ b/src/messages/end_txn_response.rs
@@ -33,7 +33,7 @@ pub struct EndTxnResponse {
     pub error_code: i16,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for EndTxnResponse {
@@ -88,8 +88,7 @@ impl Decodable for EndTxnResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/envelope_request.rs
+++ b/src/messages/envelope_request.rs
@@ -38,7 +38,7 @@ pub struct EnvelopeRequest {
     pub client_host_address: Bytes,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for EnvelopeRequest {
@@ -91,8 +91,7 @@ impl Decodable for EnvelopeRequest {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {

--- a/src/messages/envelope_response.rs
+++ b/src/messages/envelope_response.rs
@@ -33,7 +33,7 @@ pub struct EnvelopeResponse {
     pub error_code: i16,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for EnvelopeResponse {
@@ -83,8 +83,7 @@ impl Decodable for EnvelopeResponse {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {

--- a/src/messages/expire_delegation_token_request.rs
+++ b/src/messages/expire_delegation_token_request.rs
@@ -33,7 +33,7 @@ pub struct ExpireDelegationTokenRequest {
     pub expiry_time_period_ms: i64,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for ExpireDelegationTokenRequest {
@@ -100,8 +100,7 @@ impl Decodable for ExpireDelegationTokenRequest {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/expire_delegation_token_response.rs
+++ b/src/messages/expire_delegation_token_response.rs
@@ -38,7 +38,7 @@ pub struct ExpireDelegationTokenResponse {
     pub throttle_time_ms: i32,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for ExpireDelegationTokenResponse {
@@ -96,8 +96,7 @@ impl Decodable for ExpireDelegationTokenResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/fetch_request.rs
+++ b/src/messages/fetch_request.rs
@@ -53,7 +53,7 @@ pub struct FetchPartition {
     pub partition_max_bytes: i32,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for FetchPartition {
@@ -152,8 +152,7 @@ impl Decodable for FetchPartition {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -208,7 +207,7 @@ pub struct FetchTopic {
     pub partitions: Vec<FetchPartition>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for FetchTopic {
@@ -306,8 +305,7 @@ impl Decodable for FetchTopic {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -356,7 +354,7 @@ pub struct ForgottenTopic {
     pub partitions: Vec<i32>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for ForgottenTopic {
@@ -470,8 +468,7 @@ impl Decodable for ForgottenTopic {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -560,7 +557,7 @@ pub struct FetchRequest {
     pub rack_id: StrBytes,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for FetchRequest {
@@ -763,8 +760,7 @@ impl Decodable for FetchRequest {
                         cluster_id = types::CompactString.decode(buf)?;
                     },
                     _ => {
-                        let mut unknown_value = vec![0; size as usize];
-                        buf.try_copy_to_slice(&mut unknown_value)?;
+                        let unknown_value = buf.try_get_bytes(size as usize)?;
                         unknown_tagged_fields.insert(tag as i32, unknown_value);
                     }
                 }

--- a/src/messages/fetch_response.rs
+++ b/src/messages/fetch_response.rs
@@ -33,7 +33,7 @@ pub struct EpochEndOffset {
     pub end_offset: i64,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for EpochEndOffset {
@@ -120,8 +120,7 @@ impl Decodable for EpochEndOffset {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -163,7 +162,7 @@ pub struct LeaderIdAndEpoch {
     pub leader_epoch: i32,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for LeaderIdAndEpoch {
@@ -250,8 +249,7 @@ impl Decodable for LeaderIdAndEpoch {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -293,7 +291,7 @@ pub struct SnapshotId {
     pub epoch: i32,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for SnapshotId {
@@ -348,8 +346,7 @@ impl Decodable for SnapshotId {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -391,7 +388,7 @@ pub struct AbortedTransaction {
     pub first_offset: i64,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for AbortedTransaction {
@@ -478,8 +475,7 @@ impl Decodable for AbortedTransaction {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -566,7 +562,7 @@ pub struct PartitionData {
     pub records: Option<Bytes>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for PartitionData {
@@ -795,8 +791,7 @@ impl Decodable for PartitionData {
                         snapshot_id = types::Struct { version }.decode(buf)?;
                     },
                     _ => {
-                        let mut unknown_value = vec![0; size as usize];
-                        buf.try_copy_to_slice(&mut unknown_value)?;
+                        let unknown_value = buf.try_get_bytes(size as usize)?;
                         unknown_tagged_fields.insert(tag as i32, unknown_value);
                     }
                 }
@@ -863,7 +858,7 @@ pub struct FetchableTopicResponse {
     pub partitions: Vec<PartitionData>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for FetchableTopicResponse {
@@ -961,8 +956,7 @@ impl Decodable for FetchableTopicResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -1016,7 +1010,7 @@ pub struct FetchResponse {
     pub responses: Vec<FetchableTopicResponse>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for FetchResponse {
@@ -1121,8 +1115,7 @@ impl Decodable for FetchResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/fetch_snapshot_request.rs
+++ b/src/messages/fetch_snapshot_request.rs
@@ -33,7 +33,7 @@ pub struct SnapshotId {
     pub epoch: i32,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for SnapshotId {
@@ -83,8 +83,7 @@ impl Decodable for SnapshotId {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {
@@ -135,7 +134,7 @@ pub struct PartitionSnapshot {
     pub position: i64,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for PartitionSnapshot {
@@ -191,8 +190,7 @@ impl Decodable for PartitionSnapshot {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {
@@ -237,7 +235,7 @@ pub struct TopicSnapshot {
     pub partitions: Vec<PartitionSnapshot>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for TopicSnapshot {
@@ -287,8 +285,7 @@ impl Decodable for TopicSnapshot {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {
@@ -339,7 +336,7 @@ pub struct FetchSnapshotRequest {
     pub topics: Vec<TopicSnapshot>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for FetchSnapshotRequest {
@@ -424,8 +421,7 @@ impl Decodable for FetchSnapshotRequest {
                     cluster_id = types::CompactString.decode(buf)?;
                 },
                 _ => {
-                    let mut unknown_value = vec![0; size as usize];
-                    buf.try_copy_to_slice(&mut unknown_value)?;
+                    let unknown_value = buf.try_get_bytes(size as usize)?;
                     unknown_tagged_fields.insert(tag as i32, unknown_value);
                 }
             }

--- a/src/messages/fetch_snapshot_response.rs
+++ b/src/messages/fetch_snapshot_response.rs
@@ -33,7 +33,7 @@ pub struct SnapshotId {
     pub epoch: i32,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for SnapshotId {
@@ -83,8 +83,7 @@ impl Decodable for SnapshotId {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {
@@ -125,7 +124,7 @@ pub struct LeaderIdAndEpoch {
     pub leader_epoch: i32,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for LeaderIdAndEpoch {
@@ -175,8 +174,7 @@ impl Decodable for LeaderIdAndEpoch {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {
@@ -242,7 +240,7 @@ pub struct PartitionSnapshot {
     pub unaligned_records: Bytes,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for PartitionSnapshot {
@@ -336,8 +334,7 @@ impl Decodable for PartitionSnapshot {
                     current_leader = types::Struct { version }.decode(buf)?;
                 },
                 _ => {
-                    let mut unknown_value = vec![0; size as usize];
-                    buf.try_copy_to_slice(&mut unknown_value)?;
+                    let unknown_value = buf.try_get_bytes(size as usize)?;
                     unknown_tagged_fields.insert(tag as i32, unknown_value);
                 }
             }
@@ -390,7 +387,7 @@ pub struct TopicSnapshot {
     pub partitions: Vec<PartitionSnapshot>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for TopicSnapshot {
@@ -440,8 +437,7 @@ impl Decodable for TopicSnapshot {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {
@@ -487,7 +483,7 @@ pub struct FetchSnapshotResponse {
     pub topics: Vec<TopicSnapshot>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for FetchSnapshotResponse {
@@ -540,8 +536,7 @@ impl Decodable for FetchSnapshotResponse {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {

--- a/src/messages/find_coordinator_request.rs
+++ b/src/messages/find_coordinator_request.rs
@@ -38,7 +38,7 @@ pub struct FindCoordinatorRequest {
     pub coordinator_keys: Vec<StrBytes>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for FindCoordinatorRequest {
@@ -156,8 +156,7 @@ impl Decodable for FindCoordinatorRequest {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/find_coordinator_response.rs
+++ b/src/messages/find_coordinator_response.rs
@@ -53,7 +53,7 @@ pub struct Coordinator {
     pub error_message: Option<StrBytes>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for Coordinator {
@@ -208,8 +208,7 @@ impl Decodable for Coordinator {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -284,7 +283,7 @@ pub struct FindCoordinatorResponse {
     pub coordinators: Vec<Coordinator>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for FindCoordinatorResponse {
@@ -474,8 +473,7 @@ impl Decodable for FindCoordinatorResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/heartbeat_request.rs
+++ b/src/messages/heartbeat_request.rs
@@ -43,7 +43,7 @@ pub struct HeartbeatRequest {
     pub group_instance_id: Option<StrBytes>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for HeartbeatRequest {
@@ -156,8 +156,7 @@ impl Decodable for HeartbeatRequest {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/heartbeat_response.rs
+++ b/src/messages/heartbeat_response.rs
@@ -33,7 +33,7 @@ pub struct HeartbeatResponse {
     pub error_code: i16,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for HeartbeatResponse {
@@ -96,8 +96,7 @@ impl Decodable for HeartbeatResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/incremental_alter_configs_request.rs
+++ b/src/messages/incremental_alter_configs_request.rs
@@ -38,7 +38,7 @@ pub struct AlterableConfig {
     pub value: Option<StrBytes>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for AlterableConfig {
@@ -120,8 +120,7 @@ impl Decodable for AlterableConfig {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -170,7 +169,7 @@ pub struct AlterConfigsResource {
     pub configs: Vec<AlterableConfig>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for AlterConfigsResource {
@@ -252,8 +251,7 @@ impl Decodable for AlterConfigsResource {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -297,7 +295,7 @@ pub struct IncrementalAlterConfigsRequest {
     pub validate_only: bool,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for IncrementalAlterConfigsRequest {
@@ -364,8 +362,7 @@ impl Decodable for IncrementalAlterConfigsRequest {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/incremental_alter_configs_response.rs
+++ b/src/messages/incremental_alter_configs_response.rs
@@ -43,7 +43,7 @@ pub struct AlterConfigsResourceResponse {
     pub resource_name: StrBytes,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for AlterConfigsResourceResponse {
@@ -128,8 +128,7 @@ impl Decodable for AlterConfigsResourceResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -175,7 +174,7 @@ pub struct IncrementalAlterConfigsResponse {
     pub responses: Vec<AlterConfigsResourceResponse>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for IncrementalAlterConfigsResponse {
@@ -242,8 +241,7 @@ impl Decodable for IncrementalAlterConfigsResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/init_producer_id_request.rs
+++ b/src/messages/init_producer_id_request.rs
@@ -43,7 +43,7 @@ pub struct InitProducerIdRequest {
     pub producer_epoch: i16,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for InitProducerIdRequest {
@@ -148,8 +148,7 @@ impl Decodable for InitProducerIdRequest {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/init_producer_id_response.rs
+++ b/src/messages/init_producer_id_response.rs
@@ -43,7 +43,7 @@ pub struct InitProducerIdResponse {
     pub producer_epoch: i16,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for InitProducerIdResponse {
@@ -104,8 +104,7 @@ impl Decodable for InitProducerIdResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/join_group_request.rs
+++ b/src/messages/join_group_request.rs
@@ -28,7 +28,7 @@ pub struct JoinGroupRequestProtocol {
     pub metadata: Bytes,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for JoinGroupRequestProtocol {
@@ -109,8 +109,7 @@ impl MapDecodable for JoinGroupRequestProtocol {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -180,7 +179,7 @@ pub struct JoinGroupRequest {
     pub reason: Option<StrBytes>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for JoinGroupRequest {
@@ -345,8 +344,7 @@ impl Decodable for JoinGroupRequest {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/join_group_response.rs
+++ b/src/messages/join_group_response.rs
@@ -38,7 +38,7 @@ pub struct JoinGroupResponseMember {
     pub metadata: Bytes,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for JoinGroupResponseMember {
@@ -140,8 +140,7 @@ impl Decodable for JoinGroupResponseMember {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -220,7 +219,7 @@ pub struct JoinGroupResponse {
     pub members: Vec<JoinGroupResponseMember>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for JoinGroupResponse {
@@ -376,8 +375,7 @@ impl Decodable for JoinGroupResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/leader_and_isr_request.rs
+++ b/src/messages/leader_and_isr_request.rs
@@ -83,7 +83,7 @@ pub struct LeaderAndIsrPartitionState {
     pub leader_recovery_state: i8,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for LeaderAndIsrPartitionState {
@@ -264,8 +264,7 @@ impl Decodable for LeaderAndIsrPartitionState {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -332,7 +331,7 @@ pub struct LeaderAndIsrTopicState {
     pub partition_states: Vec<LeaderAndIsrPartitionState>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for LeaderAndIsrTopicState {
@@ -454,8 +453,7 @@ impl Decodable for LeaderAndIsrTopicState {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -504,7 +502,7 @@ pub struct LeaderAndIsrLiveLeader {
     pub port: i32,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for LeaderAndIsrLiveLeader {
@@ -574,8 +572,7 @@ impl Decodable for LeaderAndIsrLiveLeader {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -644,7 +641,7 @@ pub struct LeaderAndIsrRequest {
     pub live_leaders: Vec<LeaderAndIsrLiveLeader>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for LeaderAndIsrRequest {
@@ -794,8 +791,7 @@ impl Decodable for LeaderAndIsrRequest {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/leader_and_isr_response.rs
+++ b/src/messages/leader_and_isr_response.rs
@@ -38,7 +38,7 @@ pub struct LeaderAndIsrPartitionError {
     pub error_code: i16,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for LeaderAndIsrPartitionError {
@@ -116,8 +116,7 @@ impl Decodable for LeaderAndIsrPartitionError {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -156,7 +155,7 @@ pub struct LeaderAndIsrTopicError {
     pub partition_errors: Vec<LeaderAndIsrPartitionError>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for LeaderAndIsrTopicError {
@@ -245,8 +244,7 @@ impl MapDecodable for LeaderAndIsrTopicError {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -291,7 +289,7 @@ pub struct LeaderAndIsrResponse {
     pub topics: indexmap::IndexMap<Uuid, LeaderAndIsrTopicError>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for LeaderAndIsrResponse {
@@ -393,8 +391,7 @@ impl Decodable for LeaderAndIsrResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/leader_change_message.rs
+++ b/src/messages/leader_change_message.rs
@@ -28,7 +28,7 @@ pub struct Voter {
     pub voter_id: i32,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for Voter {
@@ -75,8 +75,7 @@ impl Decodable for Voter {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {
@@ -125,7 +124,7 @@ pub struct LeaderChangeMessage {
     pub granting_voters: Vec<Voter>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for LeaderChangeMessage {
@@ -181,8 +180,7 @@ impl Decodable for LeaderChangeMessage {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {

--- a/src/messages/leave_group_request.rs
+++ b/src/messages/leave_group_request.rs
@@ -38,7 +38,7 @@ pub struct MemberIdentity {
     pub reason: Option<StrBytes>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for MemberIdentity {
@@ -160,8 +160,7 @@ impl Decodable for MemberIdentity {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -210,7 +209,7 @@ pub struct LeaveGroupRequest {
     pub members: Vec<MemberIdentity>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for LeaveGroupRequest {
@@ -324,8 +323,7 @@ impl Decodable for LeaveGroupRequest {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/leave_group_response.rs
+++ b/src/messages/leave_group_response.rs
@@ -38,7 +38,7 @@ pub struct MemberResponse {
     pub error_code: i16,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for MemberResponse {
@@ -168,8 +168,7 @@ impl Decodable for MemberResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -218,7 +217,7 @@ pub struct LeaveGroupResponse {
     pub members: Vec<MemberResponse>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for LeaveGroupResponse {
@@ -312,8 +311,7 @@ impl Decodable for LeaveGroupResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/list_groups_request.rs
+++ b/src/messages/list_groups_request.rs
@@ -28,7 +28,7 @@ pub struct ListGroupsRequest {
     pub states_filter: Vec<StrBytes>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for ListGroupsRequest {
@@ -96,8 +96,7 @@ impl Decodable for ListGroupsRequest {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/list_groups_response.rs
+++ b/src/messages/list_groups_response.rs
@@ -38,7 +38,7 @@ pub struct ListedGroup {
     pub group_state: StrBytes,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for ListedGroup {
@@ -128,8 +128,7 @@ impl Decodable for ListedGroup {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -178,7 +177,7 @@ pub struct ListGroupsResponse {
     pub groups: Vec<ListedGroup>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for ListGroupsResponse {
@@ -256,8 +255,7 @@ impl Decodable for ListGroupsResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/list_offsets_request.rs
+++ b/src/messages/list_offsets_request.rs
@@ -43,7 +43,7 @@ pub struct ListOffsetsPartition {
     pub max_num_offsets: i32,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for ListOffsetsPartition {
@@ -128,8 +128,7 @@ impl Decodable for ListOffsetsPartition {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -175,7 +174,7 @@ pub struct ListOffsetsTopic {
     pub partitions: Vec<ListOffsetsPartition>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for ListOffsetsTopic {
@@ -254,8 +253,7 @@ impl Decodable for ListOffsetsTopic {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -302,7 +300,7 @@ pub struct ListOffsetsRequest {
     pub topics: Vec<ListOffsetsTopic>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for ListOffsetsRequest {
@@ -388,8 +386,7 @@ impl Decodable for ListOffsetsRequest {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/list_offsets_response.rs
+++ b/src/messages/list_offsets_response.rs
@@ -53,7 +53,7 @@ pub struct ListOffsetsPartitionResponse {
     pub leader_epoch: i32,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for ListOffsetsPartitionResponse {
@@ -184,8 +184,7 @@ impl Decodable for ListOffsetsPartitionResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -235,7 +234,7 @@ pub struct ListOffsetsTopicResponse {
     pub partitions: Vec<ListOffsetsPartitionResponse>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for ListOffsetsTopicResponse {
@@ -314,8 +313,7 @@ impl Decodable for ListOffsetsTopicResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -357,7 +355,7 @@ pub struct ListOffsetsResponse {
     pub topics: Vec<ListOffsetsTopicResponse>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for ListOffsetsResponse {
@@ -432,8 +430,7 @@ impl Decodable for ListOffsetsResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/list_partition_reassignments_request.rs
+++ b/src/messages/list_partition_reassignments_request.rs
@@ -33,7 +33,7 @@ pub struct ListPartitionReassignmentsTopics {
     pub partition_indexes: Vec<i32>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for ListPartitionReassignmentsTopics {
@@ -83,8 +83,7 @@ impl Decodable for ListPartitionReassignmentsTopics {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {
@@ -125,7 +124,7 @@ pub struct ListPartitionReassignmentsRequest {
     pub topics: Option<Vec<ListPartitionReassignmentsTopics>>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for ListPartitionReassignmentsRequest {
@@ -175,8 +174,7 @@ impl Decodable for ListPartitionReassignmentsRequest {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {

--- a/src/messages/list_partition_reassignments_response.rs
+++ b/src/messages/list_partition_reassignments_response.rs
@@ -43,7 +43,7 @@ pub struct OngoingPartitionReassignment {
     pub removing_replicas: Vec<super::BrokerId>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for OngoingPartitionReassignment {
@@ -99,8 +99,7 @@ impl Decodable for OngoingPartitionReassignment {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {
@@ -145,7 +144,7 @@ pub struct OngoingTopicReassignment {
     pub partitions: Vec<OngoingPartitionReassignment>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for OngoingTopicReassignment {
@@ -195,8 +194,7 @@ impl Decodable for OngoingTopicReassignment {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {
@@ -247,7 +245,7 @@ pub struct ListPartitionReassignmentsResponse {
     pub topics: Vec<OngoingTopicReassignment>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for ListPartitionReassignmentsResponse {
@@ -303,8 +301,7 @@ impl Decodable for ListPartitionReassignmentsResponse {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {

--- a/src/messages/list_transactions_request.rs
+++ b/src/messages/list_transactions_request.rs
@@ -33,7 +33,7 @@ pub struct ListTransactionsRequest {
     pub producer_id_filters: Vec<super::ProducerId>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for ListTransactionsRequest {
@@ -83,8 +83,7 @@ impl Decodable for ListTransactionsRequest {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {

--- a/src/messages/list_transactions_response.rs
+++ b/src/messages/list_transactions_response.rs
@@ -38,7 +38,7 @@ pub struct TransactionState {
     pub transaction_state: StrBytes,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for TransactionState {
@@ -91,8 +91,7 @@ impl Decodable for TransactionState {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {
@@ -145,7 +144,7 @@ pub struct ListTransactionsResponse {
     pub transaction_states: Vec<TransactionState>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for ListTransactionsResponse {
@@ -201,8 +200,7 @@ impl Decodable for ListTransactionsResponse {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {

--- a/src/messages/metadata_request.rs
+++ b/src/messages/metadata_request.rs
@@ -33,7 +33,7 @@ pub struct MetadataRequestTopic {
     pub name: Option<super::TopicName>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for MetadataRequestTopic {
@@ -108,8 +108,7 @@ impl Decodable for MetadataRequestTopic {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -161,7 +160,7 @@ pub struct MetadataRequest {
     pub include_topic_authorized_operations: bool,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for MetadataRequest {
@@ -282,8 +281,7 @@ impl Decodable for MetadataRequest {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/metadata_response.rs
+++ b/src/messages/metadata_response.rs
@@ -38,7 +38,7 @@ pub struct MetadataResponseBroker {
     pub rack: Option<StrBytes>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for MetadataResponseBroker {
@@ -133,8 +133,7 @@ impl MapDecodable for MetadataResponseBroker {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -203,7 +202,7 @@ pub struct MetadataResponsePartition {
     pub offline_replicas: Vec<super::BrokerId>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for MetadataResponsePartition {
@@ -325,8 +324,7 @@ impl Decodable for MetadataResponsePartition {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -393,7 +391,7 @@ pub struct MetadataResponseTopic {
     pub topic_authorized_operations: i32,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for MetadataResponseTopic {
@@ -518,8 +516,7 @@ impl MapDecodable for MetadataResponseTopic {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -587,7 +584,7 @@ pub struct MetadataResponse {
     pub cluster_authorized_operations: i32,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for MetadataResponse {
@@ -730,8 +727,7 @@ impl Decodable for MetadataResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/offset_commit_request.rs
+++ b/src/messages/offset_commit_request.rs
@@ -48,7 +48,7 @@ pub struct OffsetCommitRequestPartition {
     pub committed_metadata: Option<StrBytes>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for OffsetCommitRequestPartition {
@@ -148,8 +148,7 @@ impl Decodable for OffsetCommitRequestPartition {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -197,7 +196,7 @@ pub struct OffsetCommitRequestTopic {
     pub partitions: Vec<OffsetCommitRequestPartition>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for OffsetCommitRequestTopic {
@@ -276,8 +275,7 @@ impl Decodable for OffsetCommitRequestTopic {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -339,7 +337,7 @@ pub struct OffsetCommitRequest {
     pub topics: Vec<OffsetCommitRequestTopic>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for OffsetCommitRequest {
@@ -494,8 +492,7 @@ impl Decodable for OffsetCommitRequest {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/offset_commit_response.rs
+++ b/src/messages/offset_commit_response.rs
@@ -33,7 +33,7 @@ pub struct OffsetCommitResponsePartition {
     pub error_code: i16,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for OffsetCommitResponsePartition {
@@ -88,8 +88,7 @@ impl Decodable for OffsetCommitResponsePartition {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -131,7 +130,7 @@ pub struct OffsetCommitResponseTopic {
     pub partitions: Vec<OffsetCommitResponsePartition>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for OffsetCommitResponseTopic {
@@ -210,8 +209,7 @@ impl Decodable for OffsetCommitResponseTopic {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -253,7 +251,7 @@ pub struct OffsetCommitResponse {
     pub topics: Vec<OffsetCommitResponseTopic>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for OffsetCommitResponse {
@@ -328,8 +326,7 @@ impl Decodable for OffsetCommitResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/offset_fetch_request.rs
+++ b/src/messages/offset_fetch_request.rs
@@ -33,7 +33,7 @@ pub struct OffsetFetchRequestTopic {
     pub partition_indexes: Vec<i32>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for OffsetFetchRequestTopic {
@@ -144,8 +144,7 @@ impl Decodable for OffsetFetchRequestTopic {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -187,7 +186,7 @@ pub struct OffsetFetchRequestTopics {
     pub partition_indexes: Vec<i32>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for OffsetFetchRequestTopics {
@@ -274,8 +273,7 @@ impl Decodable for OffsetFetchRequestTopics {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -317,7 +315,7 @@ pub struct OffsetFetchRequestGroup {
     pub topics: Option<Vec<OffsetFetchRequestTopics>>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for OffsetFetchRequestGroup {
@@ -404,8 +402,7 @@ impl Decodable for OffsetFetchRequestGroup {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -457,7 +454,7 @@ pub struct OffsetFetchRequest {
     pub require_stable: bool,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for OffsetFetchRequest {
@@ -606,8 +603,7 @@ impl Decodable for OffsetFetchRequest {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/offset_fetch_response.rs
+++ b/src/messages/offset_fetch_response.rs
@@ -48,7 +48,7 @@ pub struct OffsetFetchResponsePartition {
     pub error_code: i16,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for OffsetFetchResponsePartition {
@@ -196,8 +196,7 @@ impl Decodable for OffsetFetchResponsePartition {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -245,7 +244,7 @@ pub struct OffsetFetchResponseTopic {
     pub partitions: Vec<OffsetFetchResponsePartition>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for OffsetFetchResponseTopic {
@@ -356,8 +355,7 @@ impl Decodable for OffsetFetchResponseTopic {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -414,7 +412,7 @@ pub struct OffsetFetchResponsePartitions {
     pub error_code: i16,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for OffsetFetchResponsePartitions {
@@ -550,8 +548,7 @@ impl Decodable for OffsetFetchResponsePartitions {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -599,7 +596,7 @@ pub struct OffsetFetchResponseTopics {
     pub partitions: Vec<OffsetFetchResponsePartitions>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for OffsetFetchResponseTopics {
@@ -686,8 +683,7 @@ impl Decodable for OffsetFetchResponseTopics {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -734,7 +730,7 @@ pub struct OffsetFetchResponseGroup {
     pub error_code: i16,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for OffsetFetchResponseGroup {
@@ -840,8 +836,7 @@ impl Decodable for OffsetFetchResponseGroup {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -895,7 +890,7 @@ pub struct OffsetFetchResponse {
     pub groups: Vec<OffsetFetchResponseGroup>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for OffsetFetchResponse {
@@ -1016,8 +1011,7 @@ impl Decodable for OffsetFetchResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/offset_for_leader_epoch_request.rs
+++ b/src/messages/offset_for_leader_epoch_request.rs
@@ -38,7 +38,7 @@ pub struct OffsetForLeaderPartition {
     pub leader_epoch: i32,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for OffsetForLeaderPartition {
@@ -104,8 +104,7 @@ impl Decodable for OffsetForLeaderPartition {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -144,7 +143,7 @@ pub struct OffsetForLeaderTopic {
     pub partitions: Vec<OffsetForLeaderPartition>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for OffsetForLeaderTopic {
@@ -225,8 +224,7 @@ impl MapDecodable for OffsetForLeaderTopic {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -266,7 +264,7 @@ pub struct OffsetForLeaderEpochRequest {
     pub topics: indexmap::IndexMap<super::TopicName, OffsetForLeaderTopic>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for OffsetForLeaderEpochRequest {
@@ -341,8 +339,7 @@ impl Decodable for OffsetForLeaderEpochRequest {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/offset_for_leader_epoch_response.rs
+++ b/src/messages/offset_for_leader_epoch_response.rs
@@ -43,7 +43,7 @@ pub struct EpochEndOffset {
     pub end_offset: i64,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for EpochEndOffset {
@@ -112,8 +112,7 @@ impl Decodable for EpochEndOffset {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -154,7 +153,7 @@ pub struct OffsetForLeaderTopicResult {
     pub partitions: Vec<EpochEndOffset>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for OffsetForLeaderTopicResult {
@@ -235,8 +234,7 @@ impl MapDecodable for OffsetForLeaderTopicResult {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -276,7 +274,7 @@ pub struct OffsetForLeaderEpochResponse {
     pub topics: indexmap::IndexMap<super::TopicName, OffsetForLeaderTopicResult>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for OffsetForLeaderEpochResponse {
@@ -351,8 +349,7 @@ impl Decodable for OffsetForLeaderEpochResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/produce_request.rs
+++ b/src/messages/produce_request.rs
@@ -33,7 +33,7 @@ pub struct PartitionProduceData {
     pub records: Option<Bytes>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for PartitionProduceData {
@@ -100,8 +100,7 @@ impl Decodable for PartitionProduceData {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -138,7 +137,7 @@ pub struct TopicProduceData {
     pub partition_data: Vec<PartitionProduceData>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for TopicProduceData {
@@ -219,8 +218,7 @@ impl MapDecodable for TopicProduceData {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -270,7 +268,7 @@ pub struct ProduceRequest {
     pub topic_data: indexmap::IndexMap<super::TopicName, TopicProduceData>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for ProduceRequest {
@@ -371,8 +369,7 @@ impl Decodable for ProduceRequest {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/produce_response.rs
+++ b/src/messages/produce_response.rs
@@ -33,7 +33,7 @@ pub struct BatchIndexAndErrorMessage {
     pub batch_index_error_message: Option<StrBytes>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for BatchIndexAndErrorMessage {
@@ -132,8 +132,7 @@ impl Decodable for BatchIndexAndErrorMessage {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -200,7 +199,7 @@ pub struct PartitionProduceResponse {
     pub error_message: Option<StrBytes>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for PartitionProduceResponse {
@@ -326,8 +325,7 @@ impl Decodable for PartitionProduceResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -374,7 +372,7 @@ pub struct TopicProduceResponse {
     pub partition_responses: Vec<PartitionProduceResponse>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for TopicProduceResponse {
@@ -455,8 +453,7 @@ impl MapDecodable for TopicProduceResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -496,7 +493,7 @@ pub struct ProduceResponse {
     pub throttle_time_ms: i32,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for ProduceResponse {
@@ -571,8 +568,7 @@ impl Decodable for ProduceResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/renew_delegation_token_request.rs
+++ b/src/messages/renew_delegation_token_request.rs
@@ -33,7 +33,7 @@ pub struct RenewDelegationTokenRequest {
     pub renew_period_ms: i64,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for RenewDelegationTokenRequest {
@@ -100,8 +100,7 @@ impl Decodable for RenewDelegationTokenRequest {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/renew_delegation_token_response.rs
+++ b/src/messages/renew_delegation_token_response.rs
@@ -38,7 +38,7 @@ pub struct RenewDelegationTokenResponse {
     pub throttle_time_ms: i32,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for RenewDelegationTokenResponse {
@@ -96,8 +96,7 @@ impl Decodable for RenewDelegationTokenResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/request_header.rs
+++ b/src/messages/request_header.rs
@@ -43,7 +43,7 @@ pub struct RequestHeader {
     pub client_id: Option<StrBytes>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for RequestHeader {
@@ -112,8 +112,7 @@ impl Decodable for RequestHeader {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/response_header.rs
+++ b/src/messages/response_header.rs
@@ -28,7 +28,7 @@ pub struct ResponseHeader {
     pub correlation_id: i32,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for ResponseHeader {
@@ -80,8 +80,7 @@ impl Decodable for ResponseHeader {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/sasl_authenticate_request.rs
+++ b/src/messages/sasl_authenticate_request.rs
@@ -28,7 +28,7 @@ pub struct SaslAuthenticateRequest {
     pub auth_bytes: Bytes,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for SaslAuthenticateRequest {
@@ -92,8 +92,7 @@ impl Decodable for SaslAuthenticateRequest {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/sasl_authenticate_response.rs
+++ b/src/messages/sasl_authenticate_response.rs
@@ -43,7 +43,7 @@ pub struct SaslAuthenticateResponse {
     pub session_lifetime_ms: i64,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for SaslAuthenticateResponse {
@@ -136,8 +136,7 @@ impl Decodable for SaslAuthenticateResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/snapshot_footer_record.rs
+++ b/src/messages/snapshot_footer_record.rs
@@ -28,7 +28,7 @@ pub struct SnapshotFooterRecord {
     pub version: i16,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for SnapshotFooterRecord {
@@ -75,8 +75,7 @@ impl Decodable for SnapshotFooterRecord {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {

--- a/src/messages/snapshot_header_record.rs
+++ b/src/messages/snapshot_header_record.rs
@@ -33,7 +33,7 @@ pub struct SnapshotHeaderRecord {
     pub last_contained_log_timestamp: i64,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for SnapshotHeaderRecord {
@@ -83,8 +83,7 @@ impl Decodable for SnapshotHeaderRecord {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {

--- a/src/messages/stop_replica_request.rs
+++ b/src/messages/stop_replica_request.rs
@@ -33,7 +33,7 @@ pub struct StopReplicaPartitionV0 {
     pub partition_index: i32,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for StopReplicaPartitionV0 {
@@ -120,8 +120,7 @@ impl Decodable for StopReplicaPartitionV0 {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -163,7 +162,7 @@ pub struct StopReplicaTopicV1 {
     pub partition_indexes: Vec<i32>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for StopReplicaTopicV1 {
@@ -274,8 +273,7 @@ impl Decodable for StopReplicaTopicV1 {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -322,7 +320,7 @@ pub struct StopReplicaPartitionState {
     pub delete_partition: bool,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for StopReplicaPartitionState {
@@ -428,8 +426,7 @@ impl Decodable for StopReplicaPartitionState {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -473,7 +470,7 @@ pub struct StopReplicaTopicState {
     pub partition_states: Vec<StopReplicaPartitionState>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for StopReplicaTopicState {
@@ -560,8 +557,7 @@ impl Decodable for StopReplicaTopicState {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -628,7 +624,7 @@ pub struct StopReplicaRequest {
     pub topic_states: Vec<StopReplicaTopicState>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for StopReplicaRequest {
@@ -782,8 +778,7 @@ impl Decodable for StopReplicaRequest {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/stop_replica_response.rs
+++ b/src/messages/stop_replica_response.rs
@@ -38,7 +38,7 @@ pub struct StopReplicaPartitionError {
     pub error_code: i16,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for StopReplicaPartitionError {
@@ -108,8 +108,7 @@ impl Decodable for StopReplicaPartitionError {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -153,7 +152,7 @@ pub struct StopReplicaResponse {
     pub partition_errors: Vec<StopReplicaPartitionError>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for StopReplicaResponse {
@@ -220,8 +219,7 @@ impl Decodable for StopReplicaResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/sync_group_request.rs
+++ b/src/messages/sync_group_request.rs
@@ -33,7 +33,7 @@ pub struct SyncGroupRequestAssignment {
     pub assignment: Bytes,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for SyncGroupRequestAssignment {
@@ -112,8 +112,7 @@ impl Decodable for SyncGroupRequestAssignment {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -180,7 +179,7 @@ pub struct SyncGroupRequest {
     pub assignments: Vec<SyncGroupRequestAssignment>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for SyncGroupRequest {
@@ -330,8 +329,7 @@ impl Decodable for SyncGroupRequest {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/sync_group_response.rs
+++ b/src/messages/sync_group_response.rs
@@ -48,7 +48,7 @@ pub struct SyncGroupResponse {
     pub assignment: Bytes,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for SyncGroupResponse {
@@ -148,8 +148,7 @@ impl Decodable for SyncGroupResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/txn_offset_commit_request.rs
+++ b/src/messages/txn_offset_commit_request.rs
@@ -43,7 +43,7 @@ pub struct TxnOffsetCommitRequestPartition {
     pub committed_metadata: Option<StrBytes>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for TxnOffsetCommitRequestPartition {
@@ -124,8 +124,7 @@ impl Decodable for TxnOffsetCommitRequestPartition {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -171,7 +170,7 @@ pub struct TxnOffsetCommitRequestTopic {
     pub partitions: Vec<TxnOffsetCommitRequestPartition>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for TxnOffsetCommitRequestTopic {
@@ -250,8 +249,7 @@ impl Decodable for TxnOffsetCommitRequestTopic {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -323,7 +321,7 @@ pub struct TxnOffsetCommitRequest {
     pub topics: Vec<TxnOffsetCommitRequestTopic>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for TxnOffsetCommitRequest {
@@ -480,8 +478,7 @@ impl Decodable for TxnOffsetCommitRequest {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/txn_offset_commit_response.rs
+++ b/src/messages/txn_offset_commit_response.rs
@@ -33,7 +33,7 @@ pub struct TxnOffsetCommitResponsePartition {
     pub error_code: i16,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for TxnOffsetCommitResponsePartition {
@@ -88,8 +88,7 @@ impl Decodable for TxnOffsetCommitResponsePartition {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -131,7 +130,7 @@ pub struct TxnOffsetCommitResponseTopic {
     pub partitions: Vec<TxnOffsetCommitResponsePartition>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for TxnOffsetCommitResponseTopic {
@@ -210,8 +209,7 @@ impl Decodable for TxnOffsetCommitResponseTopic {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -253,7 +251,7 @@ pub struct TxnOffsetCommitResponse {
     pub topics: Vec<TxnOffsetCommitResponseTopic>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for TxnOffsetCommitResponse {
@@ -320,8 +318,7 @@ impl Decodable for TxnOffsetCommitResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/unregister_broker_request.rs
+++ b/src/messages/unregister_broker_request.rs
@@ -28,7 +28,7 @@ pub struct UnregisterBrokerRequest {
     pub broker_id: super::BrokerId,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for UnregisterBrokerRequest {
@@ -75,8 +75,7 @@ impl Decodable for UnregisterBrokerRequest {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {

--- a/src/messages/unregister_broker_response.rs
+++ b/src/messages/unregister_broker_response.rs
@@ -38,7 +38,7 @@ pub struct UnregisterBrokerResponse {
     pub error_message: Option<StrBytes>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for UnregisterBrokerResponse {
@@ -91,8 +91,7 @@ impl Decodable for UnregisterBrokerResponse {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {

--- a/src/messages/update_features_request.rs
+++ b/src/messages/update_features_request.rs
@@ -38,7 +38,7 @@ pub struct FeatureUpdateKey {
     pub upgrade_type: i8,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for FeatureUpdateKey {
@@ -128,8 +128,7 @@ impl MapDecodable for FeatureUpdateKey {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok((key_field, Self {
@@ -177,7 +176,7 @@ pub struct UpdateFeaturesRequest {
     pub validate_only: bool,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for UpdateFeaturesRequest {
@@ -246,8 +245,7 @@ impl Decodable for UpdateFeaturesRequest {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {

--- a/src/messages/update_features_response.rs
+++ b/src/messages/update_features_response.rs
@@ -33,7 +33,7 @@ pub struct UpdatableFeatureResult {
     pub error_message: Option<StrBytes>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for UpdatableFeatureResult {
@@ -88,8 +88,7 @@ impl MapDecodable for UpdatableFeatureResult {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok((key_field, Self {
@@ -140,7 +139,7 @@ pub struct UpdateFeaturesResponse {
     pub results: indexmap::IndexMap<StrBytes, UpdatableFeatureResult>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for UpdateFeaturesResponse {
@@ -196,8 +195,7 @@ impl Decodable for UpdateFeaturesResponse {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {

--- a/src/messages/update_metadata_request.rs
+++ b/src/messages/update_metadata_request.rs
@@ -68,7 +68,7 @@ pub struct UpdateMetadataPartitionState {
     pub offline_replicas: Vec<super::BrokerId>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for UpdateMetadataPartitionState {
@@ -196,8 +196,7 @@ impl Decodable for UpdateMetadataPartitionState {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -258,7 +257,7 @@ pub struct UpdateMetadataTopicState {
     pub partition_states: Vec<UpdateMetadataPartitionState>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for UpdateMetadataTopicState {
@@ -380,8 +379,7 @@ impl Decodable for UpdateMetadataTopicState {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -435,7 +433,7 @@ pub struct UpdateMetadataEndpoint {
     pub security_protocol: i16,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for UpdateMetadataEndpoint {
@@ -576,8 +574,7 @@ impl Decodable for UpdateMetadataEndpoint {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -638,7 +635,7 @@ pub struct UpdateMetadataBroker {
     pub rack: Option<StrBytes>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for UpdateMetadataBroker {
@@ -758,8 +755,7 @@ impl Decodable for UpdateMetadataBroker {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -827,7 +823,7 @@ pub struct UpdateMetadataRequest {
     pub live_brokers: Vec<UpdateMetadataBroker>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for UpdateMetadataRequest {
@@ -958,8 +954,7 @@ impl Decodable for UpdateMetadataRequest {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/update_metadata_response.rs
+++ b/src/messages/update_metadata_response.rs
@@ -28,7 +28,7 @@ pub struct UpdateMetadataResponse {
     pub error_code: i16,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for UpdateMetadataResponse {
@@ -80,8 +80,7 @@ impl Decodable for UpdateMetadataResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/vote_request.rs
+++ b/src/messages/vote_request.rs
@@ -48,7 +48,7 @@ pub struct PartitionData {
     pub last_offset: i64,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for PartitionData {
@@ -107,8 +107,7 @@ impl Decodable for PartitionData {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {
@@ -155,7 +154,7 @@ pub struct TopicData {
     pub partitions: Vec<PartitionData>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for TopicData {
@@ -205,8 +204,7 @@ impl Decodable for TopicData {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {
@@ -247,7 +245,7 @@ pub struct VoteRequest {
     pub topics: Vec<TopicData>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for VoteRequest {
@@ -297,8 +295,7 @@ impl Decodable for VoteRequest {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {

--- a/src/messages/vote_response.rs
+++ b/src/messages/vote_response.rs
@@ -48,7 +48,7 @@ pub struct PartitionData {
     pub vote_granted: bool,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for PartitionData {
@@ -107,8 +107,7 @@ impl Decodable for PartitionData {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {
@@ -155,7 +154,7 @@ pub struct TopicData {
     pub partitions: Vec<PartitionData>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for TopicData {
@@ -205,8 +204,7 @@ impl Decodable for TopicData {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {
@@ -247,7 +245,7 @@ pub struct VoteResponse {
     pub topics: Vec<TopicData>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for VoteResponse {
@@ -297,8 +295,7 @@ impl Decodable for VoteResponse {
         for _ in 0..num_tagged_fields {
             let tag: u32 = types::UnsignedVarInt.decode(buf)?;
             let size: u32 = types::UnsignedVarInt.decode(buf)?;
-            let mut unknown_value = vec![0; size as usize];
-            buf.try_copy_to_slice(&mut unknown_value)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
         Ok(Self {

--- a/src/messages/write_txn_markers_request.rs
+++ b/src/messages/write_txn_markers_request.rs
@@ -33,7 +33,7 @@ pub struct WritableTxnMarkerTopic {
     pub partition_indexes: Vec<i32>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for WritableTxnMarkerTopic {
@@ -112,8 +112,7 @@ impl Decodable for WritableTxnMarkerTopic {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -170,7 +169,7 @@ pub struct WritableTxnMarker {
     pub coordinator_epoch: i32,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for WritableTxnMarker {
@@ -246,8 +245,7 @@ impl Decodable for WritableTxnMarker {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -290,7 +288,7 @@ pub struct WriteTxnMarkersRequest {
     pub markers: Vec<WritableTxnMarker>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for WriteTxnMarkersRequest {
@@ -354,8 +352,7 @@ impl Decodable for WriteTxnMarkersRequest {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/messages/write_txn_markers_response.rs
+++ b/src/messages/write_txn_markers_response.rs
@@ -33,7 +33,7 @@ pub struct WritableTxnMarkerPartitionResult {
     pub error_code: i16,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for WritableTxnMarkerPartitionResult {
@@ -88,8 +88,7 @@ impl Decodable for WritableTxnMarkerPartitionResult {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -131,7 +130,7 @@ pub struct WritableTxnMarkerTopicResult {
     pub partitions: Vec<WritableTxnMarkerPartitionResult>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for WritableTxnMarkerTopicResult {
@@ -210,8 +209,7 @@ impl Decodable for WritableTxnMarkerTopicResult {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -253,7 +251,7 @@ pub struct WritableTxnMarkerResult {
     pub topics: Vec<WritableTxnMarkerTopicResult>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for WritableTxnMarkerResult {
@@ -320,8 +318,7 @@ impl Decodable for WritableTxnMarkerResult {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
@@ -358,7 +355,7 @@ pub struct WriteTxnMarkersResponse {
     pub markers: Vec<WritableTxnMarkerResult>,
 
     /// Other tagged fields
-    pub unknown_tagged_fields: BTreeMap<i32, Vec<u8>>,
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl Builder for WriteTxnMarkersResponse {
@@ -422,8 +419,7 @@ impl Decodable for WriteTxnMarkersResponse {
             for _ in 0..num_tagged_fields {
                 let tag: u32 = types::UnsignedVarInt.decode(buf)?;
                 let size: u32 = types::UnsignedVarInt.decode(buf)?;
-                let mut unknown_value = vec![0; size as usize];
-                buf.try_copy_to_slice(&mut unknown_value)?;
+                let unknown_value = buf.try_get_bytes(size as usize)?;
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }

--- a/src/protocol/buf.rs
+++ b/src/protocol/buf.rs
@@ -25,7 +25,7 @@ pub trait ByteBuf: Buf {
     fn peek_bytes(&mut self, r: Range<usize>) -> Bytes;
     /// Get `size` bytes from the underlying buffer.
     fn get_bytes(&mut self, size: usize) -> Bytes;
-    /// Try to peek ahead in the buffer bu the provided range, returning an error if there are less
+    /// Try to peek ahead in the buffer by the provided range, returning an error if there are less
     /// bytes than the requested range.
     fn try_peek_bytes(&mut self, r: Range<usize>) -> Result<Bytes, NotEnoughBytesError> {
         if self.remaining() < r.end {


### PR DESCRIPTION
I dont know why this was previously stored as a `Vec`, but it makes more sense to be a `Bytes` to avoid having to reallocate.
I dont believe there are any downsides when unknown_tagged_fields is unused.
`Bytes` does take up more space on the stack than `Vec` but if unknown_tagged_fields is empty that doesnt matter anyway since there is no memory allocated by the HashMap for that size difference to come into effect.

All generated code is isolated to the second commit.

This is a breaking change.