### PR TITLE
Remove indirection from primitive types that are copy

### DIFF
--- a/protocol_codegen/src/generate_messages/expr.rs
+++ b/protocol_codegen/src/generate_messages/expr.rs
@@ -204,7 +204,7 @@ impl Expr {
                 value: ExprValue::Flat(s.clone()),
             }
         } else {
-            self.unary("*")
+            self.clone()
         }
     }
     pub fn unary(&self, op: &str) -> Self {

--- a/src/messages/add_offsets_to_txn_request.rs
+++ b/src/messages/add_offsets_to_txn_request.rs
@@ -62,7 +62,7 @@ impl Encodable for AddOffsetsToTxnRequest {
             types::String.encode(buf, &self.transactional_id)?;
         }
         types::Int64.encode(buf, &self.producer_id)?;
-        types::Int16.encode(buf, &self.producer_epoch)?;
+        buf.put_i16(self.producer_epoch);
         if version >= 3 {
             types::CompactString.encode(buf, &self.group_id)?;
         } else {
@@ -74,7 +74,7 @@ impl Encodable for AddOffsetsToTxnRequest {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -88,7 +88,7 @@ impl Encodable for AddOffsetsToTxnRequest {
             total_size += types::String.compute_size(&self.transactional_id)?;
         }
         total_size += types::Int64.compute_size(&self.producer_id)?;
-        total_size += types::Int16.compute_size(&self.producer_epoch)?;
+        total_size += 2;
         if version >= 3 {
             total_size += types::CompactString.compute_size(&self.group_id)?;
         } else {
@@ -116,7 +116,7 @@ impl Decodable for AddOffsetsToTxnRequest {
             types::String.decode(buf)?
         };
         let producer_id = types::Int64.decode(buf)?;
-        let producer_epoch = types::Int16.decode(buf)?;
+        let producer_epoch = buf.try_get_i16()?;
         let group_id = if version >= 3 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/add_offsets_to_txn_response.rs
+++ b/src/messages/add_offsets_to_txn_response.rs
@@ -46,15 +46,15 @@ impl Builder for AddOffsetsToTxnResponse {
 
 impl Encodable for AddOffsetsToTxnResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.throttle_time_ms)?;
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i32(self.throttle_time_ms);
+        buf.put_i16(self.error_code);
         if version >= 3 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -62,8 +62,8 @@ impl Encodable for AddOffsetsToTxnResponse {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 4;
+        total_size += 2;
         if version >= 3 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
@@ -80,8 +80,8 @@ impl Encodable for AddOffsetsToTxnResponse {
 
 impl Decodable for AddOffsetsToTxnResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let throttle_time_ms = types::Int32.decode(buf)?;
-        let error_code = types::Int16.decode(buf)?;
+        let throttle_time_ms = buf.try_get_i32()?;
+        let error_code = buf.try_get_i16()?;
         let mut unknown_tagged_fields = BTreeMap::new();
         if version >= 3 {
             let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;

--- a/src/messages/add_partitions_to_txn_request.rs
+++ b/src/messages/add_partitions_to_txn_request.rs
@@ -58,7 +58,7 @@ impl MapEncodable for AddPartitionsToTxnTopic {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -178,7 +178,7 @@ impl Encodable for AddPartitionsToTxnRequest {
             types::String.encode(buf, &self.transactional_id)?;
         }
         types::Int64.encode(buf, &self.producer_id)?;
-        types::Int16.encode(buf, &self.producer_epoch)?;
+        buf.put_i16(self.producer_epoch);
         if version >= 3 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
         } else {
@@ -190,7 +190,7 @@ impl Encodable for AddPartitionsToTxnRequest {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -204,7 +204,7 @@ impl Encodable for AddPartitionsToTxnRequest {
             total_size += types::String.compute_size(&self.transactional_id)?;
         }
         total_size += types::Int64.compute_size(&self.producer_id)?;
-        total_size += types::Int16.compute_size(&self.producer_epoch)?;
+        total_size += 2;
         if version >= 3 {
             total_size += types::CompactArray(types::Struct { version }).compute_size(&self.topics)?;
         } else {
@@ -232,7 +232,7 @@ impl Decodable for AddPartitionsToTxnRequest {
             types::String.decode(buf)?
         };
         let producer_id = types::Int64.decode(buf)?;
-        let producer_epoch = types::Int16.decode(buf)?;
+        let producer_epoch = buf.try_get_i16()?;
         let topics = if version >= 3 {
             types::CompactArray(types::Struct { version }).decode(buf)?
         } else {

--- a/src/messages/add_partitions_to_txn_response.rs
+++ b/src/messages/add_partitions_to_txn_response.rs
@@ -42,15 +42,15 @@ impl Builder for AddPartitionsToTxnPartitionResult {
 impl MapEncodable for AddPartitionsToTxnPartitionResult {
     type Key = i32;
     fn encode<B: ByteBufMut>(&self, key: &Self::Key, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, key)?;
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i32(*key);
+        buf.put_i16(self.error_code);
         if version >= 3 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -58,8 +58,8 @@ impl MapEncodable for AddPartitionsToTxnPartitionResult {
     }
     fn compute_size(&self, key: &Self::Key, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(key)?;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 4;
+        total_size += 2;
         if version >= 3 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
@@ -77,8 +77,8 @@ impl MapEncodable for AddPartitionsToTxnPartitionResult {
 impl MapDecodable for AddPartitionsToTxnPartitionResult {
     type Key = i32;
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<(Self::Key, Self), DecodeError> {
-        let key_field = types::Int32.decode(buf)?;
-        let error_code = types::Int16.decode(buf)?;
+        let key_field = buf.try_get_i32()?;
+        let error_code = buf.try_get_i16()?;
         let mut unknown_tagged_fields = BTreeMap::new();
         if version >= 3 {
             let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
@@ -150,7 +150,7 @@ impl MapEncodable for AddPartitionsToTxnTopicResult {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -254,7 +254,7 @@ impl Builder for AddPartitionsToTxnResponse {
 
 impl Encodable for AddPartitionsToTxnResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.throttle_time_ms)?;
+        buf.put_i32(self.throttle_time_ms);
         if version >= 3 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.results)?;
         } else {
@@ -266,7 +266,7 @@ impl Encodable for AddPartitionsToTxnResponse {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -274,7 +274,7 @@ impl Encodable for AddPartitionsToTxnResponse {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
+        total_size += 4;
         if version >= 3 {
             total_size += types::CompactArray(types::Struct { version }).compute_size(&self.results)?;
         } else {
@@ -296,7 +296,7 @@ impl Encodable for AddPartitionsToTxnResponse {
 
 impl Decodable for AddPartitionsToTxnResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let throttle_time_ms = types::Int32.decode(buf)?;
+        let throttle_time_ms = buf.try_get_i32()?;
         let results = if version >= 3 {
             types::CompactArray(types::Struct { version }).decode(buf)?
         } else {

--- a/src/messages/allocate_producer_ids_response.rs
+++ b/src/messages/allocate_producer_ids_response.rs
@@ -56,26 +56,26 @@ impl Builder for AllocateProducerIdsResponse {
 
 impl Encodable for AllocateProducerIdsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.throttle_time_ms)?;
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i32(self.throttle_time_ms);
+        buf.put_i16(self.error_code);
         types::Int64.encode(buf, &self.producer_id_start)?;
-        types::Int32.encode(buf, &self.producer_id_len)?;
+        buf.put_i32(self.producer_id_len);
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 4;
+        total_size += 2;
         total_size += types::Int64.compute_size(&self.producer_id_start)?;
-        total_size += types::Int32.compute_size(&self.producer_id_len)?;
+        total_size += 4;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
@@ -90,10 +90,10 @@ impl Encodable for AllocateProducerIdsResponse {
 
 impl Decodable for AllocateProducerIdsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let throttle_time_ms = types::Int32.decode(buf)?;
-        let error_code = types::Int16.decode(buf)?;
+        let throttle_time_ms = buf.try_get_i32()?;
+        let error_code = buf.try_get_i16()?;
         let producer_id_start = types::Int64.decode(buf)?;
-        let producer_id_len = types::Int32.decode(buf)?;
+        let producer_id_len = buf.try_get_i32()?;
         let mut unknown_tagged_fields = BTreeMap::new();
         let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
         for _ in 0..num_tagged_fields {

--- a/src/messages/alter_client_quotas_request.rs
+++ b/src/messages/alter_client_quotas_request.rs
@@ -62,7 +62,7 @@ impl Encodable for EntityData {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -177,15 +177,15 @@ impl Encodable for OpData {
         } else {
             types::String.encode(buf, &self.key)?;
         }
-        types::Float64.encode(buf, &self.value)?;
-        types::Boolean.encode(buf, &self.remove)?;
+        types::Float64.encode(buf, self.value)?;
+        types::Boolean.encode(buf, self.remove)?;
         if version >= 1 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -198,8 +198,8 @@ impl Encodable for OpData {
         } else {
             total_size += types::String.compute_size(&self.key)?;
         }
-        total_size += types::Float64.compute_size(&self.value)?;
-        total_size += types::Boolean.compute_size(&self.remove)?;
+        total_size += types::Float64.compute_size(self.value)?;
+        total_size += types::Boolean.compute_size(self.remove)?;
         if version >= 1 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
@@ -302,7 +302,7 @@ impl Encodable for EntryData {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -412,14 +412,14 @@ impl Encodable for AlterClientQuotasRequest {
         } else {
             types::Array(types::Struct { version }).encode(buf, &self.entries)?;
         }
-        types::Boolean.encode(buf, &self.validate_only)?;
+        types::Boolean.encode(buf, self.validate_only)?;
         if version >= 1 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -432,7 +432,7 @@ impl Encodable for AlterClientQuotasRequest {
         } else {
             total_size += types::Array(types::Struct { version }).compute_size(&self.entries)?;
         }
-        total_size += types::Boolean.compute_size(&self.validate_only)?;
+        total_size += types::Boolean.compute_size(self.validate_only)?;
         if version >= 1 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {

--- a/src/messages/alter_client_quotas_response.rs
+++ b/src/messages/alter_client_quotas_response.rs
@@ -62,7 +62,7 @@ impl Encodable for EntityData {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -172,7 +172,7 @@ impl Builder for EntryData {
 
 impl Encodable for EntryData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i16(self.error_code);
         if version >= 1 {
             types::CompactString.encode(buf, &self.error_message)?;
         } else {
@@ -189,7 +189,7 @@ impl Encodable for EntryData {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -197,7 +197,7 @@ impl Encodable for EntryData {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 2;
         if version >= 1 {
             total_size += types::CompactString.compute_size(&self.error_message)?;
         } else {
@@ -224,7 +224,7 @@ impl Encodable for EntryData {
 
 impl Decodable for EntryData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let error_code = types::Int16.decode(buf)?;
+        let error_code = buf.try_get_i16()?;
         let error_message = if version >= 1 {
             types::CompactString.decode(buf)?
         } else {
@@ -298,7 +298,7 @@ impl Builder for AlterClientQuotasResponse {
 
 impl Encodable for AlterClientQuotasResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.throttle_time_ms)?;
+        buf.put_i32(self.throttle_time_ms);
         if version >= 1 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.entries)?;
         } else {
@@ -310,7 +310,7 @@ impl Encodable for AlterClientQuotasResponse {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -318,7 +318,7 @@ impl Encodable for AlterClientQuotasResponse {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
+        total_size += 4;
         if version >= 1 {
             total_size += types::CompactArray(types::Struct { version }).compute_size(&self.entries)?;
         } else {
@@ -340,7 +340,7 @@ impl Encodable for AlterClientQuotasResponse {
 
 impl Decodable for AlterClientQuotasResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let throttle_time_ms = types::Int32.decode(buf)?;
+        let throttle_time_ms = buf.try_get_i32()?;
         let entries = if version >= 1 {
             types::CompactArray(types::Struct { version }).decode(buf)?
         } else {

--- a/src/messages/alter_configs_request.rs
+++ b/src/messages/alter_configs_request.rs
@@ -58,7 +58,7 @@ impl MapEncodable for AlterableConfig {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -167,7 +167,7 @@ impl Builder for AlterConfigsResource {
 
 impl Encodable for AlterConfigsResource {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int8.encode(buf, &self.resource_type)?;
+        buf.put_i8(self.resource_type);
         if version >= 2 {
             types::CompactString.encode(buf, &self.resource_name)?;
         } else {
@@ -184,7 +184,7 @@ impl Encodable for AlterConfigsResource {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -192,7 +192,7 @@ impl Encodable for AlterConfigsResource {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int8.compute_size(&self.resource_type)?;
+        total_size += 1;
         if version >= 2 {
             total_size += types::CompactString.compute_size(&self.resource_name)?;
         } else {
@@ -219,7 +219,7 @@ impl Encodable for AlterConfigsResource {
 
 impl Decodable for AlterConfigsResource {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let resource_type = types::Int8.decode(buf)?;
+        let resource_type = buf.try_get_i8()?;
         let resource_name = if version >= 2 {
             types::CompactString.decode(buf)?
         } else {
@@ -298,14 +298,14 @@ impl Encodable for AlterConfigsRequest {
         } else {
             types::Array(types::Struct { version }).encode(buf, &self.resources)?;
         }
-        types::Boolean.encode(buf, &self.validate_only)?;
+        types::Boolean.encode(buf, self.validate_only)?;
         if version >= 2 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -318,7 +318,7 @@ impl Encodable for AlterConfigsRequest {
         } else {
             total_size += types::Array(types::Struct { version }).compute_size(&self.resources)?;
         }
-        total_size += types::Boolean.compute_size(&self.validate_only)?;
+        total_size += types::Boolean.compute_size(self.validate_only)?;
         if version >= 2 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {

--- a/src/messages/alter_configs_response.rs
+++ b/src/messages/alter_configs_response.rs
@@ -56,13 +56,13 @@ impl Builder for AlterConfigsResourceResponse {
 
 impl Encodable for AlterConfigsResourceResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i16(self.error_code);
         if version >= 2 {
             types::CompactString.encode(buf, &self.error_message)?;
         } else {
             types::String.encode(buf, &self.error_message)?;
         }
-        types::Int8.encode(buf, &self.resource_type)?;
+        buf.put_i8(self.resource_type);
         if version >= 2 {
             types::CompactString.encode(buf, &self.resource_name)?;
         } else {
@@ -74,7 +74,7 @@ impl Encodable for AlterConfigsResourceResponse {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -82,13 +82,13 @@ impl Encodable for AlterConfigsResourceResponse {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 2;
         if version >= 2 {
             total_size += types::CompactString.compute_size(&self.error_message)?;
         } else {
             total_size += types::String.compute_size(&self.error_message)?;
         }
-        total_size += types::Int8.compute_size(&self.resource_type)?;
+        total_size += 1;
         if version >= 2 {
             total_size += types::CompactString.compute_size(&self.resource_name)?;
         } else {
@@ -110,13 +110,13 @@ impl Encodable for AlterConfigsResourceResponse {
 
 impl Decodable for AlterConfigsResourceResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let error_code = types::Int16.decode(buf)?;
+        let error_code = buf.try_get_i16()?;
         let error_message = if version >= 2 {
             types::CompactString.decode(buf)?
         } else {
             types::String.decode(buf)?
         };
-        let resource_type = types::Int8.decode(buf)?;
+        let resource_type = buf.try_get_i8()?;
         let resource_name = if version >= 2 {
             types::CompactString.decode(buf)?
         } else {
@@ -187,7 +187,7 @@ impl Builder for AlterConfigsResponse {
 
 impl Encodable for AlterConfigsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.throttle_time_ms)?;
+        buf.put_i32(self.throttle_time_ms);
         if version >= 2 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.responses)?;
         } else {
@@ -199,7 +199,7 @@ impl Encodable for AlterConfigsResponse {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -207,7 +207,7 @@ impl Encodable for AlterConfigsResponse {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
+        total_size += 4;
         if version >= 2 {
             total_size += types::CompactArray(types::Struct { version }).compute_size(&self.responses)?;
         } else {
@@ -229,7 +229,7 @@ impl Encodable for AlterConfigsResponse {
 
 impl Decodable for AlterConfigsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let throttle_time_ms = types::Int32.decode(buf)?;
+        let throttle_time_ms = buf.try_get_i32()?;
         let responses = if version >= 2 {
             types::CompactArray(types::Struct { version }).decode(buf)?
         } else {

--- a/src/messages/alter_partition_reassignments_request.rs
+++ b/src/messages/alter_partition_reassignments_request.rs
@@ -46,21 +46,21 @@ impl Builder for ReassignablePartition {
 
 impl Encodable for ReassignablePartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.partition_index)?;
+        buf.put_i32(self.partition_index);
         types::CompactArray(types::Int32).encode(buf, &self.replicas)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.partition_index)?;
+        total_size += 4;
         total_size += types::CompactArray(types::Int32).compute_size(&self.replicas)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
@@ -76,7 +76,7 @@ impl Encodable for ReassignablePartition {
 
 impl Decodable for ReassignablePartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let partition_index = types::Int32.decode(buf)?;
+        let partition_index = buf.try_get_i32()?;
         let replicas = types::CompactArray(types::Int32).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
         let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
@@ -144,7 +144,7 @@ impl Encodable for ReassignableTopic {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
@@ -228,21 +228,21 @@ impl Builder for AlterPartitionReassignmentsRequest {
 
 impl Encodable for AlterPartitionReassignmentsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.timeout_ms)?;
+        buf.put_i32(self.timeout_ms);
         types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.timeout_ms)?;
+        total_size += 4;
         total_size += types::CompactArray(types::Struct { version }).compute_size(&self.topics)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
@@ -258,7 +258,7 @@ impl Encodable for AlterPartitionReassignmentsRequest {
 
 impl Decodable for AlterPartitionReassignmentsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let timeout_ms = types::Int32.decode(buf)?;
+        let timeout_ms = buf.try_get_i32()?;
         let topics = types::CompactArray(types::Struct { version }).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
         let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;

--- a/src/messages/alter_partition_reassignments_response.rs
+++ b/src/messages/alter_partition_reassignments_response.rs
@@ -51,23 +51,23 @@ impl Builder for ReassignablePartitionResponse {
 
 impl Encodable for ReassignablePartitionResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.partition_index)?;
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i32(self.partition_index);
+        buf.put_i16(self.error_code);
         types::CompactString.encode(buf, &self.error_message)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.partition_index)?;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 4;
+        total_size += 2;
         total_size += types::CompactString.compute_size(&self.error_message)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
@@ -83,8 +83,8 @@ impl Encodable for ReassignablePartitionResponse {
 
 impl Decodable for ReassignablePartitionResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let partition_index = types::Int32.decode(buf)?;
-        let error_code = types::Int16.decode(buf)?;
+        let partition_index = buf.try_get_i32()?;
+        let error_code = buf.try_get_i16()?;
         let error_message = types::CompactString.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
         let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
@@ -154,7 +154,7 @@ impl Encodable for ReassignableTopicResponse {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
@@ -248,8 +248,8 @@ impl Builder for AlterPartitionReassignmentsResponse {
 
 impl Encodable for AlterPartitionReassignmentsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.throttle_time_ms)?;
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i32(self.throttle_time_ms);
+        buf.put_i16(self.error_code);
         types::CompactString.encode(buf, &self.error_message)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.responses)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -257,15 +257,15 @@ impl Encodable for AlterPartitionReassignmentsResponse {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 4;
+        total_size += 2;
         total_size += types::CompactString.compute_size(&self.error_message)?;
         total_size += types::CompactArray(types::Struct { version }).compute_size(&self.responses)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -282,8 +282,8 @@ impl Encodable for AlterPartitionReassignmentsResponse {
 
 impl Decodable for AlterPartitionReassignmentsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let throttle_time_ms = types::Int32.decode(buf)?;
-        let error_code = types::Int16.decode(buf)?;
+        let throttle_time_ms = buf.try_get_i32()?;
+        let error_code = buf.try_get_i16()?;
         let error_message = types::CompactString.decode(buf)?;
         let responses = types::CompactArray(types::Struct { version }).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();

--- a/src/messages/alter_replica_log_dirs_request.rs
+++ b/src/messages/alter_replica_log_dirs_request.rs
@@ -58,7 +58,7 @@ impl MapEncodable for AlterReplicaLogDirTopic {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -174,7 +174,7 @@ impl MapEncodable for AlterReplicaLogDir {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -284,7 +284,7 @@ impl Encodable for AlterReplicaLogDirsRequest {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }

--- a/src/messages/alter_replica_log_dirs_response.rs
+++ b/src/messages/alter_replica_log_dirs_response.rs
@@ -46,15 +46,15 @@ impl Builder for AlterReplicaLogDirPartitionResult {
 
 impl Encodable for AlterReplicaLogDirPartitionResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.partition_index)?;
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i32(self.partition_index);
+        buf.put_i16(self.error_code);
         if version >= 2 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -62,8 +62,8 @@ impl Encodable for AlterReplicaLogDirPartitionResult {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.partition_index)?;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 4;
+        total_size += 2;
         if version >= 2 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
@@ -80,8 +80,8 @@ impl Encodable for AlterReplicaLogDirPartitionResult {
 
 impl Decodable for AlterReplicaLogDirPartitionResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let partition_index = types::Int32.decode(buf)?;
-        let error_code = types::Int16.decode(buf)?;
+        let partition_index = buf.try_get_i32()?;
+        let error_code = buf.try_get_i16()?;
         let mut unknown_tagged_fields = BTreeMap::new();
         if version >= 2 {
             let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
@@ -159,7 +159,7 @@ impl Encodable for AlterReplicaLogDirTopicResult {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -264,7 +264,7 @@ impl Builder for AlterReplicaLogDirsResponse {
 
 impl Encodable for AlterReplicaLogDirsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.throttle_time_ms)?;
+        buf.put_i32(self.throttle_time_ms);
         if version >= 2 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.results)?;
         } else {
@@ -276,7 +276,7 @@ impl Encodable for AlterReplicaLogDirsResponse {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -284,7 +284,7 @@ impl Encodable for AlterReplicaLogDirsResponse {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
+        total_size += 4;
         if version >= 2 {
             total_size += types::CompactArray(types::Struct { version }).compute_size(&self.results)?;
         } else {
@@ -306,7 +306,7 @@ impl Encodable for AlterReplicaLogDirsResponse {
 
 impl Decodable for AlterReplicaLogDirsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let throttle_time_ms = types::Int32.decode(buf)?;
+        let throttle_time_ms = buf.try_get_i32()?;
         let results = if version >= 2 {
             types::CompactArray(types::Struct { version }).decode(buf)?
         } else {

--- a/src/messages/alter_user_scram_credentials_request.rs
+++ b/src/messages/alter_user_scram_credentials_request.rs
@@ -47,13 +47,13 @@ impl Builder for ScramCredentialDeletion {
 impl Encodable for ScramCredentialDeletion {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
         types::CompactString.encode(buf, &self.name)?;
-        types::Int8.encode(buf, &self.mechanism)?;
+        buf.put_i8(self.mechanism);
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
@@ -61,7 +61,7 @@ impl Encodable for ScramCredentialDeletion {
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
         total_size += types::CompactString.compute_size(&self.name)?;
-        total_size += types::Int8.compute_size(&self.mechanism)?;
+        total_size += 1;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
@@ -77,7 +77,7 @@ impl Encodable for ScramCredentialDeletion {
 impl Decodable for ScramCredentialDeletion {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
         let name = types::CompactString.decode(buf)?;
-        let mechanism = types::Int8.decode(buf)?;
+        let mechanism = buf.try_get_i8()?;
         let mut unknown_tagged_fields = BTreeMap::new();
         let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
         for _ in 0..num_tagged_fields {
@@ -153,8 +153,8 @@ impl Builder for ScramCredentialUpsertion {
 impl Encodable for ScramCredentialUpsertion {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
         types::CompactString.encode(buf, &self.name)?;
-        types::Int8.encode(buf, &self.mechanism)?;
-        types::Int32.encode(buf, &self.iterations)?;
+        buf.put_i8(self.mechanism);
+        buf.put_i32(self.iterations);
         types::CompactBytes.encode(buf, &self.salt)?;
         types::CompactBytes.encode(buf, &self.salted_password)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -162,7 +162,7 @@ impl Encodable for ScramCredentialUpsertion {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
@@ -170,8 +170,8 @@ impl Encodable for ScramCredentialUpsertion {
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
         total_size += types::CompactString.compute_size(&self.name)?;
-        total_size += types::Int8.compute_size(&self.mechanism)?;
-        total_size += types::Int32.compute_size(&self.iterations)?;
+        total_size += 1;
+        total_size += 4;
         total_size += types::CompactBytes.compute_size(&self.salt)?;
         total_size += types::CompactBytes.compute_size(&self.salted_password)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -189,8 +189,8 @@ impl Encodable for ScramCredentialUpsertion {
 impl Decodable for ScramCredentialUpsertion {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
         let name = types::CompactString.decode(buf)?;
-        let mechanism = types::Int8.decode(buf)?;
-        let iterations = types::Int32.decode(buf)?;
+        let mechanism = buf.try_get_i8()?;
+        let iterations = buf.try_get_i32()?;
         let salt = types::CompactBytes.decode(buf)?;
         let salted_password = types::CompactBytes.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
@@ -265,7 +265,7 @@ impl Encodable for AlterUserScramCredentialsRequest {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())

--- a/src/messages/alter_user_scram_credentials_response.rs
+++ b/src/messages/alter_user_scram_credentials_response.rs
@@ -52,14 +52,14 @@ impl Builder for AlterUserScramCredentialsResult {
 impl Encodable for AlterUserScramCredentialsResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
         types::CompactString.encode(buf, &self.user)?;
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i16(self.error_code);
         types::CompactString.encode(buf, &self.error_message)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
@@ -67,7 +67,7 @@ impl Encodable for AlterUserScramCredentialsResult {
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
         total_size += types::CompactString.compute_size(&self.user)?;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 2;
         total_size += types::CompactString.compute_size(&self.error_message)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
@@ -84,7 +84,7 @@ impl Encodable for AlterUserScramCredentialsResult {
 impl Decodable for AlterUserScramCredentialsResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
         let user = types::CompactString.decode(buf)?;
-        let error_code = types::Int16.decode(buf)?;
+        let error_code = buf.try_get_i16()?;
         let error_message = types::CompactString.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
         let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
@@ -147,21 +147,21 @@ impl Builder for AlterUserScramCredentialsResponse {
 
 impl Encodable for AlterUserScramCredentialsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.throttle_time_ms)?;
+        buf.put_i32(self.throttle_time_ms);
         types::CompactArray(types::Struct { version }).encode(buf, &self.results)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
+        total_size += 4;
         total_size += types::CompactArray(types::Struct { version }).compute_size(&self.results)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
@@ -177,7 +177,7 @@ impl Encodable for AlterUserScramCredentialsResponse {
 
 impl Decodable for AlterUserScramCredentialsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let throttle_time_ms = types::Int32.decode(buf)?;
+        let throttle_time_ms = buf.try_get_i32()?;
         let results = types::CompactArray(types::Struct { version }).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
         let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;

--- a/src/messages/api_versions_request.rs
+++ b/src/messages/api_versions_request.rs
@@ -58,7 +58,7 @@ impl Encodable for ApiVersionsRequest {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }

--- a/src/messages/api_versions_response.rs
+++ b/src/messages/api_versions_response.rs
@@ -47,16 +47,16 @@ impl Builder for ApiVersion {
 impl MapEncodable for ApiVersion {
     type Key = i16;
     fn encode<B: ByteBufMut>(&self, key: &Self::Key, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int16.encode(buf, key)?;
-        types::Int16.encode(buf, &self.min_version)?;
-        types::Int16.encode(buf, &self.max_version)?;
+        buf.put_i16(*key);
+        buf.put_i16(self.min_version);
+        buf.put_i16(self.max_version);
         if version >= 3 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -64,9 +64,9 @@ impl MapEncodable for ApiVersion {
     }
     fn compute_size(&self, key: &Self::Key, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int16.compute_size(key)?;
-        total_size += types::Int16.compute_size(&self.min_version)?;
-        total_size += types::Int16.compute_size(&self.max_version)?;
+        total_size += 2;
+        total_size += 2;
+        total_size += 2;
         if version >= 3 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
@@ -84,9 +84,9 @@ impl MapEncodable for ApiVersion {
 impl MapDecodable for ApiVersion {
     type Key = i16;
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<(Self::Key, Self), DecodeError> {
-        let key_field = types::Int16.decode(buf)?;
-        let min_version = types::Int16.decode(buf)?;
-        let max_version = types::Int16.decode(buf)?;
+        let key_field = buf.try_get_i16()?;
+        let min_version = buf.try_get_i16()?;
+        let max_version = buf.try_get_i16()?;
         let mut unknown_tagged_fields = BTreeMap::new();
         if version >= 3 {
             let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
@@ -157,14 +157,14 @@ impl MapEncodable for SupportedFeatureKey {
             }
         }
         if version >= 3 {
-            types::Int16.encode(buf, &self.min_version)?;
+            buf.put_i16(self.min_version);
         } else {
             if self.min_version != 0 {
                 return Err(EncodeError)
             }
         }
         if version >= 3 {
-            types::Int16.encode(buf, &self.max_version)?;
+            buf.put_i16(self.max_version);
         } else {
             if self.max_version != 0 {
                 return Err(EncodeError)
@@ -176,7 +176,7 @@ impl MapEncodable for SupportedFeatureKey {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -192,14 +192,14 @@ impl MapEncodable for SupportedFeatureKey {
             }
         }
         if version >= 3 {
-            total_size += types::Int16.compute_size(&self.min_version)?;
+            total_size += 2;
         } else {
             if self.min_version != 0 {
                 return Err(EncodeError)
             }
         }
         if version >= 3 {
-            total_size += types::Int16.compute_size(&self.max_version)?;
+            total_size += 2;
         } else {
             if self.max_version != 0 {
                 return Err(EncodeError)
@@ -228,12 +228,12 @@ impl MapDecodable for SupportedFeatureKey {
             Default::default()
         };
         let min_version = if version >= 3 {
-            types::Int16.decode(buf)?
+            buf.try_get_i16()?
         } else {
             0
         };
         let max_version = if version >= 3 {
-            types::Int16.decode(buf)?
+            buf.try_get_i16()?
         } else {
             0
         };
@@ -307,14 +307,14 @@ impl MapEncodable for FinalizedFeatureKey {
             }
         }
         if version >= 3 {
-            types::Int16.encode(buf, &self.max_version_level)?;
+            buf.put_i16(self.max_version_level);
         } else {
             if self.max_version_level != 0 {
                 return Err(EncodeError)
             }
         }
         if version >= 3 {
-            types::Int16.encode(buf, &self.min_version_level)?;
+            buf.put_i16(self.min_version_level);
         } else {
             if self.min_version_level != 0 {
                 return Err(EncodeError)
@@ -326,7 +326,7 @@ impl MapEncodable for FinalizedFeatureKey {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -342,14 +342,14 @@ impl MapEncodable for FinalizedFeatureKey {
             }
         }
         if version >= 3 {
-            total_size += types::Int16.compute_size(&self.max_version_level)?;
+            total_size += 2;
         } else {
             if self.max_version_level != 0 {
                 return Err(EncodeError)
             }
         }
         if version >= 3 {
-            total_size += types::Int16.compute_size(&self.min_version_level)?;
+            total_size += 2;
         } else {
             if self.min_version_level != 0 {
                 return Err(EncodeError)
@@ -378,12 +378,12 @@ impl MapDecodable for FinalizedFeatureKey {
             Default::default()
         };
         let max_version_level = if version >= 3 {
-            types::Int16.decode(buf)?
+            buf.try_get_i16()?
         } else {
             0
         };
         let min_version_level = if version >= 3 {
-            types::Int16.decode(buf)?
+            buf.try_get_i16()?
         } else {
             0
         };
@@ -468,14 +468,14 @@ impl Builder for ApiVersionsResponse {
 
 impl Encodable for ApiVersionsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i16(self.error_code);
         if version >= 3 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.api_keys)?;
         } else {
             types::Array(types::Struct { version }).encode(buf, &self.api_keys)?;
         }
         if version >= 1 {
-            types::Int32.encode(buf, &self.throttle_time_ms)?;
+            buf.put_i32(self.throttle_time_ms);
         }
         if version >= 3 {
             let mut num_tagged_fields = self.unknown_tagged_fields.len();
@@ -492,26 +492,26 @@ impl Encodable for ApiVersionsResponse {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
             if !self.supported_features.is_empty() {
                 let computed_size = types::CompactArray(types::Struct { version }).compute_size(&self.supported_features)?;
                 if computed_size > std::u32::MAX as usize {
                     error!("Tagged field is too large to encode ({} bytes)", computed_size);
                     return Err(EncodeError);
                 }
-                types::UnsignedVarInt.encode(buf, 0)?;
-                types::UnsignedVarInt.encode(buf, computed_size as u32)?;
+                buf.put_i32(0);
+                buf.put_i32(computed_size as i32);
                 types::CompactArray(types::Struct { version }).encode(buf, &self.supported_features)?;
             }
             if self.finalized_features_epoch != -1 {
-                let computed_size = types::Int64.compute_size(&self.finalized_features_epoch)?;
+                let computed_size = types::Int64.compute_size(self.finalized_features_epoch)?;
                 if computed_size > std::u32::MAX as usize {
                     error!("Tagged field is too large to encode ({} bytes)", computed_size);
                     return Err(EncodeError);
                 }
-                types::UnsignedVarInt.encode(buf, 1)?;
-                types::UnsignedVarInt.encode(buf, computed_size as u32)?;
-                types::Int64.encode(buf, &self.finalized_features_epoch)?;
+                buf.put_i32(1);
+                buf.put_i32(computed_size as i32);
+                buf.put_i64(self.finalized_features_epoch);
             }
             if !self.finalized_features.is_empty() {
                 let computed_size = types::CompactArray(types::Struct { version }).compute_size(&self.finalized_features)?;
@@ -519,8 +519,8 @@ impl Encodable for ApiVersionsResponse {
                     error!("Tagged field is too large to encode ({} bytes)", computed_size);
                     return Err(EncodeError);
                 }
-                types::UnsignedVarInt.encode(buf, 2)?;
-                types::UnsignedVarInt.encode(buf, computed_size as u32)?;
+                buf.put_i32(2);
+                buf.put_i32(computed_size as i32);
                 types::CompactArray(types::Struct { version }).encode(buf, &self.finalized_features)?;
             }
 
@@ -530,14 +530,14 @@ impl Encodable for ApiVersionsResponse {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 2;
         if version >= 3 {
             total_size += types::CompactArray(types::Struct { version }).compute_size(&self.api_keys)?;
         } else {
             total_size += types::Array(types::Struct { version }).compute_size(&self.api_keys)?;
         }
         if version >= 1 {
-            total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
+            total_size += 4;
         }
         if version >= 3 {
             let mut num_tagged_fields = self.unknown_tagged_fields.len();
@@ -561,18 +561,18 @@ impl Encodable for ApiVersionsResponse {
                     error!("Tagged field is too large to encode ({} bytes)", computed_size);
                     return Err(EncodeError);
                 }
-                total_size += types::UnsignedVarInt.compute_size(0)?;
-                total_size += types::UnsignedVarInt.compute_size(computed_size as u32)?;
+                total_size += 4;
+                total_size += 4;
                 total_size += computed_size;
             }
             if self.finalized_features_epoch != -1 {
-                let computed_size = types::Int64.compute_size(&self.finalized_features_epoch)?;
+                let computed_size = types::Int64.compute_size(self.finalized_features_epoch)?;
                 if computed_size > std::u32::MAX as usize {
                     error!("Tagged field is too large to encode ({} bytes)", computed_size);
                     return Err(EncodeError);
                 }
-                total_size += types::UnsignedVarInt.compute_size(1)?;
-                total_size += types::UnsignedVarInt.compute_size(computed_size as u32)?;
+                total_size += 4;
+                total_size += 4;
                 total_size += computed_size;
             }
             if !self.finalized_features.is_empty() {
@@ -581,8 +581,8 @@ impl Encodable for ApiVersionsResponse {
                     error!("Tagged field is too large to encode ({} bytes)", computed_size);
                     return Err(EncodeError);
                 }
-                total_size += types::UnsignedVarInt.compute_size(2)?;
-                total_size += types::UnsignedVarInt.compute_size(computed_size as u32)?;
+                total_size += 4;
+                total_size += 4;
                 total_size += computed_size;
             }
 
@@ -594,14 +594,14 @@ impl Encodable for ApiVersionsResponse {
 
 impl Decodable for ApiVersionsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let error_code = types::Int16.decode(buf)?;
+        let error_code = buf.try_get_i16()?;
         let api_keys = if version >= 3 {
             types::CompactArray(types::Struct { version }).decode(buf)?
         } else {
             types::Array(types::Struct { version }).decode(buf)?
         };
         let throttle_time_ms = if version >= 1 {
-            types::Int32.decode(buf)?
+            buf.try_get_i32()?
         } else {
             0
         };

--- a/src/messages/begin_quorum_epoch_request.rs
+++ b/src/messages/begin_quorum_epoch_request.rs
@@ -49,17 +49,17 @@ impl Builder for PartitionData {
 
 impl Encodable for PartitionData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.partition_index)?;
+        buf.put_i32(self.partition_index);
         types::Int32.encode(buf, &self.leader_id)?;
-        types::Int32.encode(buf, &self.leader_epoch)?;
+        buf.put_i32(self.leader_epoch);
 
         Ok(())
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.partition_index)?;
+        total_size += 4;
         total_size += types::Int32.compute_size(&self.leader_id)?;
-        total_size += types::Int32.compute_size(&self.leader_epoch)?;
+        total_size += 4;
 
         Ok(total_size)
     }
@@ -67,9 +67,9 @@ impl Encodable for PartitionData {
 
 impl Decodable for PartitionData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let partition_index = types::Int32.decode(buf)?;
+        let partition_index = buf.try_get_i32()?;
         let leader_id = types::Int32.decode(buf)?;
-        let leader_epoch = types::Int32.decode(buf)?;
+        let leader_epoch = buf.try_get_i32()?;
         Ok(Self {
             partition_index,
             leader_id,

--- a/src/messages/begin_quorum_epoch_response.rs
+++ b/src/messages/begin_quorum_epoch_response.rs
@@ -54,19 +54,19 @@ impl Builder for PartitionData {
 
 impl Encodable for PartitionData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.partition_index)?;
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i32(self.partition_index);
+        buf.put_i16(self.error_code);
         types::Int32.encode(buf, &self.leader_id)?;
-        types::Int32.encode(buf, &self.leader_epoch)?;
+        buf.put_i32(self.leader_epoch);
 
         Ok(())
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.partition_index)?;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 4;
+        total_size += 2;
         total_size += types::Int32.compute_size(&self.leader_id)?;
-        total_size += types::Int32.compute_size(&self.leader_epoch)?;
+        total_size += 4;
 
         Ok(total_size)
     }
@@ -74,10 +74,10 @@ impl Encodable for PartitionData {
 
 impl Decodable for PartitionData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let partition_index = types::Int32.decode(buf)?;
-        let error_code = types::Int16.decode(buf)?;
+        let partition_index = buf.try_get_i32()?;
+        let error_code = buf.try_get_i16()?;
         let leader_id = types::Int32.decode(buf)?;
-        let leader_epoch = types::Int32.decode(buf)?;
+        let leader_epoch = buf.try_get_i32()?;
         Ok(Self {
             partition_index,
             error_code,
@@ -194,14 +194,14 @@ impl Builder for BeginQuorumEpochResponse {
 
 impl Encodable for BeginQuorumEpochResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i16(self.error_code);
         types::Array(types::Struct { version }).encode(buf, &self.topics)?;
 
         Ok(())
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 2;
         total_size += types::Array(types::Struct { version }).compute_size(&self.topics)?;
 
         Ok(total_size)
@@ -210,7 +210,7 @@ impl Encodable for BeginQuorumEpochResponse {
 
 impl Decodable for BeginQuorumEpochResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let error_code = types::Int16.decode(buf)?;
+        let error_code = buf.try_get_i16()?;
         let topics = types::Array(types::Struct { version }).decode(buf)?;
         Ok(Self {
             error_code,

--- a/src/messages/broker_heartbeat_response.rs
+++ b/src/messages/broker_heartbeat_response.rs
@@ -61,28 +61,28 @@ impl Builder for BrokerHeartbeatResponse {
 
 impl Encodable for BrokerHeartbeatResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.throttle_time_ms)?;
-        types::Int16.encode(buf, &self.error_code)?;
-        types::Boolean.encode(buf, &self.is_caught_up)?;
-        types::Boolean.encode(buf, &self.is_fenced)?;
-        types::Boolean.encode(buf, &self.should_shut_down)?;
+        buf.put_i32(self.throttle_time_ms);
+        buf.put_i16(self.error_code);
+        types::Boolean.encode(buf, self.is_caught_up)?;
+        types::Boolean.encode(buf, self.is_fenced)?;
+        types::Boolean.encode(buf, self.should_shut_down)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
-        total_size += types::Int16.compute_size(&self.error_code)?;
-        total_size += types::Boolean.compute_size(&self.is_caught_up)?;
-        total_size += types::Boolean.compute_size(&self.is_fenced)?;
-        total_size += types::Boolean.compute_size(&self.should_shut_down)?;
+        total_size += 4;
+        total_size += 2;
+        total_size += types::Boolean.compute_size(self.is_caught_up)?;
+        total_size += types::Boolean.compute_size(self.is_fenced)?;
+        total_size += types::Boolean.compute_size(self.should_shut_down)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
@@ -97,8 +97,8 @@ impl Encodable for BrokerHeartbeatResponse {
 
 impl Decodable for BrokerHeartbeatResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let throttle_time_ms = types::Int32.decode(buf)?;
-        let error_code = types::Int16.decode(buf)?;
+        let throttle_time_ms = buf.try_get_i32()?;
+        let error_code = buf.try_get_i16()?;
         let is_caught_up = types::Boolean.decode(buf)?;
         let is_fenced = types::Boolean.decode(buf)?;
         let should_shut_down = types::Boolean.decode(buf)?;

--- a/src/messages/broker_registration_response.rs
+++ b/src/messages/broker_registration_response.rs
@@ -51,24 +51,24 @@ impl Builder for BrokerRegistrationResponse {
 
 impl Encodable for BrokerRegistrationResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.throttle_time_ms)?;
-        types::Int16.encode(buf, &self.error_code)?;
-        types::Int64.encode(buf, &self.broker_epoch)?;
+        buf.put_i32(self.throttle_time_ms);
+        buf.put_i16(self.error_code);
+        buf.put_i64(self.broker_epoch);
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
-        total_size += types::Int16.compute_size(&self.error_code)?;
-        total_size += types::Int64.compute_size(&self.broker_epoch)?;
+        total_size += 4;
+        total_size += 2;
+        total_size += 8;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
@@ -83,9 +83,9 @@ impl Encodable for BrokerRegistrationResponse {
 
 impl Decodable for BrokerRegistrationResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let throttle_time_ms = types::Int32.decode(buf)?;
-        let error_code = types::Int16.decode(buf)?;
-        let broker_epoch = types::Int64.decode(buf)?;
+        let throttle_time_ms = buf.try_get_i32()?;
+        let error_code = buf.try_get_i16()?;
+        let broker_epoch = buf.try_get_i64()?;
         let mut unknown_tagged_fields = BTreeMap::new();
         let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
         for _ in 0..num_tagged_fields {

--- a/src/messages/controlled_shutdown_response.rs
+++ b/src/messages/controlled_shutdown_response.rs
@@ -51,14 +51,14 @@ impl Encodable for RemainingPartition {
         } else {
             types::String.encode(buf, &self.topic_name)?;
         }
-        types::Int32.encode(buf, &self.partition_index)?;
+        buf.put_i32(self.partition_index);
         if version >= 3 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -71,7 +71,7 @@ impl Encodable for RemainingPartition {
         } else {
             total_size += types::String.compute_size(&self.topic_name)?;
         }
-        total_size += types::Int32.compute_size(&self.partition_index)?;
+        total_size += 4;
         if version >= 3 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
@@ -93,7 +93,7 @@ impl Decodable for RemainingPartition {
         } else {
             types::String.decode(buf)?
         };
-        let partition_index = types::Int32.decode(buf)?;
+        let partition_index = buf.try_get_i32()?;
         let mut unknown_tagged_fields = BTreeMap::new();
         if version >= 3 {
             let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
@@ -155,7 +155,7 @@ impl Builder for ControlledShutdownResponse {
 
 impl Encodable for ControlledShutdownResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i16(self.error_code);
         if version >= 3 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.remaining_partitions)?;
         } else {
@@ -167,7 +167,7 @@ impl Encodable for ControlledShutdownResponse {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -175,7 +175,7 @@ impl Encodable for ControlledShutdownResponse {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 2;
         if version >= 3 {
             total_size += types::CompactArray(types::Struct { version }).compute_size(&self.remaining_partitions)?;
         } else {
@@ -197,7 +197,7 @@ impl Encodable for ControlledShutdownResponse {
 
 impl Decodable for ControlledShutdownResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let error_code = types::Int16.decode(buf)?;
+        let error_code = buf.try_get_i16()?;
         let remaining_partitions = if version >= 3 {
             types::CompactArray(types::Struct { version }).decode(buf)?
         } else {

--- a/src/messages/create_acls_request.rs
+++ b/src/messages/create_acls_request.rs
@@ -71,14 +71,14 @@ impl Builder for AclCreation {
 
 impl Encodable for AclCreation {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int8.encode(buf, &self.resource_type)?;
+        buf.put_i8(self.resource_type);
         if version >= 2 {
             types::CompactString.encode(buf, &self.resource_name)?;
         } else {
             types::String.encode(buf, &self.resource_name)?;
         }
         if version >= 1 {
-            types::Int8.encode(buf, &self.resource_pattern_type)?;
+            buf.put_i8(self.resource_pattern_type);
         } else {
             if self.resource_pattern_type != 3 {
                 return Err(EncodeError)
@@ -94,15 +94,15 @@ impl Encodable for AclCreation {
         } else {
             types::String.encode(buf, &self.host)?;
         }
-        types::Int8.encode(buf, &self.operation)?;
-        types::Int8.encode(buf, &self.permission_type)?;
+        buf.put_i8(self.operation);
+        buf.put_i8(self.permission_type);
         if version >= 2 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -110,14 +110,14 @@ impl Encodable for AclCreation {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int8.compute_size(&self.resource_type)?;
+        total_size += 1;
         if version >= 2 {
             total_size += types::CompactString.compute_size(&self.resource_name)?;
         } else {
             total_size += types::String.compute_size(&self.resource_name)?;
         }
         if version >= 1 {
-            total_size += types::Int8.compute_size(&self.resource_pattern_type)?;
+            total_size += 1;
         } else {
             if self.resource_pattern_type != 3 {
                 return Err(EncodeError)
@@ -133,8 +133,8 @@ impl Encodable for AclCreation {
         } else {
             total_size += types::String.compute_size(&self.host)?;
         }
-        total_size += types::Int8.compute_size(&self.operation)?;
-        total_size += types::Int8.compute_size(&self.permission_type)?;
+        total_size += 1;
+        total_size += 1;
         if version >= 2 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
@@ -151,14 +151,14 @@ impl Encodable for AclCreation {
 
 impl Decodable for AclCreation {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let resource_type = types::Int8.decode(buf)?;
+        let resource_type = buf.try_get_i8()?;
         let resource_name = if version >= 2 {
             types::CompactString.decode(buf)?
         } else {
             types::String.decode(buf)?
         };
         let resource_pattern_type = if version >= 1 {
-            types::Int8.decode(buf)?
+            buf.try_get_i8()?
         } else {
             3
         };
@@ -172,8 +172,8 @@ impl Decodable for AclCreation {
         } else {
             types::String.decode(buf)?
         };
-        let operation = types::Int8.decode(buf)?;
-        let permission_type = types::Int8.decode(buf)?;
+        let operation = buf.try_get_i8()?;
+        let permission_type = buf.try_get_i8()?;
         let mut unknown_tagged_fields = BTreeMap::new();
         if version >= 2 {
             let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
@@ -251,7 +251,7 @@ impl Encodable for CreateAclsRequest {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }

--- a/src/messages/create_acls_response.rs
+++ b/src/messages/create_acls_response.rs
@@ -46,7 +46,7 @@ impl Builder for AclCreationResult {
 
 impl Encodable for AclCreationResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i16(self.error_code);
         if version >= 2 {
             types::CompactString.encode(buf, &self.error_message)?;
         } else {
@@ -58,7 +58,7 @@ impl Encodable for AclCreationResult {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -66,7 +66,7 @@ impl Encodable for AclCreationResult {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 2;
         if version >= 2 {
             total_size += types::CompactString.compute_size(&self.error_message)?;
         } else {
@@ -88,7 +88,7 @@ impl Encodable for AclCreationResult {
 
 impl Decodable for AclCreationResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let error_code = types::Int16.decode(buf)?;
+        let error_code = buf.try_get_i16()?;
         let error_message = if version >= 2 {
             types::CompactString.decode(buf)?
         } else {
@@ -155,7 +155,7 @@ impl Builder for CreateAclsResponse {
 
 impl Encodable for CreateAclsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.throttle_time_ms)?;
+        buf.put_i32(self.throttle_time_ms);
         if version >= 2 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.results)?;
         } else {
@@ -167,7 +167,7 @@ impl Encodable for CreateAclsResponse {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -175,7 +175,7 @@ impl Encodable for CreateAclsResponse {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
+        total_size += 4;
         if version >= 2 {
             total_size += types::CompactArray(types::Struct { version }).compute_size(&self.results)?;
         } else {
@@ -197,7 +197,7 @@ impl Encodable for CreateAclsResponse {
 
 impl Decodable for CreateAclsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let throttle_time_ms = types::Int32.decode(buf)?;
+        let throttle_time_ms = buf.try_get_i32()?;
         let results = if version >= 2 {
             types::CompactArray(types::Struct { version }).decode(buf)?
         } else {

--- a/src/messages/create_delegation_token_request.rs
+++ b/src/messages/create_delegation_token_request.rs
@@ -62,7 +62,7 @@ impl Encodable for CreatableRenewers {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -196,14 +196,14 @@ impl Encodable for CreateDelegationTokenRequest {
         } else {
             types::Array(types::Struct { version }).encode(buf, &self.renewers)?;
         }
-        types::Int64.encode(buf, &self.max_lifetime_ms)?;
+        buf.put_i64(self.max_lifetime_ms);
         if version >= 2 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -230,7 +230,7 @@ impl Encodable for CreateDelegationTokenRequest {
         } else {
             total_size += types::Array(types::Struct { version }).compute_size(&self.renewers)?;
         }
-        total_size += types::Int64.compute_size(&self.max_lifetime_ms)?;
+        total_size += 8;
         if version >= 2 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
@@ -262,7 +262,7 @@ impl Decodable for CreateDelegationTokenRequest {
         } else {
             types::Array(types::Struct { version }).decode(buf)?
         };
-        let max_lifetime_ms = types::Int64.decode(buf)?;
+        let max_lifetime_ms = buf.try_get_i64()?;
         let mut unknown_tagged_fields = BTreeMap::new();
         if version >= 2 {
             let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;

--- a/src/messages/create_delegation_token_response.rs
+++ b/src/messages/create_delegation_token_response.rs
@@ -91,7 +91,7 @@ impl Builder for CreateDelegationTokenResponse {
 
 impl Encodable for CreateDelegationTokenResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i16(self.error_code);
         if version >= 2 {
             types::CompactString.encode(buf, &self.principal_type)?;
         } else {
@@ -116,9 +116,9 @@ impl Encodable for CreateDelegationTokenResponse {
                 return Err(EncodeError)
             }
         }
-        types::Int64.encode(buf, &self.issue_timestamp_ms)?;
-        types::Int64.encode(buf, &self.expiry_timestamp_ms)?;
-        types::Int64.encode(buf, &self.max_timestamp_ms)?;
+        buf.put_i64(self.issue_timestamp_ms);
+        buf.put_i64(self.expiry_timestamp_ms);
+        buf.put_i64(self.max_timestamp_ms);
         if version >= 2 {
             types::CompactString.encode(buf, &self.token_id)?;
         } else {
@@ -129,14 +129,14 @@ impl Encodable for CreateDelegationTokenResponse {
         } else {
             types::Bytes.encode(buf, &self.hmac)?;
         }
-        types::Int32.encode(buf, &self.throttle_time_ms)?;
+        buf.put_i32(self.throttle_time_ms);
         if version >= 2 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -144,7 +144,7 @@ impl Encodable for CreateDelegationTokenResponse {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 2;
         if version >= 2 {
             total_size += types::CompactString.compute_size(&self.principal_type)?;
         } else {
@@ -169,9 +169,9 @@ impl Encodable for CreateDelegationTokenResponse {
                 return Err(EncodeError)
             }
         }
-        total_size += types::Int64.compute_size(&self.issue_timestamp_ms)?;
-        total_size += types::Int64.compute_size(&self.expiry_timestamp_ms)?;
-        total_size += types::Int64.compute_size(&self.max_timestamp_ms)?;
+        total_size += 8;
+        total_size += 8;
+        total_size += 8;
         if version >= 2 {
             total_size += types::CompactString.compute_size(&self.token_id)?;
         } else {
@@ -182,7 +182,7 @@ impl Encodable for CreateDelegationTokenResponse {
         } else {
             total_size += types::Bytes.compute_size(&self.hmac)?;
         }
-        total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
+        total_size += 4;
         if version >= 2 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
@@ -199,7 +199,7 @@ impl Encodable for CreateDelegationTokenResponse {
 
 impl Decodable for CreateDelegationTokenResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let error_code = types::Int16.decode(buf)?;
+        let error_code = buf.try_get_i16()?;
         let principal_type = if version >= 2 {
             types::CompactString.decode(buf)?
         } else {
@@ -220,9 +220,9 @@ impl Decodable for CreateDelegationTokenResponse {
         } else {
             Default::default()
         };
-        let issue_timestamp_ms = types::Int64.decode(buf)?;
-        let expiry_timestamp_ms = types::Int64.decode(buf)?;
-        let max_timestamp_ms = types::Int64.decode(buf)?;
+        let issue_timestamp_ms = buf.try_get_i64()?;
+        let expiry_timestamp_ms = buf.try_get_i64()?;
+        let max_timestamp_ms = buf.try_get_i64()?;
         let token_id = if version >= 2 {
             types::CompactString.decode(buf)?
         } else {
@@ -233,7 +233,7 @@ impl Decodable for CreateDelegationTokenResponse {
         } else {
             types::Bytes.decode(buf)?
         };
-        let throttle_time_ms = types::Int32.decode(buf)?;
+        let throttle_time_ms = buf.try_get_i32()?;
         let mut unknown_tagged_fields = BTreeMap::new();
         if version >= 2 {
             let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;

--- a/src/messages/create_partitions_request.rs
+++ b/src/messages/create_partitions_request.rs
@@ -52,7 +52,7 @@ impl Encodable for CreatePartitionsAssignment {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -151,7 +151,7 @@ impl MapEncodable for CreatePartitionsTopic {
         } else {
             types::String.encode(buf, key)?;
         }
-        types::Int32.encode(buf, &self.count)?;
+        buf.put_i32(self.count);
         if version >= 2 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.assignments)?;
         } else {
@@ -163,7 +163,7 @@ impl MapEncodable for CreatePartitionsTopic {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -176,7 +176,7 @@ impl MapEncodable for CreatePartitionsTopic {
         } else {
             total_size += types::String.compute_size(key)?;
         }
-        total_size += types::Int32.compute_size(&self.count)?;
+        total_size += 4;
         if version >= 2 {
             total_size += types::CompactArray(types::Struct { version }).compute_size(&self.assignments)?;
         } else {
@@ -204,7 +204,7 @@ impl MapDecodable for CreatePartitionsTopic {
         } else {
             types::String.decode(buf)?
         };
-        let count = types::Int32.decode(buf)?;
+        let count = buf.try_get_i32()?;
         let assignments = if version >= 2 {
             types::CompactArray(types::Struct { version }).decode(buf)?
         } else {
@@ -281,15 +281,15 @@ impl Encodable for CreatePartitionsRequest {
         } else {
             types::Array(types::Struct { version }).encode(buf, &self.topics)?;
         }
-        types::Int32.encode(buf, &self.timeout_ms)?;
-        types::Boolean.encode(buf, &self.validate_only)?;
+        buf.put_i32(self.timeout_ms);
+        types::Boolean.encode(buf, self.validate_only)?;
         if version >= 2 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -302,8 +302,8 @@ impl Encodable for CreatePartitionsRequest {
         } else {
             total_size += types::Array(types::Struct { version }).compute_size(&self.topics)?;
         }
-        total_size += types::Int32.compute_size(&self.timeout_ms)?;
-        total_size += types::Boolean.compute_size(&self.validate_only)?;
+        total_size += 4;
+        total_size += types::Boolean.compute_size(self.validate_only)?;
         if version >= 2 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
@@ -325,7 +325,7 @@ impl Decodable for CreatePartitionsRequest {
         } else {
             types::Array(types::Struct { version }).decode(buf)?
         };
-        let timeout_ms = types::Int32.decode(buf)?;
+        let timeout_ms = buf.try_get_i32()?;
         let validate_only = types::Boolean.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
         if version >= 2 {

--- a/src/messages/create_partitions_response.rs
+++ b/src/messages/create_partitions_response.rs
@@ -56,7 +56,7 @@ impl Encodable for CreatePartitionsTopicResult {
         } else {
             types::String.encode(buf, &self.name)?;
         }
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i16(self.error_code);
         if version >= 2 {
             types::CompactString.encode(buf, &self.error_message)?;
         } else {
@@ -68,7 +68,7 @@ impl Encodable for CreatePartitionsTopicResult {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -81,7 +81,7 @@ impl Encodable for CreatePartitionsTopicResult {
         } else {
             total_size += types::String.compute_size(&self.name)?;
         }
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 2;
         if version >= 2 {
             total_size += types::CompactString.compute_size(&self.error_message)?;
         } else {
@@ -108,7 +108,7 @@ impl Decodable for CreatePartitionsTopicResult {
         } else {
             types::String.decode(buf)?
         };
-        let error_code = types::Int16.decode(buf)?;
+        let error_code = buf.try_get_i16()?;
         let error_message = if version >= 2 {
             types::CompactString.decode(buf)?
         } else {
@@ -177,7 +177,7 @@ impl Builder for CreatePartitionsResponse {
 
 impl Encodable for CreatePartitionsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.throttle_time_ms)?;
+        buf.put_i32(self.throttle_time_ms);
         if version >= 2 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.results)?;
         } else {
@@ -189,7 +189,7 @@ impl Encodable for CreatePartitionsResponse {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -197,7 +197,7 @@ impl Encodable for CreatePartitionsResponse {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
+        total_size += 4;
         if version >= 2 {
             total_size += types::CompactArray(types::Struct { version }).compute_size(&self.results)?;
         } else {
@@ -219,7 +219,7 @@ impl Encodable for CreatePartitionsResponse {
 
 impl Decodable for CreatePartitionsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let throttle_time_ms = types::Int32.decode(buf)?;
+        let throttle_time_ms = buf.try_get_i32()?;
         let results = if version >= 2 {
             types::CompactArray(types::Struct { version }).decode(buf)?
         } else {

--- a/src/messages/default_principal_data.rs
+++ b/src/messages/default_principal_data.rs
@@ -53,13 +53,13 @@ impl Encodable for DefaultPrincipalData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
         types::CompactString.encode(buf, &self._type)?;
         types::CompactString.encode(buf, &self.name)?;
-        types::Boolean.encode(buf, &self.token_authenticated)?;
+        types::Boolean.encode(buf, self.token_authenticated)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
@@ -68,7 +68,7 @@ impl Encodable for DefaultPrincipalData {
         let mut total_size = 0;
         total_size += types::CompactString.compute_size(&self._type)?;
         total_size += types::CompactString.compute_size(&self.name)?;
-        total_size += types::Boolean.compute_size(&self.token_authenticated)?;
+        total_size += types::Boolean.compute_size(self.token_authenticated)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);

--- a/src/messages/delete_acls_request.rs
+++ b/src/messages/delete_acls_request.rs
@@ -71,14 +71,14 @@ impl Builder for DeleteAclsFilter {
 
 impl Encodable for DeleteAclsFilter {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int8.encode(buf, &self.resource_type_filter)?;
+        buf.put_i8(self.resource_type_filter);
         if version >= 2 {
             types::CompactString.encode(buf, &self.resource_name_filter)?;
         } else {
             types::String.encode(buf, &self.resource_name_filter)?;
         }
         if version >= 1 {
-            types::Int8.encode(buf, &self.pattern_type_filter)?;
+            buf.put_i8(self.pattern_type_filter);
         } else {
             if self.pattern_type_filter != 3 {
                 return Err(EncodeError)
@@ -94,15 +94,15 @@ impl Encodable for DeleteAclsFilter {
         } else {
             types::String.encode(buf, &self.host_filter)?;
         }
-        types::Int8.encode(buf, &self.operation)?;
-        types::Int8.encode(buf, &self.permission_type)?;
+        buf.put_i8(self.operation);
+        buf.put_i8(self.permission_type);
         if version >= 2 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -110,14 +110,14 @@ impl Encodable for DeleteAclsFilter {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int8.compute_size(&self.resource_type_filter)?;
+        total_size += 1;
         if version >= 2 {
             total_size += types::CompactString.compute_size(&self.resource_name_filter)?;
         } else {
             total_size += types::String.compute_size(&self.resource_name_filter)?;
         }
         if version >= 1 {
-            total_size += types::Int8.compute_size(&self.pattern_type_filter)?;
+            total_size += 1;
         } else {
             if self.pattern_type_filter != 3 {
                 return Err(EncodeError)
@@ -133,8 +133,8 @@ impl Encodable for DeleteAclsFilter {
         } else {
             total_size += types::String.compute_size(&self.host_filter)?;
         }
-        total_size += types::Int8.compute_size(&self.operation)?;
-        total_size += types::Int8.compute_size(&self.permission_type)?;
+        total_size += 1;
+        total_size += 1;
         if version >= 2 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
@@ -151,14 +151,14 @@ impl Encodable for DeleteAclsFilter {
 
 impl Decodable for DeleteAclsFilter {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let resource_type_filter = types::Int8.decode(buf)?;
+        let resource_type_filter = buf.try_get_i8()?;
         let resource_name_filter = if version >= 2 {
             types::CompactString.decode(buf)?
         } else {
             types::String.decode(buf)?
         };
         let pattern_type_filter = if version >= 1 {
-            types::Int8.decode(buf)?
+            buf.try_get_i8()?
         } else {
             3
         };
@@ -172,8 +172,8 @@ impl Decodable for DeleteAclsFilter {
         } else {
             types::String.decode(buf)?
         };
-        let operation = types::Int8.decode(buf)?;
-        let permission_type = types::Int8.decode(buf)?;
+        let operation = buf.try_get_i8()?;
+        let permission_type = buf.try_get_i8()?;
         let mut unknown_tagged_fields = BTreeMap::new();
         if version >= 2 {
             let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
@@ -251,7 +251,7 @@ impl Encodable for DeleteAclsRequest {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }

--- a/src/messages/delete_acls_response.rs
+++ b/src/messages/delete_acls_response.rs
@@ -81,20 +81,20 @@ impl Builder for DeleteAclsMatchingAcl {
 
 impl Encodable for DeleteAclsMatchingAcl {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i16(self.error_code);
         if version >= 2 {
             types::CompactString.encode(buf, &self.error_message)?;
         } else {
             types::String.encode(buf, &self.error_message)?;
         }
-        types::Int8.encode(buf, &self.resource_type)?;
+        buf.put_i8(self.resource_type);
         if version >= 2 {
             types::CompactString.encode(buf, &self.resource_name)?;
         } else {
             types::String.encode(buf, &self.resource_name)?;
         }
         if version >= 1 {
-            types::Int8.encode(buf, &self.pattern_type)?;
+            buf.put_i8(self.pattern_type);
         } else {
             if self.pattern_type != 3 {
                 return Err(EncodeError)
@@ -110,15 +110,15 @@ impl Encodable for DeleteAclsMatchingAcl {
         } else {
             types::String.encode(buf, &self.host)?;
         }
-        types::Int8.encode(buf, &self.operation)?;
-        types::Int8.encode(buf, &self.permission_type)?;
+        buf.put_i8(self.operation);
+        buf.put_i8(self.permission_type);
         if version >= 2 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -126,20 +126,20 @@ impl Encodable for DeleteAclsMatchingAcl {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 2;
         if version >= 2 {
             total_size += types::CompactString.compute_size(&self.error_message)?;
         } else {
             total_size += types::String.compute_size(&self.error_message)?;
         }
-        total_size += types::Int8.compute_size(&self.resource_type)?;
+        total_size += 1;
         if version >= 2 {
             total_size += types::CompactString.compute_size(&self.resource_name)?;
         } else {
             total_size += types::String.compute_size(&self.resource_name)?;
         }
         if version >= 1 {
-            total_size += types::Int8.compute_size(&self.pattern_type)?;
+            total_size += 1;
         } else {
             if self.pattern_type != 3 {
                 return Err(EncodeError)
@@ -155,8 +155,8 @@ impl Encodable for DeleteAclsMatchingAcl {
         } else {
             total_size += types::String.compute_size(&self.host)?;
         }
-        total_size += types::Int8.compute_size(&self.operation)?;
-        total_size += types::Int8.compute_size(&self.permission_type)?;
+        total_size += 1;
+        total_size += 1;
         if version >= 2 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
@@ -173,20 +173,20 @@ impl Encodable for DeleteAclsMatchingAcl {
 
 impl Decodable for DeleteAclsMatchingAcl {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let error_code = types::Int16.decode(buf)?;
+        let error_code = buf.try_get_i16()?;
         let error_message = if version >= 2 {
             types::CompactString.decode(buf)?
         } else {
             types::String.decode(buf)?
         };
-        let resource_type = types::Int8.decode(buf)?;
+        let resource_type = buf.try_get_i8()?;
         let resource_name = if version >= 2 {
             types::CompactString.decode(buf)?
         } else {
             types::String.decode(buf)?
         };
         let pattern_type = if version >= 1 {
-            types::Int8.decode(buf)?
+            buf.try_get_i8()?
         } else {
             3
         };
@@ -200,8 +200,8 @@ impl Decodable for DeleteAclsMatchingAcl {
         } else {
             types::String.decode(buf)?
         };
-        let operation = types::Int8.decode(buf)?;
-        let permission_type = types::Int8.decode(buf)?;
+        let operation = buf.try_get_i8()?;
+        let permission_type = buf.try_get_i8()?;
         let mut unknown_tagged_fields = BTreeMap::new();
         if version >= 2 {
             let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
@@ -282,7 +282,7 @@ impl Builder for DeleteAclsFilterResult {
 
 impl Encodable for DeleteAclsFilterResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i16(self.error_code);
         if version >= 2 {
             types::CompactString.encode(buf, &self.error_message)?;
         } else {
@@ -299,7 +299,7 @@ impl Encodable for DeleteAclsFilterResult {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -307,7 +307,7 @@ impl Encodable for DeleteAclsFilterResult {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 2;
         if version >= 2 {
             total_size += types::CompactString.compute_size(&self.error_message)?;
         } else {
@@ -334,7 +334,7 @@ impl Encodable for DeleteAclsFilterResult {
 
 impl Decodable for DeleteAclsFilterResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let error_code = types::Int16.decode(buf)?;
+        let error_code = buf.try_get_i16()?;
         let error_message = if version >= 2 {
             types::CompactString.decode(buf)?
         } else {
@@ -408,7 +408,7 @@ impl Builder for DeleteAclsResponse {
 
 impl Encodable for DeleteAclsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.throttle_time_ms)?;
+        buf.put_i32(self.throttle_time_ms);
         if version >= 2 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.filter_results)?;
         } else {
@@ -420,7 +420,7 @@ impl Encodable for DeleteAclsResponse {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -428,7 +428,7 @@ impl Encodable for DeleteAclsResponse {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
+        total_size += 4;
         if version >= 2 {
             total_size += types::CompactArray(types::Struct { version }).compute_size(&self.filter_results)?;
         } else {
@@ -450,7 +450,7 @@ impl Encodable for DeleteAclsResponse {
 
 impl Decodable for DeleteAclsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let throttle_time_ms = types::Int32.decode(buf)?;
+        let throttle_time_ms = buf.try_get_i32()?;
         let filter_results = if version >= 2 {
             types::CompactArray(types::Struct { version }).decode(buf)?
         } else {

--- a/src/messages/delete_groups_request.rs
+++ b/src/messages/delete_groups_request.rs
@@ -52,7 +52,7 @@ impl Encodable for DeleteGroupsRequest {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }

--- a/src/messages/delete_groups_response.rs
+++ b/src/messages/delete_groups_response.rs
@@ -47,14 +47,14 @@ impl MapEncodable for DeletableGroupResult {
         } else {
             types::String.encode(buf, key)?;
         }
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i16(self.error_code);
         if version >= 2 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -67,7 +67,7 @@ impl MapEncodable for DeletableGroupResult {
         } else {
             total_size += types::String.compute_size(key)?;
         }
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 2;
         if version >= 2 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
@@ -90,7 +90,7 @@ impl MapDecodable for DeletableGroupResult {
         } else {
             types::String.decode(buf)?
         };
-        let error_code = types::Int16.decode(buf)?;
+        let error_code = buf.try_get_i16()?;
         let mut unknown_tagged_fields = BTreeMap::new();
         if version >= 2 {
             let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
@@ -150,7 +150,7 @@ impl Builder for DeleteGroupsResponse {
 
 impl Encodable for DeleteGroupsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.throttle_time_ms)?;
+        buf.put_i32(self.throttle_time_ms);
         if version >= 2 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.results)?;
         } else {
@@ -162,7 +162,7 @@ impl Encodable for DeleteGroupsResponse {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -170,7 +170,7 @@ impl Encodable for DeleteGroupsResponse {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
+        total_size += 4;
         if version >= 2 {
             total_size += types::CompactArray(types::Struct { version }).compute_size(&self.results)?;
         } else {
@@ -192,7 +192,7 @@ impl Encodable for DeleteGroupsResponse {
 
 impl Decodable for DeleteGroupsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let throttle_time_ms = types::Int32.decode(buf)?;
+        let throttle_time_ms = buf.try_get_i32()?;
         let results = if version >= 2 {
             types::CompactArray(types::Struct { version }).decode(buf)?
         } else {

--- a/src/messages/delete_records_request.rs
+++ b/src/messages/delete_records_request.rs
@@ -46,15 +46,15 @@ impl Builder for DeleteRecordsPartition {
 
 impl Encodable for DeleteRecordsPartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.partition_index)?;
-        types::Int64.encode(buf, &self.offset)?;
+        buf.put_i32(self.partition_index);
+        buf.put_i64(self.offset);
         if version >= 2 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -62,8 +62,8 @@ impl Encodable for DeleteRecordsPartition {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.partition_index)?;
-        total_size += types::Int64.compute_size(&self.offset)?;
+        total_size += 4;
+        total_size += 8;
         if version >= 2 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
@@ -80,8 +80,8 @@ impl Encodable for DeleteRecordsPartition {
 
 impl Decodable for DeleteRecordsPartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let partition_index = types::Int32.decode(buf)?;
-        let offset = types::Int64.decode(buf)?;
+        let partition_index = buf.try_get_i32()?;
+        let offset = buf.try_get_i64()?;
         let mut unknown_tagged_fields = BTreeMap::new();
         if version >= 2 {
             let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
@@ -159,7 +159,7 @@ impl Encodable for DeleteRecordsTopic {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -269,14 +269,14 @@ impl Encodable for DeleteRecordsRequest {
         } else {
             types::Array(types::Struct { version }).encode(buf, &self.topics)?;
         }
-        types::Int32.encode(buf, &self.timeout_ms)?;
+        buf.put_i32(self.timeout_ms);
         if version >= 2 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -289,7 +289,7 @@ impl Encodable for DeleteRecordsRequest {
         } else {
             total_size += types::Array(types::Struct { version }).compute_size(&self.topics)?;
         }
-        total_size += types::Int32.compute_size(&self.timeout_ms)?;
+        total_size += 4;
         if version >= 2 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
@@ -311,7 +311,7 @@ impl Decodable for DeleteRecordsRequest {
         } else {
             types::Array(types::Struct { version }).decode(buf)?
         };
-        let timeout_ms = types::Int32.decode(buf)?;
+        let timeout_ms = buf.try_get_i32()?;
         let mut unknown_tagged_fields = BTreeMap::new();
         if version >= 2 {
             let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;

--- a/src/messages/delete_topics_request.rs
+++ b/src/messages/delete_topics_request.rs
@@ -54,9 +54,9 @@ impl Encodable for DeleteTopicState {
             }
         }
         if version >= 6 {
-            types::Uuid.encode(buf, &self.topic_id)?;
+            types::Uuid.encode(buf, self.topic_id)?;
         } else {
-            if &self.topic_id != &Uuid::nil() {
+            if self.topic_id != Uuid::nil() {
                 return Err(EncodeError)
             }
         }
@@ -66,7 +66,7 @@ impl Encodable for DeleteTopicState {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -82,9 +82,9 @@ impl Encodable for DeleteTopicState {
             }
         }
         if version >= 6 {
-            total_size += types::Uuid.compute_size(&self.topic_id)?;
+            total_size += types::Uuid.compute_size(self.topic_id)?;
         } else {
-            if &self.topic_id != &Uuid::nil() {
+            if self.topic_id != Uuid::nil() {
                 return Err(EncodeError)
             }
         }
@@ -194,14 +194,14 @@ impl Encodable for DeleteTopicsRequest {
                 types::Array(types::String).encode(buf, &self.topic_names)?;
             }
         }
-        types::Int32.encode(buf, &self.timeout_ms)?;
+        buf.put_i32(self.timeout_ms);
         if version >= 4 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -223,7 +223,7 @@ impl Encodable for DeleteTopicsRequest {
                 total_size += types::Array(types::String).compute_size(&self.topic_names)?;
             }
         }
-        total_size += types::Int32.compute_size(&self.timeout_ms)?;
+        total_size += 4;
         if version >= 4 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
@@ -254,7 +254,7 @@ impl Decodable for DeleteTopicsRequest {
         } else {
             Default::default()
         };
-        let timeout_ms = types::Int32.decode(buf)?;
+        let timeout_ms = buf.try_get_i32()?;
         let mut unknown_tagged_fields = BTreeMap::new();
         if version >= 4 {
             let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;

--- a/src/messages/describe_acls_request.rs
+++ b/src/messages/describe_acls_request.rs
@@ -71,14 +71,14 @@ impl Builder for DescribeAclsRequest {
 
 impl Encodable for DescribeAclsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int8.encode(buf, &self.resource_type_filter)?;
+        buf.put_i8(self.resource_type_filter);
         if version >= 2 {
             types::CompactString.encode(buf, &self.resource_name_filter)?;
         } else {
             types::String.encode(buf, &self.resource_name_filter)?;
         }
         if version >= 1 {
-            types::Int8.encode(buf, &self.pattern_type_filter)?;
+            buf.put_i8(self.pattern_type_filter);
         } else {
             if self.pattern_type_filter != 3 {
                 return Err(EncodeError)
@@ -94,15 +94,15 @@ impl Encodable for DescribeAclsRequest {
         } else {
             types::String.encode(buf, &self.host_filter)?;
         }
-        types::Int8.encode(buf, &self.operation)?;
-        types::Int8.encode(buf, &self.permission_type)?;
+        buf.put_i8(self.operation);
+        buf.put_i8(self.permission_type);
         if version >= 2 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -110,14 +110,14 @@ impl Encodable for DescribeAclsRequest {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int8.compute_size(&self.resource_type_filter)?;
+        total_size += 1;
         if version >= 2 {
             total_size += types::CompactString.compute_size(&self.resource_name_filter)?;
         } else {
             total_size += types::String.compute_size(&self.resource_name_filter)?;
         }
         if version >= 1 {
-            total_size += types::Int8.compute_size(&self.pattern_type_filter)?;
+            total_size += 1;
         } else {
             if self.pattern_type_filter != 3 {
                 return Err(EncodeError)
@@ -133,8 +133,8 @@ impl Encodable for DescribeAclsRequest {
         } else {
             total_size += types::String.compute_size(&self.host_filter)?;
         }
-        total_size += types::Int8.compute_size(&self.operation)?;
-        total_size += types::Int8.compute_size(&self.permission_type)?;
+        total_size += 1;
+        total_size += 1;
         if version >= 2 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
@@ -151,14 +151,14 @@ impl Encodable for DescribeAclsRequest {
 
 impl Decodable for DescribeAclsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let resource_type_filter = types::Int8.decode(buf)?;
+        let resource_type_filter = buf.try_get_i8()?;
         let resource_name_filter = if version >= 2 {
             types::CompactString.decode(buf)?
         } else {
             types::String.decode(buf)?
         };
         let pattern_type_filter = if version >= 1 {
-            types::Int8.decode(buf)?
+            buf.try_get_i8()?
         } else {
             3
         };
@@ -172,8 +172,8 @@ impl Decodable for DescribeAclsRequest {
         } else {
             types::String.decode(buf)?
         };
-        let operation = types::Int8.decode(buf)?;
-        let permission_type = types::Int8.decode(buf)?;
+        let operation = buf.try_get_i8()?;
+        let permission_type = buf.try_get_i8()?;
         let mut unknown_tagged_fields = BTreeMap::new();
         if version >= 2 {
             let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;

--- a/src/messages/describe_acls_response.rs
+++ b/src/messages/describe_acls_response.rs
@@ -66,15 +66,15 @@ impl Encodable for AclDescription {
         } else {
             types::String.encode(buf, &self.host)?;
         }
-        types::Int8.encode(buf, &self.operation)?;
-        types::Int8.encode(buf, &self.permission_type)?;
+        buf.put_i8(self.operation);
+        buf.put_i8(self.permission_type);
         if version >= 2 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -92,8 +92,8 @@ impl Encodable for AclDescription {
         } else {
             total_size += types::String.compute_size(&self.host)?;
         }
-        total_size += types::Int8.compute_size(&self.operation)?;
-        total_size += types::Int8.compute_size(&self.permission_type)?;
+        total_size += 1;
+        total_size += 1;
         if version >= 2 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
@@ -120,8 +120,8 @@ impl Decodable for AclDescription {
         } else {
             types::String.decode(buf)?
         };
-        let operation = types::Int8.decode(buf)?;
-        let permission_type = types::Int8.decode(buf)?;
+        let operation = buf.try_get_i8()?;
+        let permission_type = buf.try_get_i8()?;
         let mut unknown_tagged_fields = BTreeMap::new();
         if version >= 2 {
             let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
@@ -197,14 +197,14 @@ impl Builder for DescribeAclsResource {
 
 impl Encodable for DescribeAclsResource {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int8.encode(buf, &self.resource_type)?;
+        buf.put_i8(self.resource_type);
         if version >= 2 {
             types::CompactString.encode(buf, &self.resource_name)?;
         } else {
             types::String.encode(buf, &self.resource_name)?;
         }
         if version >= 1 {
-            types::Int8.encode(buf, &self.pattern_type)?;
+            buf.put_i8(self.pattern_type);
         } else {
             if self.pattern_type != 3 {
                 return Err(EncodeError)
@@ -221,7 +221,7 @@ impl Encodable for DescribeAclsResource {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -229,14 +229,14 @@ impl Encodable for DescribeAclsResource {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int8.compute_size(&self.resource_type)?;
+        total_size += 1;
         if version >= 2 {
             total_size += types::CompactString.compute_size(&self.resource_name)?;
         } else {
             total_size += types::String.compute_size(&self.resource_name)?;
         }
         if version >= 1 {
-            total_size += types::Int8.compute_size(&self.pattern_type)?;
+            total_size += 1;
         } else {
             if self.pattern_type != 3 {
                 return Err(EncodeError)
@@ -263,14 +263,14 @@ impl Encodable for DescribeAclsResource {
 
 impl Decodable for DescribeAclsResource {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let resource_type = types::Int8.decode(buf)?;
+        let resource_type = buf.try_get_i8()?;
         let resource_name = if version >= 2 {
             types::CompactString.decode(buf)?
         } else {
             types::String.decode(buf)?
         };
         let pattern_type = if version >= 1 {
-            types::Int8.decode(buf)?
+            buf.try_get_i8()?
         } else {
             3
         };
@@ -354,8 +354,8 @@ impl Builder for DescribeAclsResponse {
 
 impl Encodable for DescribeAclsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.throttle_time_ms)?;
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i32(self.throttle_time_ms);
+        buf.put_i16(self.error_code);
         if version >= 2 {
             types::CompactString.encode(buf, &self.error_message)?;
         } else {
@@ -372,7 +372,7 @@ impl Encodable for DescribeAclsResponse {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -380,8 +380,8 @@ impl Encodable for DescribeAclsResponse {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 4;
+        total_size += 2;
         if version >= 2 {
             total_size += types::CompactString.compute_size(&self.error_message)?;
         } else {
@@ -408,8 +408,8 @@ impl Encodable for DescribeAclsResponse {
 
 impl Decodable for DescribeAclsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let throttle_time_ms = types::Int32.decode(buf)?;
-        let error_code = types::Int16.decode(buf)?;
+        let throttle_time_ms = buf.try_get_i32()?;
+        let error_code = buf.try_get_i16()?;
         let error_message = if version >= 2 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/describe_client_quotas_request.rs
+++ b/src/messages/describe_client_quotas_request.rs
@@ -56,7 +56,7 @@ impl Encodable for ComponentData {
         } else {
             types::String.encode(buf, &self.entity_type)?;
         }
-        types::Int8.encode(buf, &self.match_type)?;
+        buf.put_i8(self.match_type);
         if version >= 1 {
             types::CompactString.encode(buf, &self._match)?;
         } else {
@@ -68,7 +68,7 @@ impl Encodable for ComponentData {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -81,7 +81,7 @@ impl Encodable for ComponentData {
         } else {
             total_size += types::String.compute_size(&self.entity_type)?;
         }
-        total_size += types::Int8.compute_size(&self.match_type)?;
+        total_size += 1;
         if version >= 1 {
             total_size += types::CompactString.compute_size(&self._match)?;
         } else {
@@ -108,7 +108,7 @@ impl Decodable for ComponentData {
         } else {
             types::String.decode(buf)?
         };
-        let match_type = types::Int8.decode(buf)?;
+        let match_type = buf.try_get_i8()?;
         let _match = if version >= 1 {
             types::CompactString.decode(buf)?
         } else {
@@ -182,14 +182,14 @@ impl Encodable for DescribeClientQuotasRequest {
         } else {
             types::Array(types::Struct { version }).encode(buf, &self.components)?;
         }
-        types::Boolean.encode(buf, &self.strict)?;
+        types::Boolean.encode(buf, self.strict)?;
         if version >= 1 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -202,7 +202,7 @@ impl Encodable for DescribeClientQuotasRequest {
         } else {
             total_size += types::Array(types::Struct { version }).compute_size(&self.components)?;
         }
-        total_size += types::Boolean.compute_size(&self.strict)?;
+        total_size += types::Boolean.compute_size(self.strict)?;
         if version >= 1 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {

--- a/src/messages/describe_client_quotas_response.rs
+++ b/src/messages/describe_client_quotas_response.rs
@@ -62,7 +62,7 @@ impl Encodable for EntityData {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -172,14 +172,14 @@ impl Encodable for ValueData {
         } else {
             types::String.encode(buf, &self.key)?;
         }
-        types::Float64.encode(buf, &self.value)?;
+        types::Float64.encode(buf, self.value)?;
         if version >= 1 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -192,7 +192,7 @@ impl Encodable for ValueData {
         } else {
             total_size += types::String.compute_size(&self.key)?;
         }
-        total_size += types::Float64.compute_size(&self.value)?;
+        total_size += types::Float64.compute_size(self.value)?;
         if version >= 1 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
@@ -292,7 +292,7 @@ impl Encodable for EntryData {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -407,8 +407,8 @@ impl Builder for DescribeClientQuotasResponse {
 
 impl Encodable for DescribeClientQuotasResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.throttle_time_ms)?;
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i32(self.throttle_time_ms);
+        buf.put_i16(self.error_code);
         if version >= 1 {
             types::CompactString.encode(buf, &self.error_message)?;
         } else {
@@ -425,7 +425,7 @@ impl Encodable for DescribeClientQuotasResponse {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -433,8 +433,8 @@ impl Encodable for DescribeClientQuotasResponse {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 4;
+        total_size += 2;
         if version >= 1 {
             total_size += types::CompactString.compute_size(&self.error_message)?;
         } else {
@@ -461,8 +461,8 @@ impl Encodable for DescribeClientQuotasResponse {
 
 impl Decodable for DescribeClientQuotasResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let throttle_time_ms = types::Int32.decode(buf)?;
-        let error_code = types::Int16.decode(buf)?;
+        let throttle_time_ms = buf.try_get_i32()?;
+        let error_code = buf.try_get_i16()?;
         let error_message = if version >= 1 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/describe_cluster_request.rs
+++ b/src/messages/describe_cluster_request.rs
@@ -41,20 +41,20 @@ impl Builder for DescribeClusterRequest {
 
 impl Encodable for DescribeClusterRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Boolean.encode(buf, &self.include_cluster_authorized_operations)?;
+        types::Boolean.encode(buf, self.include_cluster_authorized_operations)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Boolean.compute_size(&self.include_cluster_authorized_operations)?;
+        total_size += types::Boolean.compute_size(self.include_cluster_authorized_operations)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);

--- a/src/messages/describe_cluster_response.rs
+++ b/src/messages/describe_cluster_response.rs
@@ -54,14 +54,14 @@ impl MapEncodable for DescribeClusterBroker {
     fn encode<B: ByteBufMut>(&self, key: &Self::Key, buf: &mut B, version: i16) -> Result<(), EncodeError> {
         types::Int32.encode(buf, key)?;
         types::CompactString.encode(buf, &self.host)?;
-        types::Int32.encode(buf, &self.port)?;
+        buf.put_i32(self.port);
         types::CompactString.encode(buf, &self.rack)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
@@ -70,7 +70,7 @@ impl MapEncodable for DescribeClusterBroker {
         let mut total_size = 0;
         total_size += types::Int32.compute_size(key)?;
         total_size += types::CompactString.compute_size(&self.host)?;
-        total_size += types::Int32.compute_size(&self.port)?;
+        total_size += 4;
         total_size += types::CompactString.compute_size(&self.rack)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
@@ -89,7 +89,7 @@ impl MapDecodable for DescribeClusterBroker {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<(Self::Key, Self), DecodeError> {
         let key_field = types::Int32.decode(buf)?;
         let host = types::CompactString.decode(buf)?;
-        let port = types::Int32.decode(buf)?;
+        let port = buf.try_get_i32()?;
         let rack = types::CompactString.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
         let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
@@ -177,32 +177,32 @@ impl Builder for DescribeClusterResponse {
 
 impl Encodable for DescribeClusterResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.throttle_time_ms)?;
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i32(self.throttle_time_ms);
+        buf.put_i16(self.error_code);
         types::CompactString.encode(buf, &self.error_message)?;
         types::CompactString.encode(buf, &self.cluster_id)?;
         types::Int32.encode(buf, &self.controller_id)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.brokers)?;
-        types::Int32.encode(buf, &self.cluster_authorized_operations)?;
+        buf.put_i32(self.cluster_authorized_operations);
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 4;
+        total_size += 2;
         total_size += types::CompactString.compute_size(&self.error_message)?;
         total_size += types::CompactString.compute_size(&self.cluster_id)?;
         total_size += types::Int32.compute_size(&self.controller_id)?;
         total_size += types::CompactArray(types::Struct { version }).compute_size(&self.brokers)?;
-        total_size += types::Int32.compute_size(&self.cluster_authorized_operations)?;
+        total_size += 4;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
@@ -217,13 +217,13 @@ impl Encodable for DescribeClusterResponse {
 
 impl Decodable for DescribeClusterResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let throttle_time_ms = types::Int32.decode(buf)?;
-        let error_code = types::Int16.decode(buf)?;
+        let throttle_time_ms = buf.try_get_i32()?;
+        let error_code = buf.try_get_i16()?;
         let error_message = types::CompactString.decode(buf)?;
         let cluster_id = types::CompactString.decode(buf)?;
         let controller_id = types::Int32.decode(buf)?;
         let brokers = types::CompactArray(types::Struct { version }).decode(buf)?;
-        let cluster_authorized_operations = types::Int32.decode(buf)?;
+        let cluster_authorized_operations = buf.try_get_i32()?;
         let mut unknown_tagged_fields = BTreeMap::new();
         let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
         for _ in 0..num_tagged_fields {

--- a/src/messages/describe_configs_request.rs
+++ b/src/messages/describe_configs_request.rs
@@ -51,7 +51,7 @@ impl Builder for DescribeConfigsResource {
 
 impl Encodable for DescribeConfigsResource {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int8.encode(buf, &self.resource_type)?;
+        buf.put_i8(self.resource_type);
         if version >= 4 {
             types::CompactString.encode(buf, &self.resource_name)?;
         } else {
@@ -68,7 +68,7 @@ impl Encodable for DescribeConfigsResource {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -76,7 +76,7 @@ impl Encodable for DescribeConfigsResource {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int8.compute_size(&self.resource_type)?;
+        total_size += 1;
         if version >= 4 {
             total_size += types::CompactString.compute_size(&self.resource_name)?;
         } else {
@@ -103,7 +103,7 @@ impl Encodable for DescribeConfigsResource {
 
 impl Decodable for DescribeConfigsResource {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let resource_type = types::Int8.decode(buf)?;
+        let resource_type = buf.try_get_i8()?;
         let resource_name = if version >= 4 {
             types::CompactString.decode(buf)?
         } else {
@@ -188,14 +188,14 @@ impl Encodable for DescribeConfigsRequest {
             types::Array(types::Struct { version }).encode(buf, &self.resources)?;
         }
         if version >= 1 {
-            types::Boolean.encode(buf, &self.include_synonyms)?;
+            types::Boolean.encode(buf, self.include_synonyms)?;
         } else {
             if self.include_synonyms {
                 return Err(EncodeError)
             }
         }
         if version >= 3 {
-            types::Boolean.encode(buf, &self.include_documentation)?;
+            types::Boolean.encode(buf, self.include_documentation)?;
         } else {
             if self.include_documentation {
                 return Err(EncodeError)
@@ -207,7 +207,7 @@ impl Encodable for DescribeConfigsRequest {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -221,14 +221,14 @@ impl Encodable for DescribeConfigsRequest {
             total_size += types::Array(types::Struct { version }).compute_size(&self.resources)?;
         }
         if version >= 1 {
-            total_size += types::Boolean.compute_size(&self.include_synonyms)?;
+            total_size += types::Boolean.compute_size(self.include_synonyms)?;
         } else {
             if self.include_synonyms {
                 return Err(EncodeError)
             }
         }
         if version >= 3 {
-            total_size += types::Boolean.compute_size(&self.include_documentation)?;
+            total_size += types::Boolean.compute_size(self.include_documentation)?;
         } else {
             if self.include_documentation {
                 return Err(EncodeError)

--- a/src/messages/describe_configs_response.rs
+++ b/src/messages/describe_configs_response.rs
@@ -74,7 +74,7 @@ impl Encodable for DescribeConfigsSynonym {
             }
         }
         if version >= 1 {
-            types::Int8.encode(buf, &self.source)?;
+            buf.put_i8(self.source);
         } else {
             if self.source != 0 {
                 return Err(EncodeError)
@@ -86,7 +86,7 @@ impl Encodable for DescribeConfigsSynonym {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -117,7 +117,7 @@ impl Encodable for DescribeConfigsSynonym {
             }
         }
         if version >= 1 {
-            total_size += types::Int8.compute_size(&self.source)?;
+            total_size += 1;
         } else {
             if self.source != 0 {
                 return Err(EncodeError)
@@ -158,7 +158,7 @@ impl Decodable for DescribeConfigsSynonym {
             Some(Default::default())
         };
         let source = if version >= 1 {
-            types::Int8.decode(buf)?
+            buf.try_get_i8()?
         } else {
             0
         };
@@ -270,18 +270,18 @@ impl Encodable for DescribeConfigsResourceResult {
         } else {
             types::String.encode(buf, &self.value)?;
         }
-        types::Boolean.encode(buf, &self.read_only)?;
+        types::Boolean.encode(buf, self.read_only)?;
         if version == 0 {
-            types::Boolean.encode(buf, &self.is_default)?;
+            types::Boolean.encode(buf, self.is_default)?;
         } else {
             if self.is_default {
                 return Err(EncodeError)
             }
         }
         if version >= 1 {
-            types::Int8.encode(buf, &self.config_source)?;
+            buf.put_i8(self.config_source);
         }
-        types::Boolean.encode(buf, &self.is_sensitive)?;
+        types::Boolean.encode(buf, self.is_sensitive)?;
         if version >= 1 {
             if version >= 4 {
                 types::CompactArray(types::Struct { version }).encode(buf, &self.synonyms)?;
@@ -290,7 +290,7 @@ impl Encodable for DescribeConfigsResourceResult {
             }
         }
         if version >= 3 {
-            types::Int8.encode(buf, &self.config_type)?;
+            buf.put_i8(self.config_type);
         }
         if version >= 3 {
             if version >= 4 {
@@ -305,7 +305,7 @@ impl Encodable for DescribeConfigsResourceResult {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -323,18 +323,18 @@ impl Encodable for DescribeConfigsResourceResult {
         } else {
             total_size += types::String.compute_size(&self.value)?;
         }
-        total_size += types::Boolean.compute_size(&self.read_only)?;
+        total_size += types::Boolean.compute_size(self.read_only)?;
         if version == 0 {
-            total_size += types::Boolean.compute_size(&self.is_default)?;
+            total_size += types::Boolean.compute_size(self.is_default)?;
         } else {
             if self.is_default {
                 return Err(EncodeError)
             }
         }
         if version >= 1 {
-            total_size += types::Int8.compute_size(&self.config_source)?;
+            total_size += 1;
         }
-        total_size += types::Boolean.compute_size(&self.is_sensitive)?;
+        total_size += types::Boolean.compute_size(self.is_sensitive)?;
         if version >= 1 {
             if version >= 4 {
                 total_size += types::CompactArray(types::Struct { version }).compute_size(&self.synonyms)?;
@@ -343,7 +343,7 @@ impl Encodable for DescribeConfigsResourceResult {
             }
         }
         if version >= 3 {
-            total_size += types::Int8.compute_size(&self.config_type)?;
+            total_size += 1;
         }
         if version >= 3 {
             if version >= 4 {
@@ -385,7 +385,7 @@ impl Decodable for DescribeConfigsResourceResult {
             false
         };
         let config_source = if version >= 1 {
-            types::Int8.decode(buf)?
+            buf.try_get_i8()?
         } else {
             -1
         };
@@ -400,7 +400,7 @@ impl Decodable for DescribeConfigsResourceResult {
             Default::default()
         };
         let config_type = if version >= 3 {
-            types::Int8.decode(buf)?
+            buf.try_get_i8()?
         } else {
             0
         };
@@ -503,13 +503,13 @@ impl Builder for DescribeConfigsResult {
 
 impl Encodable for DescribeConfigsResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i16(self.error_code);
         if version >= 4 {
             types::CompactString.encode(buf, &self.error_message)?;
         } else {
             types::String.encode(buf, &self.error_message)?;
         }
-        types::Int8.encode(buf, &self.resource_type)?;
+        buf.put_i8(self.resource_type);
         if version >= 4 {
             types::CompactString.encode(buf, &self.resource_name)?;
         } else {
@@ -526,7 +526,7 @@ impl Encodable for DescribeConfigsResult {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -534,13 +534,13 @@ impl Encodable for DescribeConfigsResult {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 2;
         if version >= 4 {
             total_size += types::CompactString.compute_size(&self.error_message)?;
         } else {
             total_size += types::String.compute_size(&self.error_message)?;
         }
-        total_size += types::Int8.compute_size(&self.resource_type)?;
+        total_size += 1;
         if version >= 4 {
             total_size += types::CompactString.compute_size(&self.resource_name)?;
         } else {
@@ -567,13 +567,13 @@ impl Encodable for DescribeConfigsResult {
 
 impl Decodable for DescribeConfigsResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let error_code = types::Int16.decode(buf)?;
+        let error_code = buf.try_get_i16()?;
         let error_message = if version >= 4 {
             types::CompactString.decode(buf)?
         } else {
             types::String.decode(buf)?
         };
-        let resource_type = types::Int8.decode(buf)?;
+        let resource_type = buf.try_get_i8()?;
         let resource_name = if version >= 4 {
             types::CompactString.decode(buf)?
         } else {
@@ -651,7 +651,7 @@ impl Builder for DescribeConfigsResponse {
 
 impl Encodable for DescribeConfigsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.throttle_time_ms)?;
+        buf.put_i32(self.throttle_time_ms);
         if version >= 4 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.results)?;
         } else {
@@ -663,7 +663,7 @@ impl Encodable for DescribeConfigsResponse {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -671,7 +671,7 @@ impl Encodable for DescribeConfigsResponse {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
+        total_size += 4;
         if version >= 4 {
             total_size += types::CompactArray(types::Struct { version }).compute_size(&self.results)?;
         } else {
@@ -693,7 +693,7 @@ impl Encodable for DescribeConfigsResponse {
 
 impl Decodable for DescribeConfigsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let throttle_time_ms = types::Int32.decode(buf)?;
+        let throttle_time_ms = buf.try_get_i32()?;
         let results = if version >= 4 {
             types::CompactArray(types::Struct { version }).decode(buf)?
         } else {

--- a/src/messages/describe_delegation_token_request.rs
+++ b/src/messages/describe_delegation_token_request.rs
@@ -62,7 +62,7 @@ impl Encodable for DescribeDelegationTokenOwner {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -173,7 +173,7 @@ impl Encodable for DescribeDelegationTokenRequest {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }

--- a/src/messages/describe_delegation_token_response.rs
+++ b/src/messages/describe_delegation_token_response.rs
@@ -62,7 +62,7 @@ impl Encodable for DescribedDelegationTokenRenewer {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -231,9 +231,9 @@ impl Encodable for DescribedDelegationToken {
                 return Err(EncodeError)
             }
         }
-        types::Int64.encode(buf, &self.issue_timestamp)?;
-        types::Int64.encode(buf, &self.expiry_timestamp)?;
-        types::Int64.encode(buf, &self.max_timestamp)?;
+        buf.put_i64(self.issue_timestamp);
+        buf.put_i64(self.expiry_timestamp);
+        buf.put_i64(self.max_timestamp);
         if version >= 2 {
             types::CompactString.encode(buf, &self.token_id)?;
         } else {
@@ -255,7 +255,7 @@ impl Encodable for DescribedDelegationToken {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -287,9 +287,9 @@ impl Encodable for DescribedDelegationToken {
                 return Err(EncodeError)
             }
         }
-        total_size += types::Int64.compute_size(&self.issue_timestamp)?;
-        total_size += types::Int64.compute_size(&self.expiry_timestamp)?;
-        total_size += types::Int64.compute_size(&self.max_timestamp)?;
+        total_size += 8;
+        total_size += 8;
+        total_size += 8;
         if version >= 2 {
             total_size += types::CompactString.compute_size(&self.token_id)?;
         } else {
@@ -341,9 +341,9 @@ impl Decodable for DescribedDelegationToken {
         } else {
             Default::default()
         };
-        let issue_timestamp = types::Int64.decode(buf)?;
-        let expiry_timestamp = types::Int64.decode(buf)?;
-        let max_timestamp = types::Int64.decode(buf)?;
+        let issue_timestamp = buf.try_get_i64()?;
+        let expiry_timestamp = buf.try_get_i64()?;
+        let max_timestamp = buf.try_get_i64()?;
         let token_id = if version >= 2 {
             types::CompactString.decode(buf)?
         } else {
@@ -441,20 +441,20 @@ impl Builder for DescribeDelegationTokenResponse {
 
 impl Encodable for DescribeDelegationTokenResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i16(self.error_code);
         if version >= 2 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.tokens)?;
         } else {
             types::Array(types::Struct { version }).encode(buf, &self.tokens)?;
         }
-        types::Int32.encode(buf, &self.throttle_time_ms)?;
+        buf.put_i32(self.throttle_time_ms);
         if version >= 2 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -462,13 +462,13 @@ impl Encodable for DescribeDelegationTokenResponse {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 2;
         if version >= 2 {
             total_size += types::CompactArray(types::Struct { version }).compute_size(&self.tokens)?;
         } else {
             total_size += types::Array(types::Struct { version }).compute_size(&self.tokens)?;
         }
-        total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
+        total_size += 4;
         if version >= 2 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
@@ -485,13 +485,13 @@ impl Encodable for DescribeDelegationTokenResponse {
 
 impl Decodable for DescribeDelegationTokenResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let error_code = types::Int16.decode(buf)?;
+        let error_code = buf.try_get_i16()?;
         let tokens = if version >= 2 {
             types::CompactArray(types::Struct { version }).decode(buf)?
         } else {
             types::Array(types::Struct { version }).decode(buf)?
         };
-        let throttle_time_ms = types::Int32.decode(buf)?;
+        let throttle_time_ms = buf.try_get_i32()?;
         let mut unknown_tagged_fields = BTreeMap::new();
         if version >= 2 {
             let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;

--- a/src/messages/describe_groups_request.rs
+++ b/src/messages/describe_groups_request.rs
@@ -52,7 +52,7 @@ impl Encodable for DescribeGroupsRequest {
             types::Array(types::String).encode(buf, &self.groups)?;
         }
         if version >= 3 {
-            types::Boolean.encode(buf, &self.include_authorized_operations)?;
+            types::Boolean.encode(buf, self.include_authorized_operations)?;
         } else {
             if self.include_authorized_operations {
                 return Err(EncodeError)
@@ -64,7 +64,7 @@ impl Encodable for DescribeGroupsRequest {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -78,7 +78,7 @@ impl Encodable for DescribeGroupsRequest {
             total_size += types::Array(types::String).compute_size(&self.groups)?;
         }
         if version >= 3 {
-            total_size += types::Boolean.compute_size(&self.include_authorized_operations)?;
+            total_size += types::Boolean.compute_size(self.include_authorized_operations)?;
         } else {
             if self.include_authorized_operations {
                 return Err(EncodeError)

--- a/src/messages/describe_groups_response.rs
+++ b/src/messages/describe_groups_response.rs
@@ -104,7 +104,7 @@ impl Encodable for DescribedGroupMember {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -288,7 +288,7 @@ impl Builder for DescribedGroup {
 
 impl Encodable for DescribedGroup {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i16(self.error_code);
         if version >= 5 {
             types::CompactString.encode(buf, &self.group_id)?;
         } else {
@@ -315,7 +315,7 @@ impl Encodable for DescribedGroup {
             types::Array(types::Struct { version }).encode(buf, &self.members)?;
         }
         if version >= 3 {
-            types::Int32.encode(buf, &self.authorized_operations)?;
+            buf.put_i32(self.authorized_operations);
         } else {
             if self.authorized_operations != -2147483648 {
                 return Err(EncodeError)
@@ -327,7 +327,7 @@ impl Encodable for DescribedGroup {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -335,7 +335,7 @@ impl Encodable for DescribedGroup {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 2;
         if version >= 5 {
             total_size += types::CompactString.compute_size(&self.group_id)?;
         } else {
@@ -362,7 +362,7 @@ impl Encodable for DescribedGroup {
             total_size += types::Array(types::Struct { version }).compute_size(&self.members)?;
         }
         if version >= 3 {
-            total_size += types::Int32.compute_size(&self.authorized_operations)?;
+            total_size += 4;
         } else {
             if self.authorized_operations != -2147483648 {
                 return Err(EncodeError)
@@ -384,7 +384,7 @@ impl Encodable for DescribedGroup {
 
 impl Decodable for DescribedGroup {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let error_code = types::Int16.decode(buf)?;
+        let error_code = buf.try_get_i16()?;
         let group_id = if version >= 5 {
             types::CompactString.decode(buf)?
         } else {
@@ -411,7 +411,7 @@ impl Decodable for DescribedGroup {
             types::Array(types::Struct { version }).decode(buf)?
         };
         let authorized_operations = if version >= 3 {
-            types::Int32.decode(buf)?
+            buf.try_get_i32()?
         } else {
             -2147483648
         };
@@ -487,7 +487,7 @@ impl Builder for DescribeGroupsResponse {
 impl Encodable for DescribeGroupsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
         if version >= 1 {
-            types::Int32.encode(buf, &self.throttle_time_ms)?;
+            buf.put_i32(self.throttle_time_ms);
         }
         if version >= 5 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.groups)?;
@@ -500,7 +500,7 @@ impl Encodable for DescribeGroupsResponse {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -509,7 +509,7 @@ impl Encodable for DescribeGroupsResponse {
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
         if version >= 1 {
-            total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
+            total_size += 4;
         }
         if version >= 5 {
             total_size += types::CompactArray(types::Struct { version }).compute_size(&self.groups)?;
@@ -533,7 +533,7 @@ impl Encodable for DescribeGroupsResponse {
 impl Decodable for DescribeGroupsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
         let throttle_time_ms = if version >= 1 {
-            types::Int32.decode(buf)?
+            buf.try_get_i32()?
         } else {
             0
         };

--- a/src/messages/describe_log_dirs_request.rs
+++ b/src/messages/describe_log_dirs_request.rs
@@ -58,7 +58,7 @@ impl MapEncodable for DescribableLogDirTopic {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -168,7 +168,7 @@ impl Encodable for DescribeLogDirsRequest {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }

--- a/src/messages/describe_producers_request.rs
+++ b/src/messages/describe_producers_request.rs
@@ -53,7 +53,7 @@ impl Encodable for TopicRequest {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
@@ -138,7 +138,7 @@ impl Encodable for DescribeProducersRequest {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())

--- a/src/messages/describe_producers_response.rs
+++ b/src/messages/describe_producers_response.rs
@@ -67,17 +67,17 @@ impl Builder for ProducerState {
 impl Encodable for ProducerState {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
         types::Int64.encode(buf, &self.producer_id)?;
-        types::Int32.encode(buf, &self.producer_epoch)?;
-        types::Int32.encode(buf, &self.last_sequence)?;
-        types::Int64.encode(buf, &self.last_timestamp)?;
-        types::Int32.encode(buf, &self.coordinator_epoch)?;
-        types::Int64.encode(buf, &self.current_txn_start_offset)?;
+        buf.put_i32(self.producer_epoch);
+        buf.put_i32(self.last_sequence);
+        buf.put_i64(self.last_timestamp);
+        buf.put_i32(self.coordinator_epoch);
+        buf.put_i64(self.current_txn_start_offset);
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
@@ -85,11 +85,11 @@ impl Encodable for ProducerState {
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
         total_size += types::Int64.compute_size(&self.producer_id)?;
-        total_size += types::Int32.compute_size(&self.producer_epoch)?;
-        total_size += types::Int32.compute_size(&self.last_sequence)?;
-        total_size += types::Int64.compute_size(&self.last_timestamp)?;
-        total_size += types::Int32.compute_size(&self.coordinator_epoch)?;
-        total_size += types::Int64.compute_size(&self.current_txn_start_offset)?;
+        total_size += 4;
+        total_size += 4;
+        total_size += 8;
+        total_size += 4;
+        total_size += 8;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
@@ -105,11 +105,11 @@ impl Encodable for ProducerState {
 impl Decodable for ProducerState {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
         let producer_id = types::Int64.decode(buf)?;
-        let producer_epoch = types::Int32.decode(buf)?;
-        let last_sequence = types::Int32.decode(buf)?;
-        let last_timestamp = types::Int64.decode(buf)?;
-        let coordinator_epoch = types::Int32.decode(buf)?;
-        let current_txn_start_offset = types::Int64.decode(buf)?;
+        let producer_epoch = buf.try_get_i32()?;
+        let last_sequence = buf.try_get_i32()?;
+        let last_timestamp = buf.try_get_i64()?;
+        let coordinator_epoch = buf.try_get_i32()?;
+        let current_txn_start_offset = buf.try_get_i64()?;
         let mut unknown_tagged_fields = BTreeMap::new();
         let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
         for _ in 0..num_tagged_fields {
@@ -187,8 +187,8 @@ impl Builder for PartitionResponse {
 
 impl Encodable for PartitionResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.partition_index)?;
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i32(self.partition_index);
+        buf.put_i16(self.error_code);
         types::CompactString.encode(buf, &self.error_message)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.active_producers)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -196,15 +196,15 @@ impl Encodable for PartitionResponse {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.partition_index)?;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 4;
+        total_size += 2;
         total_size += types::CompactString.compute_size(&self.error_message)?;
         total_size += types::CompactArray(types::Struct { version }).compute_size(&self.active_producers)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -221,8 +221,8 @@ impl Encodable for PartitionResponse {
 
 impl Decodable for PartitionResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let partition_index = types::Int32.decode(buf)?;
-        let error_code = types::Int16.decode(buf)?;
+        let partition_index = buf.try_get_i32()?;
+        let error_code = buf.try_get_i16()?;
         let error_message = types::CompactString.decode(buf)?;
         let active_producers = types::CompactArray(types::Struct { version }).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
@@ -295,7 +295,7 @@ impl Encodable for TopicResponse {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
@@ -379,21 +379,21 @@ impl Builder for DescribeProducersResponse {
 
 impl Encodable for DescribeProducersResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.throttle_time_ms)?;
+        buf.put_i32(self.throttle_time_ms);
         types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
+        total_size += 4;
         total_size += types::CompactArray(types::Struct { version }).compute_size(&self.topics)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
@@ -409,7 +409,7 @@ impl Encodable for DescribeProducersResponse {
 
 impl Decodable for DescribeProducersResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let throttle_time_ms = types::Int32.decode(buf)?;
+        let throttle_time_ms = buf.try_get_i32()?;
         let topics = types::CompactArray(types::Struct { version }).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
         let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;

--- a/src/messages/describe_quorum_request.rs
+++ b/src/messages/describe_quorum_request.rs
@@ -41,20 +41,20 @@ impl Builder for PartitionData {
 
 impl Encodable for PartitionData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.partition_index)?;
+        buf.put_i32(self.partition_index);
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.partition_index)?;
+        total_size += 4;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
@@ -69,7 +69,7 @@ impl Encodable for PartitionData {
 
 impl Decodable for PartitionData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let partition_index = types::Int32.decode(buf)?;
+        let partition_index = buf.try_get_i32()?;
         let mut unknown_tagged_fields = BTreeMap::new();
         let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
         for _ in 0..num_tagged_fields {
@@ -134,7 +134,7 @@ impl Encodable for TopicData {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
@@ -219,7 +219,7 @@ impl Encodable for DescribeQuorumRequest {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())

--- a/src/messages/describe_transactions_request.rs
+++ b/src/messages/describe_transactions_request.rs
@@ -47,7 +47,7 @@ impl Encodable for DescribeTransactionsRequest {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())

--- a/src/messages/describe_transactions_response.rs
+++ b/src/messages/describe_transactions_response.rs
@@ -49,7 +49,7 @@ impl MapEncodable for TopicData {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
@@ -162,33 +162,33 @@ impl Builder for TransactionState {
 
 impl Encodable for TransactionState {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i16(self.error_code);
         types::CompactString.encode(buf, &self.transactional_id)?;
         types::CompactString.encode(buf, &self.transaction_state)?;
-        types::Int32.encode(buf, &self.transaction_timeout_ms)?;
-        types::Int64.encode(buf, &self.transaction_start_time_ms)?;
+        buf.put_i32(self.transaction_timeout_ms);
+        buf.put_i64(self.transaction_start_time_ms);
         types::Int64.encode(buf, &self.producer_id)?;
-        types::Int16.encode(buf, &self.producer_epoch)?;
+        buf.put_i16(self.producer_epoch);
         types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 2;
         total_size += types::CompactString.compute_size(&self.transactional_id)?;
         total_size += types::CompactString.compute_size(&self.transaction_state)?;
-        total_size += types::Int32.compute_size(&self.transaction_timeout_ms)?;
-        total_size += types::Int64.compute_size(&self.transaction_start_time_ms)?;
+        total_size += 4;
+        total_size += 8;
         total_size += types::Int64.compute_size(&self.producer_id)?;
-        total_size += types::Int16.compute_size(&self.producer_epoch)?;
+        total_size += 2;
         total_size += types::CompactArray(types::Struct { version }).compute_size(&self.topics)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
@@ -204,13 +204,13 @@ impl Encodable for TransactionState {
 
 impl Decodable for TransactionState {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let error_code = types::Int16.decode(buf)?;
+        let error_code = buf.try_get_i16()?;
         let transactional_id = types::CompactString.decode(buf)?;
         let transaction_state = types::CompactString.decode(buf)?;
-        let transaction_timeout_ms = types::Int32.decode(buf)?;
-        let transaction_start_time_ms = types::Int64.decode(buf)?;
+        let transaction_timeout_ms = buf.try_get_i32()?;
+        let transaction_start_time_ms = buf.try_get_i64()?;
         let producer_id = types::Int64.decode(buf)?;
-        let producer_epoch = types::Int16.decode(buf)?;
+        let producer_epoch = buf.try_get_i16()?;
         let topics = types::CompactArray(types::Struct { version }).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
         let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
@@ -283,21 +283,21 @@ impl Builder for DescribeTransactionsResponse {
 
 impl Encodable for DescribeTransactionsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.throttle_time_ms)?;
+        buf.put_i32(self.throttle_time_ms);
         types::CompactArray(types::Struct { version }).encode(buf, &self.transaction_states)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
+        total_size += 4;
         total_size += types::CompactArray(types::Struct { version }).compute_size(&self.transaction_states)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
@@ -313,7 +313,7 @@ impl Encodable for DescribeTransactionsResponse {
 
 impl Decodable for DescribeTransactionsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let throttle_time_ms = types::Int32.decode(buf)?;
+        let throttle_time_ms = buf.try_get_i32()?;
         let transaction_states = types::CompactArray(types::Struct { version }).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
         let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;

--- a/src/messages/describe_user_scram_credentials_request.rs
+++ b/src/messages/describe_user_scram_credentials_request.rs
@@ -47,7 +47,7 @@ impl Encodable for UserName {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
@@ -128,7 +128,7 @@ impl Encodable for DescribeUserScramCredentialsRequest {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())

--- a/src/messages/describe_user_scram_credentials_response.rs
+++ b/src/messages/describe_user_scram_credentials_response.rs
@@ -46,22 +46,22 @@ impl Builder for CredentialInfo {
 
 impl Encodable for CredentialInfo {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int8.encode(buf, &self.mechanism)?;
-        types::Int32.encode(buf, &self.iterations)?;
+        buf.put_i8(self.mechanism);
+        buf.put_i32(self.iterations);
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int8.compute_size(&self.mechanism)?;
-        total_size += types::Int32.compute_size(&self.iterations)?;
+        total_size += 1;
+        total_size += 4;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
@@ -76,8 +76,8 @@ impl Encodable for CredentialInfo {
 
 impl Decodable for CredentialInfo {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let mechanism = types::Int8.decode(buf)?;
-        let iterations = types::Int32.decode(buf)?;
+        let mechanism = buf.try_get_i8()?;
+        let iterations = buf.try_get_i32()?;
         let mut unknown_tagged_fields = BTreeMap::new();
         let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
         for _ in 0..num_tagged_fields {
@@ -148,7 +148,7 @@ impl Builder for DescribeUserScramCredentialsResult {
 impl Encodable for DescribeUserScramCredentialsResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
         types::CompactString.encode(buf, &self.user)?;
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i16(self.error_code);
         types::CompactString.encode(buf, &self.error_message)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.credential_infos)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -156,7 +156,7 @@ impl Encodable for DescribeUserScramCredentialsResult {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
@@ -164,7 +164,7 @@ impl Encodable for DescribeUserScramCredentialsResult {
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
         total_size += types::CompactString.compute_size(&self.user)?;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 2;
         total_size += types::CompactString.compute_size(&self.error_message)?;
         total_size += types::CompactArray(types::Struct { version }).compute_size(&self.credential_infos)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -182,7 +182,7 @@ impl Encodable for DescribeUserScramCredentialsResult {
 impl Decodable for DescribeUserScramCredentialsResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
         let user = types::CompactString.decode(buf)?;
-        let error_code = types::Int16.decode(buf)?;
+        let error_code = buf.try_get_i16()?;
         let error_message = types::CompactString.decode(buf)?;
         let credential_infos = types::CompactArray(types::Struct { version }).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
@@ -258,8 +258,8 @@ impl Builder for DescribeUserScramCredentialsResponse {
 
 impl Encodable for DescribeUserScramCredentialsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.throttle_time_ms)?;
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i32(self.throttle_time_ms);
+        buf.put_i16(self.error_code);
         types::CompactString.encode(buf, &self.error_message)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.results)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -267,15 +267,15 @@ impl Encodable for DescribeUserScramCredentialsResponse {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 4;
+        total_size += 2;
         total_size += types::CompactString.compute_size(&self.error_message)?;
         total_size += types::CompactArray(types::Struct { version }).compute_size(&self.results)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -292,8 +292,8 @@ impl Encodable for DescribeUserScramCredentialsResponse {
 
 impl Decodable for DescribeUserScramCredentialsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let throttle_time_ms = types::Int32.decode(buf)?;
-        let error_code = types::Int16.decode(buf)?;
+        let throttle_time_ms = buf.try_get_i32()?;
+        let error_code = buf.try_get_i16()?;
         let error_message = types::CompactString.decode(buf)?;
         let results = types::CompactArray(types::Struct { version }).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();

--- a/src/messages/elect_leaders_response.rs
+++ b/src/messages/elect_leaders_response.rs
@@ -51,8 +51,8 @@ impl Builder for PartitionResult {
 
 impl Encodable for PartitionResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.partition_id)?;
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i32(self.partition_id);
+        buf.put_i16(self.error_code);
         if version >= 2 {
             types::CompactString.encode(buf, &self.error_message)?;
         } else {
@@ -64,7 +64,7 @@ impl Encodable for PartitionResult {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -72,8 +72,8 @@ impl Encodable for PartitionResult {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.partition_id)?;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 4;
+        total_size += 2;
         if version >= 2 {
             total_size += types::CompactString.compute_size(&self.error_message)?;
         } else {
@@ -95,8 +95,8 @@ impl Encodable for PartitionResult {
 
 impl Decodable for PartitionResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let partition_id = types::Int32.decode(buf)?;
-        let error_code = types::Int16.decode(buf)?;
+        let partition_id = buf.try_get_i32()?;
+        let error_code = buf.try_get_i16()?;
         let error_message = if version >= 2 {
             types::CompactString.decode(buf)?
         } else {
@@ -181,7 +181,7 @@ impl Encodable for ReplicaElectionResult {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -291,9 +291,9 @@ impl Builder for ElectLeadersResponse {
 
 impl Encodable for ElectLeadersResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.throttle_time_ms)?;
+        buf.put_i32(self.throttle_time_ms);
         if version >= 1 {
-            types::Int16.encode(buf, &self.error_code)?;
+            buf.put_i16(self.error_code);
         } else {
             if self.error_code != 0 {
                 return Err(EncodeError)
@@ -310,7 +310,7 @@ impl Encodable for ElectLeadersResponse {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -318,9 +318,9 @@ impl Encodable for ElectLeadersResponse {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
+        total_size += 4;
         if version >= 1 {
-            total_size += types::Int16.compute_size(&self.error_code)?;
+            total_size += 2;
         } else {
             if self.error_code != 0 {
                 return Err(EncodeError)
@@ -347,9 +347,9 @@ impl Encodable for ElectLeadersResponse {
 
 impl Decodable for ElectLeadersResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let throttle_time_ms = types::Int32.decode(buf)?;
+        let throttle_time_ms = buf.try_get_i32()?;
         let error_code = if version >= 1 {
-            types::Int16.decode(buf)?
+            buf.try_get_i16()?
         } else {
             0
         };

--- a/src/messages/end_quorum_epoch_request.rs
+++ b/src/messages/end_quorum_epoch_request.rs
@@ -54,18 +54,18 @@ impl Builder for PartitionData {
 
 impl Encodable for PartitionData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.partition_index)?;
+        buf.put_i32(self.partition_index);
         types::Int32.encode(buf, &self.leader_id)?;
-        types::Int32.encode(buf, &self.leader_epoch)?;
+        buf.put_i32(self.leader_epoch);
         types::Array(types::Int32).encode(buf, &self.preferred_successors)?;
 
         Ok(())
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.partition_index)?;
+        total_size += 4;
         total_size += types::Int32.compute_size(&self.leader_id)?;
-        total_size += types::Int32.compute_size(&self.leader_epoch)?;
+        total_size += 4;
         total_size += types::Array(types::Int32).compute_size(&self.preferred_successors)?;
 
         Ok(total_size)
@@ -74,9 +74,9 @@ impl Encodable for PartitionData {
 
 impl Decodable for PartitionData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let partition_index = types::Int32.decode(buf)?;
+        let partition_index = buf.try_get_i32()?;
         let leader_id = types::Int32.decode(buf)?;
-        let leader_epoch = types::Int32.decode(buf)?;
+        let leader_epoch = buf.try_get_i32()?;
         let preferred_successors = types::Array(types::Int32).decode(buf)?;
         Ok(Self {
             partition_index,

--- a/src/messages/end_quorum_epoch_response.rs
+++ b/src/messages/end_quorum_epoch_response.rs
@@ -54,19 +54,19 @@ impl Builder for PartitionData {
 
 impl Encodable for PartitionData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.partition_index)?;
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i32(self.partition_index);
+        buf.put_i16(self.error_code);
         types::Int32.encode(buf, &self.leader_id)?;
-        types::Int32.encode(buf, &self.leader_epoch)?;
+        buf.put_i32(self.leader_epoch);
 
         Ok(())
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.partition_index)?;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 4;
+        total_size += 2;
         total_size += types::Int32.compute_size(&self.leader_id)?;
-        total_size += types::Int32.compute_size(&self.leader_epoch)?;
+        total_size += 4;
 
         Ok(total_size)
     }
@@ -74,10 +74,10 @@ impl Encodable for PartitionData {
 
 impl Decodable for PartitionData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let partition_index = types::Int32.decode(buf)?;
-        let error_code = types::Int16.decode(buf)?;
+        let partition_index = buf.try_get_i32()?;
+        let error_code = buf.try_get_i16()?;
         let leader_id = types::Int32.decode(buf)?;
-        let leader_epoch = types::Int32.decode(buf)?;
+        let leader_epoch = buf.try_get_i32()?;
         Ok(Self {
             partition_index,
             error_code,
@@ -194,14 +194,14 @@ impl Builder for EndQuorumEpochResponse {
 
 impl Encodable for EndQuorumEpochResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i16(self.error_code);
         types::Array(types::Struct { version }).encode(buf, &self.topics)?;
 
         Ok(())
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 2;
         total_size += types::Array(types::Struct { version }).compute_size(&self.topics)?;
 
         Ok(total_size)
@@ -210,7 +210,7 @@ impl Encodable for EndQuorumEpochResponse {
 
 impl Decodable for EndQuorumEpochResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let error_code = types::Int16.decode(buf)?;
+        let error_code = buf.try_get_i16()?;
         let topics = types::Array(types::Struct { version }).decode(buf)?;
         Ok(Self {
             error_code,

--- a/src/messages/end_txn_response.rs
+++ b/src/messages/end_txn_response.rs
@@ -46,15 +46,15 @@ impl Builder for EndTxnResponse {
 
 impl Encodable for EndTxnResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.throttle_time_ms)?;
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i32(self.throttle_time_ms);
+        buf.put_i16(self.error_code);
         if version >= 3 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -62,8 +62,8 @@ impl Encodable for EndTxnResponse {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 4;
+        total_size += 2;
         if version >= 3 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
@@ -80,8 +80,8 @@ impl Encodable for EndTxnResponse {
 
 impl Decodable for EndTxnResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let throttle_time_ms = types::Int32.decode(buf)?;
-        let error_code = types::Int16.decode(buf)?;
+        let throttle_time_ms = buf.try_get_i32()?;
+        let error_code = buf.try_get_i16()?;
         let mut unknown_tagged_fields = BTreeMap::new();
         if version >= 3 {
             let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;

--- a/src/messages/envelope_request.rs
+++ b/src/messages/envelope_request.rs
@@ -59,7 +59,7 @@ impl Encodable for EnvelopeRequest {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())

--- a/src/messages/expire_delegation_token_request.rs
+++ b/src/messages/expire_delegation_token_request.rs
@@ -51,14 +51,14 @@ impl Encodable for ExpireDelegationTokenRequest {
         } else {
             types::Bytes.encode(buf, &self.hmac)?;
         }
-        types::Int64.encode(buf, &self.expiry_time_period_ms)?;
+        buf.put_i64(self.expiry_time_period_ms);
         if version >= 2 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -71,7 +71,7 @@ impl Encodable for ExpireDelegationTokenRequest {
         } else {
             total_size += types::Bytes.compute_size(&self.hmac)?;
         }
-        total_size += types::Int64.compute_size(&self.expiry_time_period_ms)?;
+        total_size += 8;
         if version >= 2 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
@@ -93,7 +93,7 @@ impl Decodable for ExpireDelegationTokenRequest {
         } else {
             types::Bytes.decode(buf)?
         };
-        let expiry_time_period_ms = types::Int64.decode(buf)?;
+        let expiry_time_period_ms = buf.try_get_i64()?;
         let mut unknown_tagged_fields = BTreeMap::new();
         if version >= 2 {
             let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;

--- a/src/messages/expire_delegation_token_response.rs
+++ b/src/messages/expire_delegation_token_response.rs
@@ -51,16 +51,16 @@ impl Builder for ExpireDelegationTokenResponse {
 
 impl Encodable for ExpireDelegationTokenResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int16.encode(buf, &self.error_code)?;
-        types::Int64.encode(buf, &self.expiry_timestamp_ms)?;
-        types::Int32.encode(buf, &self.throttle_time_ms)?;
+        buf.put_i16(self.error_code);
+        buf.put_i64(self.expiry_timestamp_ms);
+        buf.put_i32(self.throttle_time_ms);
         if version >= 2 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -68,9 +68,9 @@ impl Encodable for ExpireDelegationTokenResponse {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int16.compute_size(&self.error_code)?;
-        total_size += types::Int64.compute_size(&self.expiry_timestamp_ms)?;
-        total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
+        total_size += 2;
+        total_size += 8;
+        total_size += 4;
         if version >= 2 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
@@ -87,9 +87,9 @@ impl Encodable for ExpireDelegationTokenResponse {
 
 impl Decodable for ExpireDelegationTokenResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let error_code = types::Int16.decode(buf)?;
-        let expiry_timestamp_ms = types::Int64.decode(buf)?;
-        let throttle_time_ms = types::Int32.decode(buf)?;
+        let error_code = buf.try_get_i16()?;
+        let expiry_timestamp_ms = buf.try_get_i64()?;
+        let throttle_time_ms = buf.try_get_i32()?;
         let mut unknown_tagged_fields = BTreeMap::new();
         if version >= 2 {
             let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;

--- a/src/messages/fetch_request.rs
+++ b/src/messages/fetch_request.rs
@@ -66,29 +66,29 @@ impl Builder for FetchPartition {
 
 impl Encodable for FetchPartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.partition)?;
+        buf.put_i32(self.partition);
         if version >= 9 {
-            types::Int32.encode(buf, &self.current_leader_epoch)?;
+            buf.put_i32(self.current_leader_epoch);
         }
-        types::Int64.encode(buf, &self.fetch_offset)?;
+        buf.put_i64(self.fetch_offset);
         if version >= 12 {
-            types::Int32.encode(buf, &self.last_fetched_epoch)?;
+            buf.put_i32(self.last_fetched_epoch);
         } else {
             if self.last_fetched_epoch != -1 {
                 return Err(EncodeError)
             }
         }
         if version >= 5 {
-            types::Int64.encode(buf, &self.log_start_offset)?;
+            buf.put_i64(self.log_start_offset);
         }
-        types::Int32.encode(buf, &self.partition_max_bytes)?;
+        buf.put_i32(self.partition_max_bytes);
         if version >= 12 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -96,22 +96,22 @@ impl Encodable for FetchPartition {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.partition)?;
+        total_size += 4;
         if version >= 9 {
-            total_size += types::Int32.compute_size(&self.current_leader_epoch)?;
+            total_size += 4;
         }
-        total_size += types::Int64.compute_size(&self.fetch_offset)?;
+        total_size += 8;
         if version >= 12 {
-            total_size += types::Int32.compute_size(&self.last_fetched_epoch)?;
+            total_size += 4;
         } else {
             if self.last_fetched_epoch != -1 {
                 return Err(EncodeError)
             }
         }
         if version >= 5 {
-            total_size += types::Int64.compute_size(&self.log_start_offset)?;
+            total_size += 8;
         }
-        total_size += types::Int32.compute_size(&self.partition_max_bytes)?;
+        total_size += 4;
         if version >= 12 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
@@ -128,24 +128,24 @@ impl Encodable for FetchPartition {
 
 impl Decodable for FetchPartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let partition = types::Int32.decode(buf)?;
+        let partition = buf.try_get_i32()?;
         let current_leader_epoch = if version >= 9 {
-            types::Int32.decode(buf)?
+            buf.try_get_i32()?
         } else {
             -1
         };
-        let fetch_offset = types::Int64.decode(buf)?;
+        let fetch_offset = buf.try_get_i64()?;
         let last_fetched_epoch = if version >= 12 {
-            types::Int32.decode(buf)?
+            buf.try_get_i32()?
         } else {
             -1
         };
         let log_start_offset = if version >= 5 {
-            types::Int64.decode(buf)?
+            buf.try_get_i64()?
         } else {
             -1
         };
-        let partition_max_bytes = types::Int32.decode(buf)?;
+        let partition_max_bytes = buf.try_get_i32()?;
         let mut unknown_tagged_fields = BTreeMap::new();
         if version >= 12 {
             let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
@@ -228,7 +228,7 @@ impl Encodable for FetchTopic {
             }
         }
         if version >= 13 {
-            types::Uuid.encode(buf, &self.topic_id)?;
+            types::Uuid.encode(buf, self.topic_id)?;
         }
         if version >= 12 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.partitions)?;
@@ -241,7 +241,7 @@ impl Encodable for FetchTopic {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -257,7 +257,7 @@ impl Encodable for FetchTopic {
             }
         }
         if version >= 13 {
-            total_size += types::Uuid.compute_size(&self.topic_id)?;
+            total_size += types::Uuid.compute_size(self.topic_id)?;
         }
         if version >= 12 {
             total_size += types::CompactArray(types::Struct { version }).compute_size(&self.partitions)?;
@@ -375,7 +375,7 @@ impl Encodable for ForgottenTopic {
             }
         }
         if version >= 13 {
-            types::Uuid.encode(buf, &self.topic_id)?;
+            types::Uuid.encode(buf, self.topic_id)?;
         }
         if version >= 7 {
             if version >= 12 {
@@ -394,7 +394,7 @@ impl Encodable for ForgottenTopic {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -410,7 +410,7 @@ impl Encodable for ForgottenTopic {
             }
         }
         if version >= 13 {
-            total_size += types::Uuid.compute_size(&self.topic_id)?;
+            total_size += types::Uuid.compute_size(self.topic_id)?;
         }
         if version >= 7 {
             if version >= 12 {
@@ -571,19 +571,19 @@ impl Builder for FetchRequest {
 impl Encodable for FetchRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
         types::Int32.encode(buf, &self.replica_id)?;
-        types::Int32.encode(buf, &self.max_wait_ms)?;
-        types::Int32.encode(buf, &self.min_bytes)?;
+        buf.put_i32(self.max_wait_ms);
+        buf.put_i32(self.min_bytes);
         if version >= 3 {
-            types::Int32.encode(buf, &self.max_bytes)?;
+            buf.put_i32(self.max_bytes);
         }
         if version >= 4 {
-            types::Int8.encode(buf, &self.isolation_level)?;
+            buf.put_i8(self.isolation_level);
         }
         if version >= 7 {
-            types::Int32.encode(buf, &self.session_id)?;
+            buf.put_i32(self.session_id);
         }
         if version >= 7 {
-            types::Int32.encode(buf, &self.session_epoch)?;
+            buf.put_i32(self.session_epoch);
         }
         if version >= 12 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
@@ -617,15 +617,15 @@ impl Encodable for FetchRequest {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
             if !self.cluster_id.is_none() {
                 let computed_size = types::CompactString.compute_size(&self.cluster_id)?;
                 if computed_size > std::u32::MAX as usize {
                     error!("Tagged field is too large to encode ({} bytes)", computed_size);
                     return Err(EncodeError);
                 }
-                types::UnsignedVarInt.encode(buf, 0)?;
-                types::UnsignedVarInt.encode(buf, computed_size as u32)?;
+                buf.put_i32(0);
+                buf.put_i32(computed_size as i32);
                 types::CompactString.encode(buf, &self.cluster_id)?;
             }
 
@@ -636,19 +636,19 @@ impl Encodable for FetchRequest {
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
         total_size += types::Int32.compute_size(&self.replica_id)?;
-        total_size += types::Int32.compute_size(&self.max_wait_ms)?;
-        total_size += types::Int32.compute_size(&self.min_bytes)?;
+        total_size += 4;
+        total_size += 4;
         if version >= 3 {
-            total_size += types::Int32.compute_size(&self.max_bytes)?;
+            total_size += 4;
         }
         if version >= 4 {
-            total_size += types::Int8.compute_size(&self.isolation_level)?;
+            total_size += 1;
         }
         if version >= 7 {
-            total_size += types::Int32.compute_size(&self.session_id)?;
+            total_size += 4;
         }
         if version >= 7 {
-            total_size += types::Int32.compute_size(&self.session_epoch)?;
+            total_size += 4;
         }
         if version >= 12 {
             total_size += types::CompactArray(types::Struct { version }).compute_size(&self.topics)?;
@@ -689,8 +689,8 @@ impl Encodable for FetchRequest {
                     error!("Tagged field is too large to encode ({} bytes)", computed_size);
                     return Err(EncodeError);
                 }
-                total_size += types::UnsignedVarInt.compute_size(0)?;
-                total_size += types::UnsignedVarInt.compute_size(computed_size as u32)?;
+                total_size += 4;
+                total_size += 4;
                 total_size += computed_size;
             }
 
@@ -704,25 +704,25 @@ impl Decodable for FetchRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
         let mut cluster_id = None;
         let replica_id = types::Int32.decode(buf)?;
-        let max_wait_ms = types::Int32.decode(buf)?;
-        let min_bytes = types::Int32.decode(buf)?;
+        let max_wait_ms = buf.try_get_i32()?;
+        let min_bytes = buf.try_get_i32()?;
         let max_bytes = if version >= 3 {
-            types::Int32.decode(buf)?
+            buf.try_get_i32()?
         } else {
             0x7fffffff
         };
         let isolation_level = if version >= 4 {
-            types::Int8.decode(buf)?
+            buf.try_get_i8()?
         } else {
             0
         };
         let session_id = if version >= 7 {
-            types::Int32.decode(buf)?
+            buf.try_get_i32()?
         } else {
             0
         };
         let session_epoch = if version >= 7 {
-            types::Int32.decode(buf)?
+            buf.try_get_i32()?
         } else {
             -1
         };

--- a/src/messages/fetch_response.rs
+++ b/src/messages/fetch_response.rs
@@ -47,14 +47,14 @@ impl Builder for EpochEndOffset {
 impl Encodable for EpochEndOffset {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
         if version >= 12 {
-            types::Int32.encode(buf, &self.epoch)?;
+            buf.put_i32(self.epoch);
         } else {
             if self.epoch != -1 {
                 return Err(EncodeError)
             }
         }
         if version >= 12 {
-            types::Int64.encode(buf, &self.end_offset)?;
+            buf.put_i64(self.end_offset);
         } else {
             if self.end_offset != -1 {
                 return Err(EncodeError)
@@ -66,7 +66,7 @@ impl Encodable for EpochEndOffset {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -75,14 +75,14 @@ impl Encodable for EpochEndOffset {
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
         if version >= 12 {
-            total_size += types::Int32.compute_size(&self.epoch)?;
+            total_size += 4;
         } else {
             if self.epoch != -1 {
                 return Err(EncodeError)
             }
         }
         if version >= 12 {
-            total_size += types::Int64.compute_size(&self.end_offset)?;
+            total_size += 8;
         } else {
             if self.end_offset != -1 {
                 return Err(EncodeError)
@@ -105,12 +105,12 @@ impl Encodable for EpochEndOffset {
 impl Decodable for EpochEndOffset {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
         let epoch = if version >= 12 {
-            types::Int32.decode(buf)?
+            buf.try_get_i32()?
         } else {
             -1
         };
         let end_offset = if version >= 12 {
-            types::Int64.decode(buf)?
+            buf.try_get_i64()?
         } else {
             -1
         };
@@ -183,7 +183,7 @@ impl Encodable for LeaderIdAndEpoch {
             }
         }
         if version >= 12 {
-            types::Int32.encode(buf, &self.leader_epoch)?;
+            buf.put_i32(self.leader_epoch);
         } else {
             if self.leader_epoch != -1 {
                 return Err(EncodeError)
@@ -195,7 +195,7 @@ impl Encodable for LeaderIdAndEpoch {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -211,7 +211,7 @@ impl Encodable for LeaderIdAndEpoch {
             }
         }
         if version >= 12 {
-            total_size += types::Int32.compute_size(&self.leader_epoch)?;
+            total_size += 4;
         } else {
             if self.leader_epoch != -1 {
                 return Err(EncodeError)
@@ -239,7 +239,7 @@ impl Decodable for LeaderIdAndEpoch {
             (-1).into()
         };
         let leader_epoch = if version >= 12 {
-            types::Int32.decode(buf)?
+            buf.try_get_i32()?
         } else {
             -1
         };
@@ -304,15 +304,15 @@ impl Builder for SnapshotId {
 
 impl Encodable for SnapshotId {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int64.encode(buf, &self.end_offset)?;
-        types::Int32.encode(buf, &self.epoch)?;
+        buf.put_i64(self.end_offset);
+        buf.put_i32(self.epoch);
         if version >= 12 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -320,8 +320,8 @@ impl Encodable for SnapshotId {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int64.compute_size(&self.end_offset)?;
-        total_size += types::Int32.compute_size(&self.epoch)?;
+        total_size += 8;
+        total_size += 4;
         if version >= 12 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
@@ -338,8 +338,8 @@ impl Encodable for SnapshotId {
 
 impl Decodable for SnapshotId {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let end_offset = types::Int64.decode(buf)?;
-        let epoch = types::Int32.decode(buf)?;
+        let end_offset = buf.try_get_i64()?;
+        let epoch = buf.try_get_i32()?;
         let mut unknown_tagged_fields = BTreeMap::new();
         if version >= 12 {
             let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
@@ -409,7 +409,7 @@ impl Encodable for AbortedTransaction {
             }
         }
         if version >= 4 {
-            types::Int64.encode(buf, &self.first_offset)?;
+            buf.put_i64(self.first_offset);
         } else {
             if self.first_offset != 0 {
                 return Err(EncodeError)
@@ -421,7 +421,7 @@ impl Encodable for AbortedTransaction {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -437,7 +437,7 @@ impl Encodable for AbortedTransaction {
             }
         }
         if version >= 4 {
-            total_size += types::Int64.compute_size(&self.first_offset)?;
+            total_size += 8;
         } else {
             if self.first_offset != 0 {
                 return Err(EncodeError)
@@ -465,7 +465,7 @@ impl Decodable for AbortedTransaction {
             (0).into()
         };
         let first_offset = if version >= 4 {
-            types::Int64.decode(buf)?
+            buf.try_get_i64()?
         } else {
             0
         };
@@ -575,14 +575,14 @@ impl Builder for PartitionData {
 
 impl Encodable for PartitionData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.partition_index)?;
-        types::Int16.encode(buf, &self.error_code)?;
-        types::Int64.encode(buf, &self.high_watermark)?;
+        buf.put_i32(self.partition_index);
+        buf.put_i16(self.error_code);
+        buf.put_i64(self.high_watermark);
         if version >= 4 {
-            types::Int64.encode(buf, &self.last_stable_offset)?;
+            buf.put_i64(self.last_stable_offset);
         }
         if version >= 5 {
-            types::Int64.encode(buf, &self.log_start_offset)?;
+            buf.put_i64(self.log_start_offset);
         }
         if version >= 4 {
             if version >= 12 {
@@ -618,15 +618,15 @@ impl Encodable for PartitionData {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
             if &self.diverging_epoch != &Default::default() {
                 let computed_size = types::Struct { version }.compute_size(&self.diverging_epoch)?;
                 if computed_size > std::u32::MAX as usize {
                     error!("Tagged field is too large to encode ({} bytes)", computed_size);
                     return Err(EncodeError);
                 }
-                types::UnsignedVarInt.encode(buf, 0)?;
-                types::UnsignedVarInt.encode(buf, computed_size as u32)?;
+                buf.put_i32(0);
+                buf.put_i32(computed_size as i32);
                 types::Struct { version }.encode(buf, &self.diverging_epoch)?;
             }
             if &self.current_leader != &Default::default() {
@@ -635,8 +635,8 @@ impl Encodable for PartitionData {
                     error!("Tagged field is too large to encode ({} bytes)", computed_size);
                     return Err(EncodeError);
                 }
-                types::UnsignedVarInt.encode(buf, 1)?;
-                types::UnsignedVarInt.encode(buf, computed_size as u32)?;
+                buf.put_i32(1);
+                buf.put_i32(computed_size as i32);
                 types::Struct { version }.encode(buf, &self.current_leader)?;
             }
             if &self.snapshot_id != &Default::default() {
@@ -645,8 +645,8 @@ impl Encodable for PartitionData {
                     error!("Tagged field is too large to encode ({} bytes)", computed_size);
                     return Err(EncodeError);
                 }
-                types::UnsignedVarInt.encode(buf, 2)?;
-                types::UnsignedVarInt.encode(buf, computed_size as u32)?;
+                buf.put_i32(2);
+                buf.put_i32(computed_size as i32);
                 types::Struct { version }.encode(buf, &self.snapshot_id)?;
             }
 
@@ -656,14 +656,14 @@ impl Encodable for PartitionData {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.partition_index)?;
-        total_size += types::Int16.compute_size(&self.error_code)?;
-        total_size += types::Int64.compute_size(&self.high_watermark)?;
+        total_size += 4;
+        total_size += 2;
+        total_size += 8;
         if version >= 4 {
-            total_size += types::Int64.compute_size(&self.last_stable_offset)?;
+            total_size += 8;
         }
         if version >= 5 {
-            total_size += types::Int64.compute_size(&self.log_start_offset)?;
+            total_size += 8;
         }
         if version >= 4 {
             if version >= 12 {
@@ -706,8 +706,8 @@ impl Encodable for PartitionData {
                     error!("Tagged field is too large to encode ({} bytes)", computed_size);
                     return Err(EncodeError);
                 }
-                total_size += types::UnsignedVarInt.compute_size(0)?;
-                total_size += types::UnsignedVarInt.compute_size(computed_size as u32)?;
+                total_size += 4;
+                total_size += 4;
                 total_size += computed_size;
             }
             if &self.current_leader != &Default::default() {
@@ -716,8 +716,8 @@ impl Encodable for PartitionData {
                     error!("Tagged field is too large to encode ({} bytes)", computed_size);
                     return Err(EncodeError);
                 }
-                total_size += types::UnsignedVarInt.compute_size(1)?;
-                total_size += types::UnsignedVarInt.compute_size(computed_size as u32)?;
+                total_size += 4;
+                total_size += 4;
                 total_size += computed_size;
             }
             if &self.snapshot_id != &Default::default() {
@@ -726,8 +726,8 @@ impl Encodable for PartitionData {
                     error!("Tagged field is too large to encode ({} bytes)", computed_size);
                     return Err(EncodeError);
                 }
-                total_size += types::UnsignedVarInt.compute_size(2)?;
-                total_size += types::UnsignedVarInt.compute_size(computed_size as u32)?;
+                total_size += 4;
+                total_size += 4;
                 total_size += computed_size;
             }
 
@@ -739,16 +739,16 @@ impl Encodable for PartitionData {
 
 impl Decodable for PartitionData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let partition_index = types::Int32.decode(buf)?;
-        let error_code = types::Int16.decode(buf)?;
-        let high_watermark = types::Int64.decode(buf)?;
+        let partition_index = buf.try_get_i32()?;
+        let error_code = buf.try_get_i16()?;
+        let high_watermark = buf.try_get_i64()?;
         let last_stable_offset = if version >= 4 {
-            types::Int64.decode(buf)?
+            buf.try_get_i64()?
         } else {
             -1
         };
         let log_start_offset = if version >= 5 {
-            types::Int64.decode(buf)?
+            buf.try_get_i64()?
         } else {
             -1
         };
@@ -879,7 +879,7 @@ impl Encodable for FetchableTopicResponse {
             }
         }
         if version >= 13 {
-            types::Uuid.encode(buf, &self.topic_id)?;
+            types::Uuid.encode(buf, self.topic_id)?;
         }
         if version >= 12 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.partitions)?;
@@ -892,7 +892,7 @@ impl Encodable for FetchableTopicResponse {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -908,7 +908,7 @@ impl Encodable for FetchableTopicResponse {
             }
         }
         if version >= 13 {
-            total_size += types::Uuid.compute_size(&self.topic_id)?;
+            total_size += types::Uuid.compute_size(self.topic_id)?;
         }
         if version >= 12 {
             total_size += types::CompactArray(types::Struct { version }).compute_size(&self.partitions)?;
@@ -1024,13 +1024,13 @@ impl Builder for FetchResponse {
 impl Encodable for FetchResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
         if version >= 1 {
-            types::Int32.encode(buf, &self.throttle_time_ms)?;
+            buf.put_i32(self.throttle_time_ms);
         }
         if version >= 7 {
-            types::Int16.encode(buf, &self.error_code)?;
+            buf.put_i16(self.error_code);
         }
         if version >= 7 {
-            types::Int32.encode(buf, &self.session_id)?;
+            buf.put_i32(self.session_id);
         } else {
             if self.session_id != 0 {
                 return Err(EncodeError)
@@ -1047,7 +1047,7 @@ impl Encodable for FetchResponse {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -1056,13 +1056,13 @@ impl Encodable for FetchResponse {
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
         if version >= 1 {
-            total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
+            total_size += 4;
         }
         if version >= 7 {
-            total_size += types::Int16.compute_size(&self.error_code)?;
+            total_size += 2;
         }
         if version >= 7 {
-            total_size += types::Int32.compute_size(&self.session_id)?;
+            total_size += 4;
         } else {
             if self.session_id != 0 {
                 return Err(EncodeError)
@@ -1090,17 +1090,17 @@ impl Encodable for FetchResponse {
 impl Decodable for FetchResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
         let throttle_time_ms = if version >= 1 {
-            types::Int32.decode(buf)?
+            buf.try_get_i32()?
         } else {
             0
         };
         let error_code = if version >= 7 {
-            types::Int16.decode(buf)?
+            buf.try_get_i16()?
         } else {
             0
         };
         let session_id = if version >= 7 {
-            types::Int32.decode(buf)?
+            buf.try_get_i32()?
         } else {
             0
         };

--- a/src/messages/find_coordinator_request.rs
+++ b/src/messages/find_coordinator_request.rs
@@ -63,7 +63,7 @@ impl Encodable for FindCoordinatorRequest {
             }
         }
         if version >= 1 {
-            types::Int8.encode(buf, &self.key_type)?;
+            buf.put_i8(self.key_type);
         } else {
             if self.key_type != 0 {
                 return Err(EncodeError)
@@ -82,7 +82,7 @@ impl Encodable for FindCoordinatorRequest {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -102,7 +102,7 @@ impl Encodable for FindCoordinatorRequest {
             }
         }
         if version >= 1 {
-            total_size += types::Int8.compute_size(&self.key_type)?;
+            total_size += 1;
         } else {
             if self.key_type != 0 {
                 return Err(EncodeError)
@@ -141,7 +141,7 @@ impl Decodable for FindCoordinatorRequest {
             Default::default()
         };
         let key_type = if version >= 1 {
-            types::Int8.decode(buf)?
+            buf.try_get_i8()?
         } else {
             0
         };

--- a/src/messages/find_coordinator_response.rs
+++ b/src/messages/find_coordinator_response.rs
@@ -88,14 +88,14 @@ impl Encodable for Coordinator {
             }
         }
         if version >= 4 {
-            types::Int32.encode(buf, &self.port)?;
+            buf.put_i32(self.port);
         } else {
             if self.port != 0 {
                 return Err(EncodeError)
             }
         }
         if version >= 4 {
-            types::Int16.encode(buf, &self.error_code)?;
+            buf.put_i16(self.error_code);
         } else {
             if self.error_code != 0 {
                 return Err(EncodeError)
@@ -110,7 +110,7 @@ impl Encodable for Coordinator {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -140,14 +140,14 @@ impl Encodable for Coordinator {
             }
         }
         if version >= 4 {
-            total_size += types::Int32.compute_size(&self.port)?;
+            total_size += 4;
         } else {
             if self.port != 0 {
                 return Err(EncodeError)
             }
         }
         if version >= 4 {
-            total_size += types::Int16.compute_size(&self.error_code)?;
+            total_size += 2;
         } else {
             if self.error_code != 0 {
                 return Err(EncodeError)
@@ -188,12 +188,12 @@ impl Decodable for Coordinator {
             Default::default()
         };
         let port = if version >= 4 {
-            types::Int32.decode(buf)?
+            buf.try_get_i32()?
         } else {
             0
         };
         let error_code = if version >= 4 {
-            types::Int16.decode(buf)?
+            buf.try_get_i16()?
         } else {
             0
         };
@@ -297,10 +297,10 @@ impl Builder for FindCoordinatorResponse {
 impl Encodable for FindCoordinatorResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
         if version >= 1 {
-            types::Int32.encode(buf, &self.throttle_time_ms)?;
+            buf.put_i32(self.throttle_time_ms);
         }
         if version <= 3 {
-            types::Int16.encode(buf, &self.error_code)?;
+            buf.put_i16(self.error_code);
         } else {
             if self.error_code != 0 {
                 return Err(EncodeError)
@@ -332,7 +332,7 @@ impl Encodable for FindCoordinatorResponse {
             }
         }
         if version <= 3 {
-            types::Int32.encode(buf, &self.port)?;
+            buf.put_i32(self.port);
         } else {
             if self.port != 0 {
                 return Err(EncodeError)
@@ -351,7 +351,7 @@ impl Encodable for FindCoordinatorResponse {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -360,10 +360,10 @@ impl Encodable for FindCoordinatorResponse {
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
         if version >= 1 {
-            total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
+            total_size += 4;
         }
         if version <= 3 {
-            total_size += types::Int16.compute_size(&self.error_code)?;
+            total_size += 2;
         } else {
             if self.error_code != 0 {
                 return Err(EncodeError)
@@ -395,7 +395,7 @@ impl Encodable for FindCoordinatorResponse {
             }
         }
         if version <= 3 {
-            total_size += types::Int32.compute_size(&self.port)?;
+            total_size += 4;
         } else {
             if self.port != 0 {
                 return Err(EncodeError)
@@ -425,12 +425,12 @@ impl Encodable for FindCoordinatorResponse {
 impl Decodable for FindCoordinatorResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
         let throttle_time_ms = if version >= 1 {
-            types::Int32.decode(buf)?
+            buf.try_get_i32()?
         } else {
             0
         };
         let error_code = if version <= 3 {
-            types::Int16.decode(buf)?
+            buf.try_get_i16()?
         } else {
             0
         };
@@ -458,7 +458,7 @@ impl Decodable for FindCoordinatorResponse {
             Default::default()
         };
         let port = if version <= 3 {
-            types::Int32.decode(buf)?
+            buf.try_get_i32()?
         } else {
             0
         };

--- a/src/messages/heartbeat_request.rs
+++ b/src/messages/heartbeat_request.rs
@@ -61,7 +61,7 @@ impl Encodable for HeartbeatRequest {
         } else {
             types::String.encode(buf, &self.group_id)?;
         }
-        types::Int32.encode(buf, &self.generation_id)?;
+        buf.put_i32(self.generation_id);
         if version >= 4 {
             types::CompactString.encode(buf, &self.member_id)?;
         } else {
@@ -84,7 +84,7 @@ impl Encodable for HeartbeatRequest {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -97,7 +97,7 @@ impl Encodable for HeartbeatRequest {
         } else {
             total_size += types::String.compute_size(&self.group_id)?;
         }
-        total_size += types::Int32.compute_size(&self.generation_id)?;
+        total_size += 4;
         if version >= 4 {
             total_size += types::CompactString.compute_size(&self.member_id)?;
         } else {
@@ -135,7 +135,7 @@ impl Decodable for HeartbeatRequest {
         } else {
             types::String.decode(buf)?
         };
-        let generation_id = types::Int32.decode(buf)?;
+        let generation_id = buf.try_get_i32()?;
         let member_id = if version >= 4 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/heartbeat_response.rs
+++ b/src/messages/heartbeat_response.rs
@@ -47,16 +47,16 @@ impl Builder for HeartbeatResponse {
 impl Encodable for HeartbeatResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
         if version >= 1 {
-            types::Int32.encode(buf, &self.throttle_time_ms)?;
+            buf.put_i32(self.throttle_time_ms);
         }
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i16(self.error_code);
         if version >= 4 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -65,9 +65,9 @@ impl Encodable for HeartbeatResponse {
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
         if version >= 1 {
-            total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
+            total_size += 4;
         }
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 2;
         if version >= 4 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
@@ -85,11 +85,11 @@ impl Encodable for HeartbeatResponse {
 impl Decodable for HeartbeatResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
         let throttle_time_ms = if version >= 1 {
-            types::Int32.decode(buf)?
+            buf.try_get_i32()?
         } else {
             0
         };
-        let error_code = types::Int16.decode(buf)?;
+        let error_code = buf.try_get_i16()?;
         let mut unknown_tagged_fields = BTreeMap::new();
         if version >= 4 {
             let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;

--- a/src/messages/incremental_alter_configs_request.rs
+++ b/src/messages/incremental_alter_configs_request.rs
@@ -56,7 +56,7 @@ impl Encodable for AlterableConfig {
         } else {
             types::String.encode(buf, &self.name)?;
         }
-        types::Int8.encode(buf, &self.config_operation)?;
+        buf.put_i8(self.config_operation);
         if version >= 1 {
             types::CompactString.encode(buf, &self.value)?;
         } else {
@@ -68,7 +68,7 @@ impl Encodable for AlterableConfig {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -81,7 +81,7 @@ impl Encodable for AlterableConfig {
         } else {
             total_size += types::String.compute_size(&self.name)?;
         }
-        total_size += types::Int8.compute_size(&self.config_operation)?;
+        total_size += 1;
         if version >= 1 {
             total_size += types::CompactString.compute_size(&self.value)?;
         } else {
@@ -108,7 +108,7 @@ impl Decodable for AlterableConfig {
         } else {
             types::String.decode(buf)?
         };
-        let config_operation = types::Int8.decode(buf)?;
+        let config_operation = buf.try_get_i8()?;
         let value = if version >= 1 {
             types::CompactString.decode(buf)?
         } else {
@@ -182,7 +182,7 @@ impl Builder for AlterConfigsResource {
 
 impl Encodable for AlterConfigsResource {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int8.encode(buf, &self.resource_type)?;
+        buf.put_i8(self.resource_type);
         if version >= 1 {
             types::CompactString.encode(buf, &self.resource_name)?;
         } else {
@@ -199,7 +199,7 @@ impl Encodable for AlterConfigsResource {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -207,7 +207,7 @@ impl Encodable for AlterConfigsResource {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int8.compute_size(&self.resource_type)?;
+        total_size += 1;
         if version >= 1 {
             total_size += types::CompactString.compute_size(&self.resource_name)?;
         } else {
@@ -234,7 +234,7 @@ impl Encodable for AlterConfigsResource {
 
 impl Decodable for AlterConfigsResource {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let resource_type = types::Int8.decode(buf)?;
+        let resource_type = buf.try_get_i8()?;
         let resource_name = if version >= 1 {
             types::CompactString.decode(buf)?
         } else {
@@ -313,14 +313,14 @@ impl Encodable for IncrementalAlterConfigsRequest {
         } else {
             types::Array(types::Struct { version }).encode(buf, &self.resources)?;
         }
-        types::Boolean.encode(buf, &self.validate_only)?;
+        types::Boolean.encode(buf, self.validate_only)?;
         if version >= 1 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -333,7 +333,7 @@ impl Encodable for IncrementalAlterConfigsRequest {
         } else {
             total_size += types::Array(types::Struct { version }).compute_size(&self.resources)?;
         }
-        total_size += types::Boolean.compute_size(&self.validate_only)?;
+        total_size += types::Boolean.compute_size(self.validate_only)?;
         if version >= 1 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {

--- a/src/messages/incremental_alter_configs_response.rs
+++ b/src/messages/incremental_alter_configs_response.rs
@@ -56,13 +56,13 @@ impl Builder for AlterConfigsResourceResponse {
 
 impl Encodable for AlterConfigsResourceResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i16(self.error_code);
         if version >= 1 {
             types::CompactString.encode(buf, &self.error_message)?;
         } else {
             types::String.encode(buf, &self.error_message)?;
         }
-        types::Int8.encode(buf, &self.resource_type)?;
+        buf.put_i8(self.resource_type);
         if version >= 1 {
             types::CompactString.encode(buf, &self.resource_name)?;
         } else {
@@ -74,7 +74,7 @@ impl Encodable for AlterConfigsResourceResponse {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -82,13 +82,13 @@ impl Encodable for AlterConfigsResourceResponse {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 2;
         if version >= 1 {
             total_size += types::CompactString.compute_size(&self.error_message)?;
         } else {
             total_size += types::String.compute_size(&self.error_message)?;
         }
-        total_size += types::Int8.compute_size(&self.resource_type)?;
+        total_size += 1;
         if version >= 1 {
             total_size += types::CompactString.compute_size(&self.resource_name)?;
         } else {
@@ -110,13 +110,13 @@ impl Encodable for AlterConfigsResourceResponse {
 
 impl Decodable for AlterConfigsResourceResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let error_code = types::Int16.decode(buf)?;
+        let error_code = buf.try_get_i16()?;
         let error_message = if version >= 1 {
             types::CompactString.decode(buf)?
         } else {
             types::String.decode(buf)?
         };
-        let resource_type = types::Int8.decode(buf)?;
+        let resource_type = buf.try_get_i8()?;
         let resource_name = if version >= 1 {
             types::CompactString.decode(buf)?
         } else {
@@ -187,7 +187,7 @@ impl Builder for IncrementalAlterConfigsResponse {
 
 impl Encodable for IncrementalAlterConfigsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.throttle_time_ms)?;
+        buf.put_i32(self.throttle_time_ms);
         if version >= 1 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.responses)?;
         } else {
@@ -199,7 +199,7 @@ impl Encodable for IncrementalAlterConfigsResponse {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -207,7 +207,7 @@ impl Encodable for IncrementalAlterConfigsResponse {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
+        total_size += 4;
         if version >= 1 {
             total_size += types::CompactArray(types::Struct { version }).compute_size(&self.responses)?;
         } else {
@@ -229,7 +229,7 @@ impl Encodable for IncrementalAlterConfigsResponse {
 
 impl Decodable for IncrementalAlterConfigsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let throttle_time_ms = types::Int32.decode(buf)?;
+        let throttle_time_ms = buf.try_get_i32()?;
         let responses = if version >= 1 {
             types::CompactArray(types::Struct { version }).decode(buf)?
         } else {

--- a/src/messages/init_producer_id_request.rs
+++ b/src/messages/init_producer_id_request.rs
@@ -61,7 +61,7 @@ impl Encodable for InitProducerIdRequest {
         } else {
             types::String.encode(buf, &self.transactional_id)?;
         }
-        types::Int32.encode(buf, &self.transaction_timeout_ms)?;
+        buf.put_i32(self.transaction_timeout_ms);
         if version >= 3 {
             types::Int64.encode(buf, &self.producer_id)?;
         } else {
@@ -70,7 +70,7 @@ impl Encodable for InitProducerIdRequest {
             }
         }
         if version >= 3 {
-            types::Int16.encode(buf, &self.producer_epoch)?;
+            buf.put_i16(self.producer_epoch);
         } else {
             if self.producer_epoch != -1 {
                 return Err(EncodeError)
@@ -82,7 +82,7 @@ impl Encodable for InitProducerIdRequest {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -95,7 +95,7 @@ impl Encodable for InitProducerIdRequest {
         } else {
             total_size += types::String.compute_size(&self.transactional_id)?;
         }
-        total_size += types::Int32.compute_size(&self.transaction_timeout_ms)?;
+        total_size += 4;
         if version >= 3 {
             total_size += types::Int64.compute_size(&self.producer_id)?;
         } else {
@@ -104,7 +104,7 @@ impl Encodable for InitProducerIdRequest {
             }
         }
         if version >= 3 {
-            total_size += types::Int16.compute_size(&self.producer_epoch)?;
+            total_size += 2;
         } else {
             if self.producer_epoch != -1 {
                 return Err(EncodeError)
@@ -131,14 +131,14 @@ impl Decodable for InitProducerIdRequest {
         } else {
             types::String.decode(buf)?
         };
-        let transaction_timeout_ms = types::Int32.decode(buf)?;
+        let transaction_timeout_ms = buf.try_get_i32()?;
         let producer_id = if version >= 3 {
             types::Int64.decode(buf)?
         } else {
             (-1).into()
         };
         let producer_epoch = if version >= 3 {
-            types::Int16.decode(buf)?
+            buf.try_get_i16()?
         } else {
             -1
         };

--- a/src/messages/init_producer_id_response.rs
+++ b/src/messages/init_producer_id_response.rs
@@ -56,17 +56,17 @@ impl Builder for InitProducerIdResponse {
 
 impl Encodable for InitProducerIdResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.throttle_time_ms)?;
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i32(self.throttle_time_ms);
+        buf.put_i16(self.error_code);
         types::Int64.encode(buf, &self.producer_id)?;
-        types::Int16.encode(buf, &self.producer_epoch)?;
+        buf.put_i16(self.producer_epoch);
         if version >= 2 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -74,10 +74,10 @@ impl Encodable for InitProducerIdResponse {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 4;
+        total_size += 2;
         total_size += types::Int64.compute_size(&self.producer_id)?;
-        total_size += types::Int16.compute_size(&self.producer_epoch)?;
+        total_size += 2;
         if version >= 2 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
@@ -94,10 +94,10 @@ impl Encodable for InitProducerIdResponse {
 
 impl Decodable for InitProducerIdResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let throttle_time_ms = types::Int32.decode(buf)?;
-        let error_code = types::Int16.decode(buf)?;
+        let throttle_time_ms = buf.try_get_i32()?;
+        let error_code = buf.try_get_i16()?;
         let producer_id = types::Int64.decode(buf)?;
-        let producer_epoch = types::Int16.decode(buf)?;
+        let producer_epoch = buf.try_get_i16()?;
         let mut unknown_tagged_fields = BTreeMap::new();
         if version >= 2 {
             let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;

--- a/src/messages/join_group_request.rs
+++ b/src/messages/join_group_request.rs
@@ -58,7 +58,7 @@ impl MapEncodable for JoinGroupRequestProtocol {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -197,9 +197,9 @@ impl Encodable for JoinGroupRequest {
         } else {
             types::String.encode(buf, &self.group_id)?;
         }
-        types::Int32.encode(buf, &self.session_timeout_ms)?;
+        buf.put_i32(self.session_timeout_ms);
         if version >= 1 {
-            types::Int32.encode(buf, &self.rebalance_timeout_ms)?;
+            buf.put_i32(self.rebalance_timeout_ms);
         }
         if version >= 6 {
             types::CompactString.encode(buf, &self.member_id)?;
@@ -236,7 +236,7 @@ impl Encodable for JoinGroupRequest {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -249,9 +249,9 @@ impl Encodable for JoinGroupRequest {
         } else {
             total_size += types::String.compute_size(&self.group_id)?;
         }
-        total_size += types::Int32.compute_size(&self.session_timeout_ms)?;
+        total_size += 4;
         if version >= 1 {
-            total_size += types::Int32.compute_size(&self.rebalance_timeout_ms)?;
+            total_size += 4;
         }
         if version >= 6 {
             total_size += types::CompactString.compute_size(&self.member_id)?;
@@ -303,9 +303,9 @@ impl Decodable for JoinGroupRequest {
         } else {
             types::String.decode(buf)?
         };
-        let session_timeout_ms = types::Int32.decode(buf)?;
+        let session_timeout_ms = buf.try_get_i32()?;
         let rebalance_timeout_ms = if version >= 1 {
-            types::Int32.decode(buf)?
+            buf.try_get_i32()?
         } else {
             -1
         };

--- a/src/messages/leader_and_isr_request.rs
+++ b/src/messages/leader_and_isr_request.rs
@@ -99,16 +99,16 @@ impl Encodable for LeaderAndIsrPartitionState {
         if version <= 1 {
             types::String.encode(buf, &self.topic_name)?;
         }
-        types::Int32.encode(buf, &self.partition_index)?;
-        types::Int32.encode(buf, &self.controller_epoch)?;
+        buf.put_i32(self.partition_index);
+        buf.put_i32(self.controller_epoch);
         types::Int32.encode(buf, &self.leader)?;
-        types::Int32.encode(buf, &self.leader_epoch)?;
+        buf.put_i32(self.leader_epoch);
         if version >= 4 {
             types::CompactArray(types::Int32).encode(buf, &self.isr)?;
         } else {
             types::Array(types::Int32).encode(buf, &self.isr)?;
         }
-        types::Int32.encode(buf, &self.partition_epoch)?;
+        buf.put_i32(self.partition_epoch);
         if version >= 4 {
             types::CompactArray(types::Int32).encode(buf, &self.replicas)?;
         } else {
@@ -129,10 +129,10 @@ impl Encodable for LeaderAndIsrPartitionState {
             }
         }
         if version >= 1 {
-            types::Boolean.encode(buf, &self.is_new)?;
+            types::Boolean.encode(buf, self.is_new)?;
         }
         if version >= 6 {
-            types::Int8.encode(buf, &self.leader_recovery_state)?;
+            buf.put_i8(self.leader_recovery_state);
         } else {
             if self.leader_recovery_state != 0 {
                 return Err(EncodeError)
@@ -144,7 +144,7 @@ impl Encodable for LeaderAndIsrPartitionState {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -155,16 +155,16 @@ impl Encodable for LeaderAndIsrPartitionState {
         if version <= 1 {
             total_size += types::String.compute_size(&self.topic_name)?;
         }
-        total_size += types::Int32.compute_size(&self.partition_index)?;
-        total_size += types::Int32.compute_size(&self.controller_epoch)?;
+        total_size += 4;
+        total_size += 4;
         total_size += types::Int32.compute_size(&self.leader)?;
-        total_size += types::Int32.compute_size(&self.leader_epoch)?;
+        total_size += 4;
         if version >= 4 {
             total_size += types::CompactArray(types::Int32).compute_size(&self.isr)?;
         } else {
             total_size += types::Array(types::Int32).compute_size(&self.isr)?;
         }
-        total_size += types::Int32.compute_size(&self.partition_epoch)?;
+        total_size += 4;
         if version >= 4 {
             total_size += types::CompactArray(types::Int32).compute_size(&self.replicas)?;
         } else {
@@ -185,10 +185,10 @@ impl Encodable for LeaderAndIsrPartitionState {
             }
         }
         if version >= 1 {
-            total_size += types::Boolean.compute_size(&self.is_new)?;
+            total_size += types::Boolean.compute_size(self.is_new)?;
         }
         if version >= 6 {
-            total_size += types::Int8.compute_size(&self.leader_recovery_state)?;
+            total_size += 1;
         } else {
             if self.leader_recovery_state != 0 {
                 return Err(EncodeError)
@@ -215,16 +215,16 @@ impl Decodable for LeaderAndIsrPartitionState {
         } else {
             Default::default()
         };
-        let partition_index = types::Int32.decode(buf)?;
-        let controller_epoch = types::Int32.decode(buf)?;
+        let partition_index = buf.try_get_i32()?;
+        let controller_epoch = buf.try_get_i32()?;
         let leader = types::Int32.decode(buf)?;
-        let leader_epoch = types::Int32.decode(buf)?;
+        let leader_epoch = buf.try_get_i32()?;
         let isr = if version >= 4 {
             types::CompactArray(types::Int32).decode(buf)?
         } else {
             types::Array(types::Int32).decode(buf)?
         };
-        let partition_epoch = types::Int32.decode(buf)?;
+        let partition_epoch = buf.try_get_i32()?;
         let replicas = if version >= 4 {
             types::CompactArray(types::Int32).decode(buf)?
         } else {
@@ -254,7 +254,7 @@ impl Decodable for LeaderAndIsrPartitionState {
             false
         };
         let leader_recovery_state = if version >= 6 {
-            types::Int8.decode(buf)?
+            buf.try_get_i8()?
         } else {
             0
         };
@@ -356,7 +356,7 @@ impl Encodable for LeaderAndIsrTopicState {
             }
         }
         if version >= 5 {
-            types::Uuid.encode(buf, &self.topic_id)?;
+            types::Uuid.encode(buf, self.topic_id)?;
         }
         if version >= 2 {
             if version >= 4 {
@@ -375,7 +375,7 @@ impl Encodable for LeaderAndIsrTopicState {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -395,7 +395,7 @@ impl Encodable for LeaderAndIsrTopicState {
             }
         }
         if version >= 5 {
-            total_size += types::Uuid.compute_size(&self.topic_id)?;
+            total_size += types::Uuid.compute_size(self.topic_id)?;
         }
         if version >= 2 {
             if version >= 4 {
@@ -521,14 +521,14 @@ impl Encodable for LeaderAndIsrLiveLeader {
         } else {
             types::String.encode(buf, &self.host_name)?;
         }
-        types::Int32.encode(buf, &self.port)?;
+        buf.put_i32(self.port);
         if version >= 4 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -542,7 +542,7 @@ impl Encodable for LeaderAndIsrLiveLeader {
         } else {
             total_size += types::String.compute_size(&self.host_name)?;
         }
-        total_size += types::Int32.compute_size(&self.port)?;
+        total_size += 4;
         if version >= 4 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
@@ -565,7 +565,7 @@ impl Decodable for LeaderAndIsrLiveLeader {
         } else {
             types::String.decode(buf)?
         };
-        let port = types::Int32.decode(buf)?;
+        let port = buf.try_get_i32()?;
         let mut unknown_tagged_fields = BTreeMap::new();
         if version >= 4 {
             let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
@@ -655,12 +655,12 @@ impl Builder for LeaderAndIsrRequest {
 impl Encodable for LeaderAndIsrRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
         types::Int32.encode(buf, &self.controller_id)?;
-        types::Int32.encode(buf, &self.controller_epoch)?;
+        buf.put_i32(self.controller_epoch);
         if version >= 2 {
-            types::Int64.encode(buf, &self.broker_epoch)?;
+            buf.put_i64(self.broker_epoch);
         }
         if version >= 5 {
-            types::Int8.encode(buf, &self._type)?;
+            buf.put_i8(self._type);
         } else {
             if self._type != 0 {
                 return Err(EncodeError)
@@ -695,7 +695,7 @@ impl Encodable for LeaderAndIsrRequest {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -704,12 +704,12 @@ impl Encodable for LeaderAndIsrRequest {
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
         total_size += types::Int32.compute_size(&self.controller_id)?;
-        total_size += types::Int32.compute_size(&self.controller_epoch)?;
+        total_size += 4;
         if version >= 2 {
-            total_size += types::Int64.compute_size(&self.broker_epoch)?;
+            total_size += 8;
         }
         if version >= 5 {
-            total_size += types::Int8.compute_size(&self._type)?;
+            total_size += 1;
         } else {
             if self._type != 0 {
                 return Err(EncodeError)
@@ -755,14 +755,14 @@ impl Encodable for LeaderAndIsrRequest {
 impl Decodable for LeaderAndIsrRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
         let controller_id = types::Int32.decode(buf)?;
-        let controller_epoch = types::Int32.decode(buf)?;
+        let controller_epoch = buf.try_get_i32()?;
         let broker_epoch = if version >= 2 {
-            types::Int64.decode(buf)?
+            buf.try_get_i64()?
         } else {
             -1
         };
         let _type = if version >= 5 {
-            types::Int8.decode(buf)?
+            buf.try_get_i8()?
         } else {
             0
         };

--- a/src/messages/leader_and_isr_response.rs
+++ b/src/messages/leader_and_isr_response.rs
@@ -58,15 +58,15 @@ impl Encodable for LeaderAndIsrPartitionError {
                 types::String.encode(buf, &self.topic_name)?;
             }
         }
-        types::Int32.encode(buf, &self.partition_index)?;
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i32(self.partition_index);
+        buf.put_i16(self.error_code);
         if version >= 4 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -81,8 +81,8 @@ impl Encodable for LeaderAndIsrPartitionError {
                 total_size += types::String.compute_size(&self.topic_name)?;
             }
         }
-        total_size += types::Int32.compute_size(&self.partition_index)?;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 4;
+        total_size += 2;
         if version >= 4 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
@@ -108,8 +108,8 @@ impl Decodable for LeaderAndIsrPartitionError {
         } else {
             Default::default()
         };
-        let partition_index = types::Int32.decode(buf)?;
-        let error_code = types::Int16.decode(buf)?;
+        let partition_index = buf.try_get_i32()?;
+        let error_code = buf.try_get_i16()?;
         let mut unknown_tagged_fields = BTreeMap::new();
         if version >= 4 {
             let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
@@ -170,9 +170,9 @@ impl MapEncodable for LeaderAndIsrTopicError {
     type Key = Uuid;
     fn encode<B: ByteBufMut>(&self, key: &Self::Key, buf: &mut B, version: i16) -> Result<(), EncodeError> {
         if version >= 5 {
-            types::Uuid.encode(buf, key)?;
+            types::Uuid.encode(buf, *key)?;
         } else {
-            if key != &Uuid::nil() {
+            if *key != Uuid::nil() {
                 return Err(EncodeError)
             }
         }
@@ -189,7 +189,7 @@ impl MapEncodable for LeaderAndIsrTopicError {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -198,9 +198,9 @@ impl MapEncodable for LeaderAndIsrTopicError {
     fn compute_size(&self, key: &Self::Key, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
         if version >= 5 {
-            total_size += types::Uuid.compute_size(key)?;
+            total_size += types::Uuid.compute_size(*key)?;
         } else {
-            if key != &Uuid::nil() {
+            if *key != Uuid::nil() {
                 return Err(EncodeError)
             }
         }
@@ -302,7 +302,7 @@ impl Builder for LeaderAndIsrResponse {
 
 impl Encodable for LeaderAndIsrResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i16(self.error_code);
         if version <= 4 {
             if version >= 4 {
                 types::CompactArray(types::Struct { version }).encode(buf, &self.partition_errors)?;
@@ -327,7 +327,7 @@ impl Encodable for LeaderAndIsrResponse {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -335,7 +335,7 @@ impl Encodable for LeaderAndIsrResponse {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 2;
         if version <= 4 {
             if version >= 4 {
                 total_size += types::CompactArray(types::Struct { version }).compute_size(&self.partition_errors)?;
@@ -370,7 +370,7 @@ impl Encodable for LeaderAndIsrResponse {
 
 impl Decodable for LeaderAndIsrResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let error_code = types::Int16.decode(buf)?;
+        let error_code = buf.try_get_i16()?;
         let partition_errors = if version <= 4 {
             if version >= 4 {
                 types::CompactArray(types::Struct { version }).decode(buf)?

--- a/src/messages/leave_group_request.rs
+++ b/src/messages/leave_group_request.rs
@@ -82,7 +82,7 @@ impl Encodable for MemberIdentity {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -251,7 +251,7 @@ impl Encodable for LeaveGroupRequest {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }

--- a/src/messages/leave_group_response.rs
+++ b/src/messages/leave_group_response.rs
@@ -74,7 +74,7 @@ impl Encodable for MemberResponse {
             }
         }
         if version >= 3 {
-            types::Int16.encode(buf, &self.error_code)?;
+            buf.put_i16(self.error_code);
         } else {
             if self.error_code != 0 {
                 return Err(EncodeError)
@@ -86,7 +86,7 @@ impl Encodable for MemberResponse {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -117,7 +117,7 @@ impl Encodable for MemberResponse {
             }
         }
         if version >= 3 {
-            total_size += types::Int16.compute_size(&self.error_code)?;
+            total_size += 2;
         } else {
             if self.error_code != 0 {
                 return Err(EncodeError)
@@ -158,7 +158,7 @@ impl Decodable for MemberResponse {
             Some(Default::default())
         };
         let error_code = if version >= 3 {
-            types::Int16.decode(buf)?
+            buf.try_get_i16()?
         } else {
             0
         };
@@ -231,9 +231,9 @@ impl Builder for LeaveGroupResponse {
 impl Encodable for LeaveGroupResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
         if version >= 1 {
-            types::Int32.encode(buf, &self.throttle_time_ms)?;
+            buf.put_i32(self.throttle_time_ms);
         }
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i16(self.error_code);
         if version >= 3 {
             if version >= 4 {
                 types::CompactArray(types::Struct { version }).encode(buf, &self.members)?;
@@ -251,7 +251,7 @@ impl Encodable for LeaveGroupResponse {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -260,9 +260,9 @@ impl Encodable for LeaveGroupResponse {
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
         if version >= 1 {
-            total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
+            total_size += 4;
         }
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 2;
         if version >= 3 {
             if version >= 4 {
                 total_size += types::CompactArray(types::Struct { version }).compute_size(&self.members)?;
@@ -291,11 +291,11 @@ impl Encodable for LeaveGroupResponse {
 impl Decodable for LeaveGroupResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
         let throttle_time_ms = if version >= 1 {
-            types::Int32.decode(buf)?
+            buf.try_get_i32()?
         } else {
             0
         };
-        let error_code = types::Int16.decode(buf)?;
+        let error_code = buf.try_get_i16()?;
         let members = if version >= 3 {
             if version >= 4 {
                 types::CompactArray(types::Struct { version }).decode(buf)?

--- a/src/messages/list_groups_request.rs
+++ b/src/messages/list_groups_request.rs
@@ -54,7 +54,7 @@ impl Encodable for ListGroupsRequest {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }

--- a/src/messages/list_offsets_request.rs
+++ b/src/messages/list_offsets_request.rs
@@ -56,13 +56,13 @@ impl Builder for ListOffsetsPartition {
 
 impl Encodable for ListOffsetsPartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.partition_index)?;
+        buf.put_i32(self.partition_index);
         if version >= 4 {
-            types::Int32.encode(buf, &self.current_leader_epoch)?;
+            buf.put_i32(self.current_leader_epoch);
         }
-        types::Int64.encode(buf, &self.timestamp)?;
+        buf.put_i64(self.timestamp);
         if version == 0 {
-            types::Int32.encode(buf, &self.max_num_offsets)?;
+            buf.put_i32(self.max_num_offsets);
         } else {
             if self.max_num_offsets != 1 {
                 return Err(EncodeError)
@@ -74,7 +74,7 @@ impl Encodable for ListOffsetsPartition {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -82,13 +82,13 @@ impl Encodable for ListOffsetsPartition {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.partition_index)?;
+        total_size += 4;
         if version >= 4 {
-            total_size += types::Int32.compute_size(&self.current_leader_epoch)?;
+            total_size += 4;
         }
-        total_size += types::Int64.compute_size(&self.timestamp)?;
+        total_size += 8;
         if version == 0 {
-            total_size += types::Int32.compute_size(&self.max_num_offsets)?;
+            total_size += 4;
         } else {
             if self.max_num_offsets != 1 {
                 return Err(EncodeError)
@@ -110,15 +110,15 @@ impl Encodable for ListOffsetsPartition {
 
 impl Decodable for ListOffsetsPartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let partition_index = types::Int32.decode(buf)?;
+        let partition_index = buf.try_get_i32()?;
         let current_leader_epoch = if version >= 4 {
-            types::Int32.decode(buf)?
+            buf.try_get_i32()?
         } else {
             -1
         };
-        let timestamp = types::Int64.decode(buf)?;
+        let timestamp = buf.try_get_i64()?;
         let max_num_offsets = if version == 0 {
-            types::Int32.decode(buf)?
+            buf.try_get_i32()?
         } else {
             1
         };
@@ -203,7 +203,7 @@ impl Encodable for ListOffsetsTopic {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -315,7 +315,7 @@ impl Encodable for ListOffsetsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
         types::Int32.encode(buf, &self.replica_id)?;
         if version >= 2 {
-            types::Int8.encode(buf, &self.isolation_level)?;
+            buf.put_i8(self.isolation_level);
         } else {
             if self.isolation_level != 0 {
                 return Err(EncodeError)
@@ -332,7 +332,7 @@ impl Encodable for ListOffsetsRequest {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -342,7 +342,7 @@ impl Encodable for ListOffsetsRequest {
         let mut total_size = 0;
         total_size += types::Int32.compute_size(&self.replica_id)?;
         if version >= 2 {
-            total_size += types::Int8.compute_size(&self.isolation_level)?;
+            total_size += 1;
         } else {
             if self.isolation_level != 0 {
                 return Err(EncodeError)
@@ -371,7 +371,7 @@ impl Decodable for ListOffsetsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
         let replica_id = types::Int32.decode(buf)?;
         let isolation_level = if version >= 2 {
-            types::Int8.decode(buf)?
+            buf.try_get_i8()?
         } else {
             0
         };

--- a/src/messages/list_offsets_response.rs
+++ b/src/messages/list_offsets_response.rs
@@ -66,8 +66,8 @@ impl Builder for ListOffsetsPartitionResponse {
 
 impl Encodable for ListOffsetsPartitionResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.partition_index)?;
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i32(self.partition_index);
+        buf.put_i16(self.error_code);
         if version == 0 {
             types::Array(types::Int64).encode(buf, &self.old_style_offsets)?;
         } else {
@@ -76,21 +76,21 @@ impl Encodable for ListOffsetsPartitionResponse {
             }
         }
         if version >= 1 {
-            types::Int64.encode(buf, &self.timestamp)?;
+            buf.put_i64(self.timestamp);
         } else {
             if self.timestamp != -1 {
                 return Err(EncodeError)
             }
         }
         if version >= 1 {
-            types::Int64.encode(buf, &self.offset)?;
+            buf.put_i64(self.offset);
         } else {
             if self.offset != -1 {
                 return Err(EncodeError)
             }
         }
         if version >= 4 {
-            types::Int32.encode(buf, &self.leader_epoch)?;
+            buf.put_i32(self.leader_epoch);
         } else {
             if self.leader_epoch != -1 {
                 return Err(EncodeError)
@@ -102,7 +102,7 @@ impl Encodable for ListOffsetsPartitionResponse {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -110,8 +110,8 @@ impl Encodable for ListOffsetsPartitionResponse {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.partition_index)?;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 4;
+        total_size += 2;
         if version == 0 {
             total_size += types::Array(types::Int64).compute_size(&self.old_style_offsets)?;
         } else {
@@ -120,21 +120,21 @@ impl Encodable for ListOffsetsPartitionResponse {
             }
         }
         if version >= 1 {
-            total_size += types::Int64.compute_size(&self.timestamp)?;
+            total_size += 8;
         } else {
             if self.timestamp != -1 {
                 return Err(EncodeError)
             }
         }
         if version >= 1 {
-            total_size += types::Int64.compute_size(&self.offset)?;
+            total_size += 8;
         } else {
             if self.offset != -1 {
                 return Err(EncodeError)
             }
         }
         if version >= 4 {
-            total_size += types::Int32.compute_size(&self.leader_epoch)?;
+            total_size += 4;
         } else {
             if self.leader_epoch != -1 {
                 return Err(EncodeError)
@@ -156,25 +156,25 @@ impl Encodable for ListOffsetsPartitionResponse {
 
 impl Decodable for ListOffsetsPartitionResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let partition_index = types::Int32.decode(buf)?;
-        let error_code = types::Int16.decode(buf)?;
+        let partition_index = buf.try_get_i32()?;
+        let error_code = buf.try_get_i16()?;
         let old_style_offsets = if version == 0 {
             types::Array(types::Int64).decode(buf)?
         } else {
             Default::default()
         };
         let timestamp = if version >= 1 {
-            types::Int64.decode(buf)?
+            buf.try_get_i64()?
         } else {
             -1
         };
         let offset = if version >= 1 {
-            types::Int64.decode(buf)?
+            buf.try_get_i64()?
         } else {
             -1
         };
         let leader_epoch = if version >= 4 {
-            types::Int32.decode(buf)?
+            buf.try_get_i32()?
         } else {
             -1
         };
@@ -263,7 +263,7 @@ impl Encodable for ListOffsetsTopicResponse {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -369,7 +369,7 @@ impl Builder for ListOffsetsResponse {
 impl Encodable for ListOffsetsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
         if version >= 2 {
-            types::Int32.encode(buf, &self.throttle_time_ms)?;
+            buf.put_i32(self.throttle_time_ms);
         }
         if version >= 6 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
@@ -382,7 +382,7 @@ impl Encodable for ListOffsetsResponse {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -391,7 +391,7 @@ impl Encodable for ListOffsetsResponse {
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
         if version >= 2 {
-            total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
+            total_size += 4;
         }
         if version >= 6 {
             total_size += types::CompactArray(types::Struct { version }).compute_size(&self.topics)?;
@@ -415,7 +415,7 @@ impl Encodable for ListOffsetsResponse {
 impl Decodable for ListOffsetsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
         let throttle_time_ms = if version >= 2 {
-            types::Int32.decode(buf)?
+            buf.try_get_i32()?
         } else {
             0
         };

--- a/src/messages/list_partition_reassignments_request.rs
+++ b/src/messages/list_partition_reassignments_request.rs
@@ -53,7 +53,7 @@ impl Encodable for ListPartitionReassignmentsTopics {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
@@ -137,21 +137,21 @@ impl Builder for ListPartitionReassignmentsRequest {
 
 impl Encodable for ListPartitionReassignmentsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.timeout_ms)?;
+        buf.put_i32(self.timeout_ms);
         types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.timeout_ms)?;
+        total_size += 4;
         total_size += types::CompactArray(types::Struct { version }).compute_size(&self.topics)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
@@ -167,7 +167,7 @@ impl Encodable for ListPartitionReassignmentsRequest {
 
 impl Decodable for ListPartitionReassignmentsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let timeout_ms = types::Int32.decode(buf)?;
+        let timeout_ms = buf.try_get_i32()?;
         let topics = types::CompactArray(types::Struct { version }).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
         let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;

--- a/src/messages/list_partition_reassignments_response.rs
+++ b/src/messages/list_partition_reassignments_response.rs
@@ -56,7 +56,7 @@ impl Builder for OngoingPartitionReassignment {
 
 impl Encodable for OngoingPartitionReassignment {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.partition_index)?;
+        buf.put_i32(self.partition_index);
         types::CompactArray(types::Int32).encode(buf, &self.replicas)?;
         types::CompactArray(types::Int32).encode(buf, &self.adding_replicas)?;
         types::CompactArray(types::Int32).encode(buf, &self.removing_replicas)?;
@@ -65,14 +65,14 @@ impl Encodable for OngoingPartitionReassignment {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.partition_index)?;
+        total_size += 4;
         total_size += types::CompactArray(types::Int32).compute_size(&self.replicas)?;
         total_size += types::CompactArray(types::Int32).compute_size(&self.adding_replicas)?;
         total_size += types::CompactArray(types::Int32).compute_size(&self.removing_replicas)?;
@@ -90,7 +90,7 @@ impl Encodable for OngoingPartitionReassignment {
 
 impl Decodable for OngoingPartitionReassignment {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let partition_index = types::Int32.decode(buf)?;
+        let partition_index = buf.try_get_i32()?;
         let replicas = types::CompactArray(types::Int32).decode(buf)?;
         let adding_replicas = types::CompactArray(types::Int32).decode(buf)?;
         let removing_replicas = types::CompactArray(types::Int32).decode(buf)?;
@@ -164,7 +164,7 @@ impl Encodable for OngoingTopicReassignment {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
@@ -258,8 +258,8 @@ impl Builder for ListPartitionReassignmentsResponse {
 
 impl Encodable for ListPartitionReassignmentsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.throttle_time_ms)?;
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i32(self.throttle_time_ms);
+        buf.put_i16(self.error_code);
         types::CompactString.encode(buf, &self.error_message)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -267,15 +267,15 @@ impl Encodable for ListPartitionReassignmentsResponse {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 4;
+        total_size += 2;
         total_size += types::CompactString.compute_size(&self.error_message)?;
         total_size += types::CompactArray(types::Struct { version }).compute_size(&self.topics)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -292,8 +292,8 @@ impl Encodable for ListPartitionReassignmentsResponse {
 
 impl Decodable for ListPartitionReassignmentsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let throttle_time_ms = types::Int32.decode(buf)?;
-        let error_code = types::Int16.decode(buf)?;
+        let throttle_time_ms = buf.try_get_i32()?;
+        let error_code = buf.try_get_i16()?;
         let error_message = types::CompactString.decode(buf)?;
         let topics = types::CompactArray(types::Struct { version }).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();

--- a/src/messages/list_transactions_request.rs
+++ b/src/messages/list_transactions_request.rs
@@ -53,7 +53,7 @@ impl Encodable for ListTransactionsRequest {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())

--- a/src/messages/metadata_request.rs
+++ b/src/messages/metadata_request.rs
@@ -47,7 +47,7 @@ impl Builder for MetadataRequestTopic {
 impl Encodable for MetadataRequestTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
         if version >= 10 {
-            types::Uuid.encode(buf, &self.topic_id)?;
+            types::Uuid.encode(buf, self.topic_id)?;
         }
         if version >= 9 {
             types::CompactString.encode(buf, &self.name)?;
@@ -60,7 +60,7 @@ impl Encodable for MetadataRequestTopic {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -69,7 +69,7 @@ impl Encodable for MetadataRequestTopic {
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
         if version >= 10 {
-            total_size += types::Uuid.compute_size(&self.topic_id)?;
+            total_size += types::Uuid.compute_size(self.topic_id)?;
         }
         if version >= 9 {
             total_size += types::CompactString.compute_size(&self.name)?;
@@ -179,21 +179,21 @@ impl Encodable for MetadataRequest {
             types::Array(types::Struct { version }).encode(buf, &self.topics)?;
         }
         if version >= 4 {
-            types::Boolean.encode(buf, &self.allow_auto_topic_creation)?;
+            types::Boolean.encode(buf, self.allow_auto_topic_creation)?;
         } else {
             if !self.allow_auto_topic_creation {
                 return Err(EncodeError)
             }
         }
         if version >= 8 && version <= 10 {
-            types::Boolean.encode(buf, &self.include_cluster_authorized_operations)?;
+            types::Boolean.encode(buf, self.include_cluster_authorized_operations)?;
         } else {
             if self.include_cluster_authorized_operations {
                 return Err(EncodeError)
             }
         }
         if version >= 8 {
-            types::Boolean.encode(buf, &self.include_topic_authorized_operations)?;
+            types::Boolean.encode(buf, self.include_topic_authorized_operations)?;
         } else {
             if self.include_topic_authorized_operations {
                 return Err(EncodeError)
@@ -205,7 +205,7 @@ impl Encodable for MetadataRequest {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -219,21 +219,21 @@ impl Encodable for MetadataRequest {
             total_size += types::Array(types::Struct { version }).compute_size(&self.topics)?;
         }
         if version >= 4 {
-            total_size += types::Boolean.compute_size(&self.allow_auto_topic_creation)?;
+            total_size += types::Boolean.compute_size(self.allow_auto_topic_creation)?;
         } else {
             if !self.allow_auto_topic_creation {
                 return Err(EncodeError)
             }
         }
         if version >= 8 && version <= 10 {
-            total_size += types::Boolean.compute_size(&self.include_cluster_authorized_operations)?;
+            total_size += types::Boolean.compute_size(self.include_cluster_authorized_operations)?;
         } else {
             if self.include_cluster_authorized_operations {
                 return Err(EncodeError)
             }
         }
         if version >= 8 {
-            total_size += types::Boolean.compute_size(&self.include_topic_authorized_operations)?;
+            total_size += types::Boolean.compute_size(self.include_topic_authorized_operations)?;
         } else {
             if self.include_topic_authorized_operations {
                 return Err(EncodeError)

--- a/src/messages/offset_commit_request.rs
+++ b/src/messages/offset_commit_request.rs
@@ -61,13 +61,13 @@ impl Builder for OffsetCommitRequestPartition {
 
 impl Encodable for OffsetCommitRequestPartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.partition_index)?;
-        types::Int64.encode(buf, &self.committed_offset)?;
+        buf.put_i32(self.partition_index);
+        buf.put_i64(self.committed_offset);
         if version >= 6 {
-            types::Int32.encode(buf, &self.committed_leader_epoch)?;
+            buf.put_i32(self.committed_leader_epoch);
         }
         if version == 1 {
-            types::Int64.encode(buf, &self.commit_timestamp)?;
+            buf.put_i64(self.commit_timestamp);
         } else {
             if self.commit_timestamp != -1 {
                 return Err(EncodeError)
@@ -84,7 +84,7 @@ impl Encodable for OffsetCommitRequestPartition {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -92,13 +92,13 @@ impl Encodable for OffsetCommitRequestPartition {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.partition_index)?;
-        total_size += types::Int64.compute_size(&self.committed_offset)?;
+        total_size += 4;
+        total_size += 8;
         if version >= 6 {
-            total_size += types::Int32.compute_size(&self.committed_leader_epoch)?;
+            total_size += 4;
         }
         if version == 1 {
-            total_size += types::Int64.compute_size(&self.commit_timestamp)?;
+            total_size += 8;
         } else {
             if self.commit_timestamp != -1 {
                 return Err(EncodeError)
@@ -125,15 +125,15 @@ impl Encodable for OffsetCommitRequestPartition {
 
 impl Decodable for OffsetCommitRequestPartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let partition_index = types::Int32.decode(buf)?;
-        let committed_offset = types::Int64.decode(buf)?;
+        let partition_index = buf.try_get_i32()?;
+        let committed_offset = buf.try_get_i64()?;
         let committed_leader_epoch = if version >= 6 {
-            types::Int32.decode(buf)?
+            buf.try_get_i32()?
         } else {
             -1
         };
         let commit_timestamp = if version == 1 {
-            types::Int64.decode(buf)?
+            buf.try_get_i64()?
         } else {
             -1
         };
@@ -225,7 +225,7 @@ impl Encodable for OffsetCommitRequestTopic {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -356,7 +356,7 @@ impl Encodable for OffsetCommitRequest {
             types::String.encode(buf, &self.group_id)?;
         }
         if version >= 1 {
-            types::Int32.encode(buf, &self.generation_id)?;
+            buf.put_i32(self.generation_id);
         }
         if version >= 1 {
             if version >= 8 {
@@ -377,7 +377,7 @@ impl Encodable for OffsetCommitRequest {
             }
         }
         if version >= 2 && version <= 4 {
-            types::Int64.encode(buf, &self.retention_time_ms)?;
+            buf.put_i64(self.retention_time_ms);
         }
         if version >= 8 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
@@ -390,7 +390,7 @@ impl Encodable for OffsetCommitRequest {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -404,7 +404,7 @@ impl Encodable for OffsetCommitRequest {
             total_size += types::String.compute_size(&self.group_id)?;
         }
         if version >= 1 {
-            total_size += types::Int32.compute_size(&self.generation_id)?;
+            total_size += 4;
         }
         if version >= 1 {
             if version >= 8 {
@@ -425,7 +425,7 @@ impl Encodable for OffsetCommitRequest {
             }
         }
         if version >= 2 && version <= 4 {
-            total_size += types::Int64.compute_size(&self.retention_time_ms)?;
+            total_size += 8;
         }
         if version >= 8 {
             total_size += types::CompactArray(types::Struct { version }).compute_size(&self.topics)?;
@@ -454,7 +454,7 @@ impl Decodable for OffsetCommitRequest {
             types::String.decode(buf)?
         };
         let generation_id = if version >= 1 {
-            types::Int32.decode(buf)?
+            buf.try_get_i32()?
         } else {
             -1
         };
@@ -477,7 +477,7 @@ impl Decodable for OffsetCommitRequest {
             None
         };
         let retention_time_ms = if version >= 2 && version <= 4 {
-            types::Int64.decode(buf)?
+            buf.try_get_i64()?
         } else {
             -1
         };

--- a/src/messages/offset_commit_response.rs
+++ b/src/messages/offset_commit_response.rs
@@ -46,15 +46,15 @@ impl Builder for OffsetCommitResponsePartition {
 
 impl Encodable for OffsetCommitResponsePartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.partition_index)?;
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i32(self.partition_index);
+        buf.put_i16(self.error_code);
         if version >= 8 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -62,8 +62,8 @@ impl Encodable for OffsetCommitResponsePartition {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.partition_index)?;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 4;
+        total_size += 2;
         if version >= 8 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
@@ -80,8 +80,8 @@ impl Encodable for OffsetCommitResponsePartition {
 
 impl Decodable for OffsetCommitResponsePartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let partition_index = types::Int32.decode(buf)?;
-        let error_code = types::Int16.decode(buf)?;
+        let partition_index = buf.try_get_i32()?;
+        let error_code = buf.try_get_i16()?;
         let mut unknown_tagged_fields = BTreeMap::new();
         if version >= 8 {
             let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
@@ -159,7 +159,7 @@ impl Encodable for OffsetCommitResponseTopic {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -265,7 +265,7 @@ impl Builder for OffsetCommitResponse {
 impl Encodable for OffsetCommitResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
         if version >= 3 {
-            types::Int32.encode(buf, &self.throttle_time_ms)?;
+            buf.put_i32(self.throttle_time_ms);
         }
         if version >= 8 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
@@ -278,7 +278,7 @@ impl Encodable for OffsetCommitResponse {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -287,7 +287,7 @@ impl Encodable for OffsetCommitResponse {
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
         if version >= 3 {
-            total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
+            total_size += 4;
         }
         if version >= 8 {
             total_size += types::CompactArray(types::Struct { version }).compute_size(&self.topics)?;
@@ -311,7 +311,7 @@ impl Encodable for OffsetCommitResponse {
 impl Decodable for OffsetCommitResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
         let throttle_time_ms = if version >= 3 {
-            types::Int32.decode(buf)?
+            buf.try_get_i32()?
         } else {
             0
         };

--- a/src/messages/offset_delete_request.rs
+++ b/src/messages/offset_delete_request.rs
@@ -39,13 +39,13 @@ impl Builder for OffsetDeleteRequestPartition {
 
 impl Encodable for OffsetDeleteRequestPartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.partition_index)?;
+        buf.put_i32(self.partition_index);
 
         Ok(())
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.partition_index)?;
+        total_size += 4;
 
         Ok(total_size)
     }
@@ -53,7 +53,7 @@ impl Encodable for OffsetDeleteRequestPartition {
 
 impl Decodable for OffsetDeleteRequestPartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let partition_index = types::Int32.decode(buf)?;
+        let partition_index = buf.try_get_i32()?;
         Ok(Self {
             partition_index,
         })

--- a/src/messages/offset_delete_response.rs
+++ b/src/messages/offset_delete_response.rs
@@ -40,15 +40,15 @@ impl Builder for OffsetDeleteResponsePartition {
 impl MapEncodable for OffsetDeleteResponsePartition {
     type Key = i32;
     fn encode<B: ByteBufMut>(&self, key: &Self::Key, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, key)?;
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i32(*key);
+        buf.put_i16(self.error_code);
 
         Ok(())
     }
     fn compute_size(&self, key: &Self::Key, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(key)?;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 4;
+        total_size += 2;
 
         Ok(total_size)
     }
@@ -57,8 +57,8 @@ impl MapEncodable for OffsetDeleteResponsePartition {
 impl MapDecodable for OffsetDeleteResponsePartition {
     type Key = i32;
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<(Self::Key, Self), DecodeError> {
-        let key_field = types::Int32.decode(buf)?;
-        let error_code = types::Int16.decode(buf)?;
+        let key_field = buf.try_get_i32()?;
+        let error_code = buf.try_get_i16()?;
         Ok((key_field, Self {
             error_code,
         }))
@@ -169,16 +169,16 @@ impl Builder for OffsetDeleteResponse {
 
 impl Encodable for OffsetDeleteResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int16.encode(buf, &self.error_code)?;
-        types::Int32.encode(buf, &self.throttle_time_ms)?;
+        buf.put_i16(self.error_code);
+        buf.put_i32(self.throttle_time_ms);
         types::Array(types::Struct { version }).encode(buf, &self.topics)?;
 
         Ok(())
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int16.compute_size(&self.error_code)?;
-        total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
+        total_size += 2;
+        total_size += 4;
         total_size += types::Array(types::Struct { version }).compute_size(&self.topics)?;
 
         Ok(total_size)
@@ -187,8 +187,8 @@ impl Encodable for OffsetDeleteResponse {
 
 impl Decodable for OffsetDeleteResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let error_code = types::Int16.decode(buf)?;
-        let throttle_time_ms = types::Int32.decode(buf)?;
+        let error_code = buf.try_get_i16()?;
+        let throttle_time_ms = buf.try_get_i32()?;
         let topics = types::Array(types::Struct { version }).decode(buf)?;
         Ok(Self {
             error_code,

--- a/src/messages/offset_fetch_request.rs
+++ b/src/messages/offset_fetch_request.rs
@@ -74,7 +74,7 @@ impl Encodable for OffsetFetchRequestTopic {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -219,7 +219,7 @@ impl Encodable for OffsetFetchRequestTopics {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -348,7 +348,7 @@ impl Encodable for OffsetFetchRequestGroup {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -497,7 +497,7 @@ impl Encodable for OffsetFetchRequest {
             }
         }
         if version >= 7 {
-            types::Boolean.encode(buf, &self.require_stable)?;
+            types::Boolean.encode(buf, self.require_stable)?;
         } else {
             if self.require_stable {
                 return Err(EncodeError)
@@ -509,7 +509,7 @@ impl Encodable for OffsetFetchRequest {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -547,7 +547,7 @@ impl Encodable for OffsetFetchRequest {
             }
         }
         if version >= 7 {
-            total_size += types::Boolean.compute_size(&self.require_stable)?;
+            total_size += types::Boolean.compute_size(self.require_stable)?;
         } else {
             if self.require_stable {
                 return Err(EncodeError)

--- a/src/messages/offset_fetch_response.rs
+++ b/src/messages/offset_fetch_response.rs
@@ -62,21 +62,21 @@ impl Builder for OffsetFetchResponsePartition {
 impl Encodable for OffsetFetchResponsePartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
         if version <= 7 {
-            types::Int32.encode(buf, &self.partition_index)?;
+            buf.put_i32(self.partition_index);
         } else {
             if self.partition_index != 0 {
                 return Err(EncodeError)
             }
         }
         if version <= 7 {
-            types::Int64.encode(buf, &self.committed_offset)?;
+            buf.put_i64(self.committed_offset);
         } else {
             if self.committed_offset != 0 {
                 return Err(EncodeError)
             }
         }
         if version >= 5 && version <= 7 {
-            types::Int32.encode(buf, &self.committed_leader_epoch)?;
+            buf.put_i32(self.committed_leader_epoch);
         }
         if version <= 7 {
             if version >= 6 {
@@ -90,7 +90,7 @@ impl Encodable for OffsetFetchResponsePartition {
             }
         }
         if version <= 7 {
-            types::Int16.encode(buf, &self.error_code)?;
+            buf.put_i16(self.error_code);
         } else {
             if self.error_code != 0 {
                 return Err(EncodeError)
@@ -102,7 +102,7 @@ impl Encodable for OffsetFetchResponsePartition {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -111,21 +111,21 @@ impl Encodable for OffsetFetchResponsePartition {
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
         if version <= 7 {
-            total_size += types::Int32.compute_size(&self.partition_index)?;
+            total_size += 4;
         } else {
             if self.partition_index != 0 {
                 return Err(EncodeError)
             }
         }
         if version <= 7 {
-            total_size += types::Int64.compute_size(&self.committed_offset)?;
+            total_size += 8;
         } else {
             if self.committed_offset != 0 {
                 return Err(EncodeError)
             }
         }
         if version >= 5 && version <= 7 {
-            total_size += types::Int32.compute_size(&self.committed_leader_epoch)?;
+            total_size += 4;
         }
         if version <= 7 {
             if version >= 6 {
@@ -139,7 +139,7 @@ impl Encodable for OffsetFetchResponsePartition {
             }
         }
         if version <= 7 {
-            total_size += types::Int16.compute_size(&self.error_code)?;
+            total_size += 2;
         } else {
             if self.error_code != 0 {
                 return Err(EncodeError)
@@ -162,17 +162,17 @@ impl Encodable for OffsetFetchResponsePartition {
 impl Decodable for OffsetFetchResponsePartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
         let partition_index = if version <= 7 {
-            types::Int32.decode(buf)?
+            buf.try_get_i32()?
         } else {
             0
         };
         let committed_offset = if version <= 7 {
-            types::Int64.decode(buf)?
+            buf.try_get_i64()?
         } else {
             0
         };
         let committed_leader_epoch = if version >= 5 && version <= 7 {
-            types::Int32.decode(buf)?
+            buf.try_get_i32()?
         } else {
             -1
         };
@@ -186,7 +186,7 @@ impl Decodable for OffsetFetchResponsePartition {
             Some(Default::default())
         };
         let error_code = if version <= 7 {
-            types::Int16.decode(buf)?
+            buf.try_get_i16()?
         } else {
             0
         };
@@ -285,7 +285,7 @@ impl Encodable for OffsetFetchResponseTopic {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -426,21 +426,21 @@ impl Builder for OffsetFetchResponsePartitions {
 impl Encodable for OffsetFetchResponsePartitions {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
         if version >= 8 {
-            types::Int32.encode(buf, &self.partition_index)?;
+            buf.put_i32(self.partition_index);
         } else {
             if self.partition_index != 0 {
                 return Err(EncodeError)
             }
         }
         if version >= 8 {
-            types::Int64.encode(buf, &self.committed_offset)?;
+            buf.put_i64(self.committed_offset);
         } else {
             if self.committed_offset != 0 {
                 return Err(EncodeError)
             }
         }
         if version >= 8 {
-            types::Int32.encode(buf, &self.committed_leader_epoch)?;
+            buf.put_i32(self.committed_leader_epoch);
         }
         if version >= 8 {
             types::CompactString.encode(buf, &self.metadata)?;
@@ -450,7 +450,7 @@ impl Encodable for OffsetFetchResponsePartitions {
             }
         }
         if version >= 8 {
-            types::Int16.encode(buf, &self.error_code)?;
+            buf.put_i16(self.error_code);
         } else {
             if self.error_code != 0 {
                 return Err(EncodeError)
@@ -462,7 +462,7 @@ impl Encodable for OffsetFetchResponsePartitions {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -471,21 +471,21 @@ impl Encodable for OffsetFetchResponsePartitions {
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
         if version >= 8 {
-            total_size += types::Int32.compute_size(&self.partition_index)?;
+            total_size += 4;
         } else {
             if self.partition_index != 0 {
                 return Err(EncodeError)
             }
         }
         if version >= 8 {
-            total_size += types::Int64.compute_size(&self.committed_offset)?;
+            total_size += 8;
         } else {
             if self.committed_offset != 0 {
                 return Err(EncodeError)
             }
         }
         if version >= 8 {
-            total_size += types::Int32.compute_size(&self.committed_leader_epoch)?;
+            total_size += 4;
         }
         if version >= 8 {
             total_size += types::CompactString.compute_size(&self.metadata)?;
@@ -495,7 +495,7 @@ impl Encodable for OffsetFetchResponsePartitions {
             }
         }
         if version >= 8 {
-            total_size += types::Int16.compute_size(&self.error_code)?;
+            total_size += 2;
         } else {
             if self.error_code != 0 {
                 return Err(EncodeError)
@@ -518,17 +518,17 @@ impl Encodable for OffsetFetchResponsePartitions {
 impl Decodable for OffsetFetchResponsePartitions {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
         let partition_index = if version >= 8 {
-            types::Int32.decode(buf)?
+            buf.try_get_i32()?
         } else {
             0
         };
         let committed_offset = if version >= 8 {
-            types::Int64.decode(buf)?
+            buf.try_get_i64()?
         } else {
             0
         };
         let committed_leader_epoch = if version >= 8 {
-            types::Int32.decode(buf)?
+            buf.try_get_i32()?
         } else {
             -1
         };
@@ -538,7 +538,7 @@ impl Decodable for OffsetFetchResponsePartitions {
             Some(Default::default())
         };
         let error_code = if version >= 8 {
-            types::Int16.decode(buf)?
+            buf.try_get_i16()?
         } else {
             0
         };
@@ -629,7 +629,7 @@ impl Encodable for OffsetFetchResponseTopics {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -758,7 +758,7 @@ impl Encodable for OffsetFetchResponseGroup {
             }
         }
         if version >= 8 {
-            types::Int16.encode(buf, &self.error_code)?;
+            buf.put_i16(self.error_code);
         } else {
             if self.error_code != 0 {
                 return Err(EncodeError)
@@ -770,7 +770,7 @@ impl Encodable for OffsetFetchResponseGroup {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -793,7 +793,7 @@ impl Encodable for OffsetFetchResponseGroup {
             }
         }
         if version >= 8 {
-            total_size += types::Int16.compute_size(&self.error_code)?;
+            total_size += 2;
         } else {
             if self.error_code != 0 {
                 return Err(EncodeError)
@@ -826,7 +826,7 @@ impl Decodable for OffsetFetchResponseGroup {
             Default::default()
         };
         let error_code = if version >= 8 {
-            types::Int16.decode(buf)?
+            buf.try_get_i16()?
         } else {
             0
         };
@@ -904,7 +904,7 @@ impl Builder for OffsetFetchResponse {
 impl Encodable for OffsetFetchResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
         if version >= 3 {
-            types::Int32.encode(buf, &self.throttle_time_ms)?;
+            buf.put_i32(self.throttle_time_ms);
         }
         if version <= 7 {
             if version >= 6 {
@@ -918,7 +918,7 @@ impl Encodable for OffsetFetchResponse {
             }
         }
         if version >= 2 && version <= 7 {
-            types::Int16.encode(buf, &self.error_code)?;
+            buf.put_i16(self.error_code);
         }
         if version >= 8 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.groups)?;
@@ -933,7 +933,7 @@ impl Encodable for OffsetFetchResponse {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -942,7 +942,7 @@ impl Encodable for OffsetFetchResponse {
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
         if version >= 3 {
-            total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
+            total_size += 4;
         }
         if version <= 7 {
             if version >= 6 {
@@ -956,7 +956,7 @@ impl Encodable for OffsetFetchResponse {
             }
         }
         if version >= 2 && version <= 7 {
-            total_size += types::Int16.compute_size(&self.error_code)?;
+            total_size += 2;
         }
         if version >= 8 {
             total_size += types::CompactArray(types::Struct { version }).compute_size(&self.groups)?;
@@ -982,7 +982,7 @@ impl Encodable for OffsetFetchResponse {
 impl Decodable for OffsetFetchResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
         let throttle_time_ms = if version >= 3 {
-            types::Int32.decode(buf)?
+            buf.try_get_i32()?
         } else {
             0
         };
@@ -996,7 +996,7 @@ impl Decodable for OffsetFetchResponse {
             Default::default()
         };
         let error_code = if version >= 2 && version <= 7 {
-            types::Int16.decode(buf)?
+            buf.try_get_i16()?
         } else {
             0
         };

--- a/src/messages/offset_for_leader_epoch_request.rs
+++ b/src/messages/offset_for_leader_epoch_request.rs
@@ -51,18 +51,18 @@ impl Builder for OffsetForLeaderPartition {
 
 impl Encodable for OffsetForLeaderPartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.partition)?;
+        buf.put_i32(self.partition);
         if version >= 2 {
-            types::Int32.encode(buf, &self.current_leader_epoch)?;
+            buf.put_i32(self.current_leader_epoch);
         }
-        types::Int32.encode(buf, &self.leader_epoch)?;
+        buf.put_i32(self.leader_epoch);
         if version >= 4 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -70,11 +70,11 @@ impl Encodable for OffsetForLeaderPartition {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.partition)?;
+        total_size += 4;
         if version >= 2 {
-            total_size += types::Int32.compute_size(&self.current_leader_epoch)?;
+            total_size += 4;
         }
-        total_size += types::Int32.compute_size(&self.leader_epoch)?;
+        total_size += 4;
         if version >= 4 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
@@ -91,13 +91,13 @@ impl Encodable for OffsetForLeaderPartition {
 
 impl Decodable for OffsetForLeaderPartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let partition = types::Int32.decode(buf)?;
+        let partition = buf.try_get_i32()?;
         let current_leader_epoch = if version >= 2 {
-            types::Int32.decode(buf)?
+            buf.try_get_i32()?
         } else {
             -1
         };
-        let leader_epoch = types::Int32.decode(buf)?;
+        let leader_epoch = buf.try_get_i32()?;
         let mut unknown_tagged_fields = BTreeMap::new();
         if version >= 4 {
             let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
@@ -173,7 +173,7 @@ impl MapEncodable for OffsetForLeaderTopic {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -291,7 +291,7 @@ impl Encodable for OffsetForLeaderEpochRequest {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }

--- a/src/messages/offset_for_leader_epoch_response.rs
+++ b/src/messages/offset_for_leader_epoch_response.rs
@@ -56,19 +56,19 @@ impl Builder for EpochEndOffset {
 
 impl Encodable for EpochEndOffset {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int16.encode(buf, &self.error_code)?;
-        types::Int32.encode(buf, &self.partition)?;
+        buf.put_i16(self.error_code);
+        buf.put_i32(self.partition);
         if version >= 1 {
-            types::Int32.encode(buf, &self.leader_epoch)?;
+            buf.put_i32(self.leader_epoch);
         }
-        types::Int64.encode(buf, &self.end_offset)?;
+        buf.put_i64(self.end_offset);
         if version >= 4 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -76,12 +76,12 @@ impl Encodable for EpochEndOffset {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int16.compute_size(&self.error_code)?;
-        total_size += types::Int32.compute_size(&self.partition)?;
+        total_size += 2;
+        total_size += 4;
         if version >= 1 {
-            total_size += types::Int32.compute_size(&self.leader_epoch)?;
+            total_size += 4;
         }
-        total_size += types::Int64.compute_size(&self.end_offset)?;
+        total_size += 8;
         if version >= 4 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
@@ -98,14 +98,14 @@ impl Encodable for EpochEndOffset {
 
 impl Decodable for EpochEndOffset {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let error_code = types::Int16.decode(buf)?;
-        let partition = types::Int32.decode(buf)?;
+        let error_code = buf.try_get_i16()?;
+        let partition = buf.try_get_i32()?;
         let leader_epoch = if version >= 1 {
-            types::Int32.decode(buf)?
+            buf.try_get_i32()?
         } else {
             -1
         };
-        let end_offset = types::Int64.decode(buf)?;
+        let end_offset = buf.try_get_i64()?;
         let mut unknown_tagged_fields = BTreeMap::new();
         if version >= 4 {
             let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
@@ -183,7 +183,7 @@ impl MapEncodable for OffsetForLeaderTopicResult {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -288,7 +288,7 @@ impl Builder for OffsetForLeaderEpochResponse {
 impl Encodable for OffsetForLeaderEpochResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
         if version >= 2 {
-            types::Int32.encode(buf, &self.throttle_time_ms)?;
+            buf.put_i32(self.throttle_time_ms);
         }
         if version >= 4 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
@@ -301,7 +301,7 @@ impl Encodable for OffsetForLeaderEpochResponse {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -310,7 +310,7 @@ impl Encodable for OffsetForLeaderEpochResponse {
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
         if version >= 2 {
-            total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
+            total_size += 4;
         }
         if version >= 4 {
             total_size += types::CompactArray(types::Struct { version }).compute_size(&self.topics)?;
@@ -334,7 +334,7 @@ impl Encodable for OffsetForLeaderEpochResponse {
 impl Decodable for OffsetForLeaderEpochResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
         let throttle_time_ms = if version >= 2 {
-            types::Int32.decode(buf)?
+            buf.try_get_i32()?
         } else {
             0
         };

--- a/src/messages/produce_response.rs
+++ b/src/messages/produce_response.rs
@@ -47,7 +47,7 @@ impl Builder for BatchIndexAndErrorMessage {
 impl Encodable for BatchIndexAndErrorMessage {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
         if version >= 8 {
-            types::Int32.encode(buf, &self.batch_index)?;
+            buf.put_i32(self.batch_index);
         } else {
             if self.batch_index != 0 {
                 return Err(EncodeError)
@@ -70,7 +70,7 @@ impl Encodable for BatchIndexAndErrorMessage {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -79,7 +79,7 @@ impl Encodable for BatchIndexAndErrorMessage {
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
         if version >= 8 {
-            total_size += types::Int32.compute_size(&self.batch_index)?;
+            total_size += 4;
         } else {
             if self.batch_index != 0 {
                 return Err(EncodeError)
@@ -113,7 +113,7 @@ impl Encodable for BatchIndexAndErrorMessage {
 impl Decodable for BatchIndexAndErrorMessage {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
         let batch_index = if version >= 8 {
-            types::Int32.decode(buf)?
+            buf.try_get_i32()?
         } else {
             0
         };
@@ -212,14 +212,14 @@ impl Builder for PartitionProduceResponse {
 
 impl Encodable for PartitionProduceResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.index)?;
-        types::Int16.encode(buf, &self.error_code)?;
-        types::Int64.encode(buf, &self.base_offset)?;
+        buf.put_i32(self.index);
+        buf.put_i16(self.error_code);
+        buf.put_i64(self.base_offset);
         if version >= 2 {
-            types::Int64.encode(buf, &self.log_append_time_ms)?;
+            buf.put_i64(self.log_append_time_ms);
         }
         if version >= 5 {
-            types::Int64.encode(buf, &self.log_start_offset)?;
+            buf.put_i64(self.log_start_offset);
         }
         if version >= 8 {
             if version >= 9 {
@@ -241,7 +241,7 @@ impl Encodable for PartitionProduceResponse {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -249,14 +249,14 @@ impl Encodable for PartitionProduceResponse {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.index)?;
-        total_size += types::Int16.compute_size(&self.error_code)?;
-        total_size += types::Int64.compute_size(&self.base_offset)?;
+        total_size += 4;
+        total_size += 2;
+        total_size += 8;
         if version >= 2 {
-            total_size += types::Int64.compute_size(&self.log_append_time_ms)?;
+            total_size += 8;
         }
         if version >= 5 {
-            total_size += types::Int64.compute_size(&self.log_start_offset)?;
+            total_size += 8;
         }
         if version >= 8 {
             if version >= 9 {
@@ -288,16 +288,16 @@ impl Encodable for PartitionProduceResponse {
 
 impl Decodable for PartitionProduceResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let index = types::Int32.decode(buf)?;
-        let error_code = types::Int16.decode(buf)?;
-        let base_offset = types::Int64.decode(buf)?;
+        let index = buf.try_get_i32()?;
+        let error_code = buf.try_get_i16()?;
+        let base_offset = buf.try_get_i64()?;
         let log_append_time_ms = if version >= 2 {
-            types::Int64.decode(buf)?
+            buf.try_get_i64()?
         } else {
             -1
         };
         let log_start_offset = if version >= 5 {
-            types::Int64.decode(buf)?
+            buf.try_get_i64()?
         } else {
             -1
         };
@@ -402,7 +402,7 @@ impl MapEncodable for TopicProduceResponse {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -512,7 +512,7 @@ impl Encodable for ProduceResponse {
             types::Array(types::Struct { version }).encode(buf, &self.responses)?;
         }
         if version >= 1 {
-            types::Int32.encode(buf, &self.throttle_time_ms)?;
+            buf.put_i32(self.throttle_time_ms);
         }
         if version >= 9 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -520,7 +520,7 @@ impl Encodable for ProduceResponse {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -534,7 +534,7 @@ impl Encodable for ProduceResponse {
             total_size += types::Array(types::Struct { version }).compute_size(&self.responses)?;
         }
         if version >= 1 {
-            total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
+            total_size += 4;
         }
         if version >= 9 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -558,7 +558,7 @@ impl Decodable for ProduceResponse {
             types::Array(types::Struct { version }).decode(buf)?
         };
         let throttle_time_ms = if version >= 1 {
-            types::Int32.decode(buf)?
+            buf.try_get_i32()?
         } else {
             0
         };

--- a/src/messages/renew_delegation_token_request.rs
+++ b/src/messages/renew_delegation_token_request.rs
@@ -51,14 +51,14 @@ impl Encodable for RenewDelegationTokenRequest {
         } else {
             types::Bytes.encode(buf, &self.hmac)?;
         }
-        types::Int64.encode(buf, &self.renew_period_ms)?;
+        buf.put_i64(self.renew_period_ms);
         if version >= 2 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -71,7 +71,7 @@ impl Encodable for RenewDelegationTokenRequest {
         } else {
             total_size += types::Bytes.compute_size(&self.hmac)?;
         }
-        total_size += types::Int64.compute_size(&self.renew_period_ms)?;
+        total_size += 8;
         if version >= 2 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
@@ -93,7 +93,7 @@ impl Decodable for RenewDelegationTokenRequest {
         } else {
             types::Bytes.decode(buf)?
         };
-        let renew_period_ms = types::Int64.decode(buf)?;
+        let renew_period_ms = buf.try_get_i64()?;
         let mut unknown_tagged_fields = BTreeMap::new();
         if version >= 2 {
             let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;

--- a/src/messages/renew_delegation_token_response.rs
+++ b/src/messages/renew_delegation_token_response.rs
@@ -51,16 +51,16 @@ impl Builder for RenewDelegationTokenResponse {
 
 impl Encodable for RenewDelegationTokenResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int16.encode(buf, &self.error_code)?;
-        types::Int64.encode(buf, &self.expiry_timestamp_ms)?;
-        types::Int32.encode(buf, &self.throttle_time_ms)?;
+        buf.put_i16(self.error_code);
+        buf.put_i64(self.expiry_timestamp_ms);
+        buf.put_i32(self.throttle_time_ms);
         if version >= 2 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -68,9 +68,9 @@ impl Encodable for RenewDelegationTokenResponse {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int16.compute_size(&self.error_code)?;
-        total_size += types::Int64.compute_size(&self.expiry_timestamp_ms)?;
-        total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
+        total_size += 2;
+        total_size += 8;
+        total_size += 4;
         if version >= 2 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
@@ -87,9 +87,9 @@ impl Encodable for RenewDelegationTokenResponse {
 
 impl Decodable for RenewDelegationTokenResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let error_code = types::Int16.decode(buf)?;
-        let expiry_timestamp_ms = types::Int64.decode(buf)?;
-        let throttle_time_ms = types::Int32.decode(buf)?;
+        let error_code = buf.try_get_i16()?;
+        let expiry_timestamp_ms = buf.try_get_i64()?;
+        let throttle_time_ms = buf.try_get_i32()?;
         let mut unknown_tagged_fields = BTreeMap::new();
         if version >= 2 {
             let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;

--- a/src/messages/sasl_authenticate_request.rs
+++ b/src/messages/sasl_authenticate_request.rs
@@ -52,7 +52,7 @@ impl Encodable for SaslAuthenticateRequest {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }

--- a/src/messages/sasl_handshake_response.rs
+++ b/src/messages/sasl_handshake_response.rs
@@ -44,14 +44,14 @@ impl Builder for SaslHandshakeResponse {
 
 impl Encodable for SaslHandshakeResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i16(self.error_code);
         types::Array(types::String).encode(buf, &self.mechanisms)?;
 
         Ok(())
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 2;
         total_size += types::Array(types::String).compute_size(&self.mechanisms)?;
 
         Ok(total_size)
@@ -60,7 +60,7 @@ impl Encodable for SaslHandshakeResponse {
 
 impl Decodable for SaslHandshakeResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let error_code = types::Int16.decode(buf)?;
+        let error_code = buf.try_get_i16()?;
         let mechanisms = types::Array(types::String).decode(buf)?;
         Ok(Self {
             error_code,

--- a/src/messages/stop_replica_request.rs
+++ b/src/messages/stop_replica_request.rs
@@ -54,7 +54,7 @@ impl Encodable for StopReplicaPartitionV0 {
             }
         }
         if version == 0 {
-            types::Int32.encode(buf, &self.partition_index)?;
+            buf.put_i32(self.partition_index);
         } else {
             if self.partition_index != 0 {
                 return Err(EncodeError)
@@ -66,7 +66,7 @@ impl Encodable for StopReplicaPartitionV0 {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -82,7 +82,7 @@ impl Encodable for StopReplicaPartitionV0 {
             }
         }
         if version == 0 {
-            total_size += types::Int32.compute_size(&self.partition_index)?;
+            total_size += 4;
         } else {
             if self.partition_index != 0 {
                 return Err(EncodeError)
@@ -110,7 +110,7 @@ impl Decodable for StopReplicaPartitionV0 {
             Default::default()
         };
         let partition_index = if version == 0 {
-            types::Int32.decode(buf)?
+            buf.try_get_i32()?
         } else {
             0
         };
@@ -203,7 +203,7 @@ impl Encodable for StopReplicaTopicV1 {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -334,21 +334,21 @@ impl Builder for StopReplicaPartitionState {
 impl Encodable for StopReplicaPartitionState {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
         if version >= 3 {
-            types::Int32.encode(buf, &self.partition_index)?;
+            buf.put_i32(self.partition_index);
         } else {
             if self.partition_index != 0 {
                 return Err(EncodeError)
             }
         }
         if version >= 3 {
-            types::Int32.encode(buf, &self.leader_epoch)?;
+            buf.put_i32(self.leader_epoch);
         } else {
             if self.leader_epoch != -1 {
                 return Err(EncodeError)
             }
         }
         if version >= 3 {
-            types::Boolean.encode(buf, &self.delete_partition)?;
+            types::Boolean.encode(buf, self.delete_partition)?;
         } else {
             if self.delete_partition {
                 return Err(EncodeError)
@@ -360,7 +360,7 @@ impl Encodable for StopReplicaPartitionState {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -369,21 +369,21 @@ impl Encodable for StopReplicaPartitionState {
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
         if version >= 3 {
-            total_size += types::Int32.compute_size(&self.partition_index)?;
+            total_size += 4;
         } else {
             if self.partition_index != 0 {
                 return Err(EncodeError)
             }
         }
         if version >= 3 {
-            total_size += types::Int32.compute_size(&self.leader_epoch)?;
+            total_size += 4;
         } else {
             if self.leader_epoch != -1 {
                 return Err(EncodeError)
             }
         }
         if version >= 3 {
-            total_size += types::Boolean.compute_size(&self.delete_partition)?;
+            total_size += types::Boolean.compute_size(self.delete_partition)?;
         } else {
             if self.delete_partition {
                 return Err(EncodeError)
@@ -406,12 +406,12 @@ impl Encodable for StopReplicaPartitionState {
 impl Decodable for StopReplicaPartitionState {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
         let partition_index = if version >= 3 {
-            types::Int32.decode(buf)?
+            buf.try_get_i32()?
         } else {
             0
         };
         let leader_epoch = if version >= 3 {
-            types::Int32.decode(buf)?
+            buf.try_get_i32()?
         } else {
             -1
         };
@@ -503,7 +503,7 @@ impl Encodable for StopReplicaTopicState {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -638,12 +638,12 @@ impl Builder for StopReplicaRequest {
 impl Encodable for StopReplicaRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
         types::Int32.encode(buf, &self.controller_id)?;
-        types::Int32.encode(buf, &self.controller_epoch)?;
+        buf.put_i32(self.controller_epoch);
         if version >= 1 {
-            types::Int64.encode(buf, &self.broker_epoch)?;
+            buf.put_i64(self.broker_epoch);
         }
         if version <= 2 {
-            types::Boolean.encode(buf, &self.delete_partitions)?;
+            types::Boolean.encode(buf, self.delete_partitions)?;
         } else {
             if self.delete_partitions {
                 return Err(EncodeError)
@@ -680,7 +680,7 @@ impl Encodable for StopReplicaRequest {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -689,12 +689,12 @@ impl Encodable for StopReplicaRequest {
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
         total_size += types::Int32.compute_size(&self.controller_id)?;
-        total_size += types::Int32.compute_size(&self.controller_epoch)?;
+        total_size += 4;
         if version >= 1 {
-            total_size += types::Int64.compute_size(&self.broker_epoch)?;
+            total_size += 8;
         }
         if version <= 2 {
-            total_size += types::Boolean.compute_size(&self.delete_partitions)?;
+            total_size += types::Boolean.compute_size(self.delete_partitions)?;
         } else {
             if self.delete_partitions {
                 return Err(EncodeError)
@@ -742,9 +742,9 @@ impl Encodable for StopReplicaRequest {
 impl Decodable for StopReplicaRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
         let controller_id = types::Int32.decode(buf)?;
-        let controller_epoch = types::Int32.decode(buf)?;
+        let controller_epoch = buf.try_get_i32()?;
         let broker_epoch = if version >= 1 {
-            types::Int64.decode(buf)?
+            buf.try_get_i64()?
         } else {
             -1
         };

--- a/src/messages/stop_replica_response.rs
+++ b/src/messages/stop_replica_response.rs
@@ -56,15 +56,15 @@ impl Encodable for StopReplicaPartitionError {
         } else {
             types::String.encode(buf, &self.topic_name)?;
         }
-        types::Int32.encode(buf, &self.partition_index)?;
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i32(self.partition_index);
+        buf.put_i16(self.error_code);
         if version >= 2 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -77,8 +77,8 @@ impl Encodable for StopReplicaPartitionError {
         } else {
             total_size += types::String.compute_size(&self.topic_name)?;
         }
-        total_size += types::Int32.compute_size(&self.partition_index)?;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 4;
+        total_size += 2;
         if version >= 2 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
@@ -100,8 +100,8 @@ impl Decodable for StopReplicaPartitionError {
         } else {
             types::String.decode(buf)?
         };
-        let partition_index = types::Int32.decode(buf)?;
-        let error_code = types::Int16.decode(buf)?;
+        let partition_index = buf.try_get_i32()?;
+        let error_code = buf.try_get_i16()?;
         let mut unknown_tagged_fields = BTreeMap::new();
         if version >= 2 {
             let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
@@ -165,7 +165,7 @@ impl Builder for StopReplicaResponse {
 
 impl Encodable for StopReplicaResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i16(self.error_code);
         if version >= 2 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.partition_errors)?;
         } else {
@@ -177,7 +177,7 @@ impl Encodable for StopReplicaResponse {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -185,7 +185,7 @@ impl Encodable for StopReplicaResponse {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 2;
         if version >= 2 {
             total_size += types::CompactArray(types::Struct { version }).compute_size(&self.partition_errors)?;
         } else {
@@ -207,7 +207,7 @@ impl Encodable for StopReplicaResponse {
 
 impl Decodable for StopReplicaResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let error_code = types::Int16.decode(buf)?;
+        let error_code = buf.try_get_i16()?;
         let partition_errors = if version >= 2 {
             types::CompactArray(types::Struct { version }).decode(buf)?
         } else {

--- a/src/messages/sync_group_request.rs
+++ b/src/messages/sync_group_request.rs
@@ -62,7 +62,7 @@ impl Encodable for SyncGroupRequestAssignment {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -197,7 +197,7 @@ impl Encodable for SyncGroupRequest {
         } else {
             types::String.encode(buf, &self.group_id)?;
         }
-        types::Int32.encode(buf, &self.generation_id)?;
+        buf.put_i32(self.generation_id);
         if version >= 4 {
             types::CompactString.encode(buf, &self.member_id)?;
         } else {
@@ -231,7 +231,7 @@ impl Encodable for SyncGroupRequest {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -244,7 +244,7 @@ impl Encodable for SyncGroupRequest {
         } else {
             total_size += types::String.compute_size(&self.group_id)?;
         }
-        total_size += types::Int32.compute_size(&self.generation_id)?;
+        total_size += 4;
         if version >= 4 {
             total_size += types::CompactString.compute_size(&self.member_id)?;
         } else {
@@ -293,7 +293,7 @@ impl Decodable for SyncGroupRequest {
         } else {
             types::String.decode(buf)?
         };
-        let generation_id = types::Int32.decode(buf)?;
+        let generation_id = buf.try_get_i32()?;
         let member_id = if version >= 4 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/sync_group_response.rs
+++ b/src/messages/sync_group_response.rs
@@ -62,9 +62,9 @@ impl Builder for SyncGroupResponse {
 impl Encodable for SyncGroupResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
         if version >= 1 {
-            types::Int32.encode(buf, &self.throttle_time_ms)?;
+            buf.put_i32(self.throttle_time_ms);
         }
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i16(self.error_code);
         if version >= 5 {
             types::CompactString.encode(buf, &self.protocol_type)?;
         }
@@ -82,7 +82,7 @@ impl Encodable for SyncGroupResponse {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -91,9 +91,9 @@ impl Encodable for SyncGroupResponse {
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
         if version >= 1 {
-            total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
+            total_size += 4;
         }
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 2;
         if version >= 5 {
             total_size += types::CompactString.compute_size(&self.protocol_type)?;
         }
@@ -122,11 +122,11 @@ impl Encodable for SyncGroupResponse {
 impl Decodable for SyncGroupResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
         let throttle_time_ms = if version >= 1 {
-            types::Int32.decode(buf)?
+            buf.try_get_i32()?
         } else {
             0
         };
-        let error_code = types::Int16.decode(buf)?;
+        let error_code = buf.try_get_i16()?;
         let protocol_type = if version >= 5 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/txn_offset_commit_request.rs
+++ b/src/messages/txn_offset_commit_request.rs
@@ -56,10 +56,10 @@ impl Builder for TxnOffsetCommitRequestPartition {
 
 impl Encodable for TxnOffsetCommitRequestPartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.partition_index)?;
-        types::Int64.encode(buf, &self.committed_offset)?;
+        buf.put_i32(self.partition_index);
+        buf.put_i64(self.committed_offset);
         if version >= 2 {
-            types::Int32.encode(buf, &self.committed_leader_epoch)?;
+            buf.put_i32(self.committed_leader_epoch);
         }
         if version >= 3 {
             types::CompactString.encode(buf, &self.committed_metadata)?;
@@ -72,7 +72,7 @@ impl Encodable for TxnOffsetCommitRequestPartition {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -80,10 +80,10 @@ impl Encodable for TxnOffsetCommitRequestPartition {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.partition_index)?;
-        total_size += types::Int64.compute_size(&self.committed_offset)?;
+        total_size += 4;
+        total_size += 8;
         if version >= 2 {
-            total_size += types::Int32.compute_size(&self.committed_leader_epoch)?;
+            total_size += 4;
         }
         if version >= 3 {
             total_size += types::CompactString.compute_size(&self.committed_metadata)?;
@@ -106,10 +106,10 @@ impl Encodable for TxnOffsetCommitRequestPartition {
 
 impl Decodable for TxnOffsetCommitRequestPartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let partition_index = types::Int32.decode(buf)?;
-        let committed_offset = types::Int64.decode(buf)?;
+        let partition_index = buf.try_get_i32()?;
+        let committed_offset = buf.try_get_i64()?;
         let committed_leader_epoch = if version >= 2 {
-            types::Int32.decode(buf)?
+            buf.try_get_i32()?
         } else {
             -1
         };
@@ -199,7 +199,7 @@ impl Encodable for TxnOffsetCommitRequestTopic {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -345,9 +345,9 @@ impl Encodable for TxnOffsetCommitRequest {
             types::String.encode(buf, &self.group_id)?;
         }
         types::Int64.encode(buf, &self.producer_id)?;
-        types::Int16.encode(buf, &self.producer_epoch)?;
+        buf.put_i16(self.producer_epoch);
         if version >= 3 {
-            types::Int32.encode(buf, &self.generation_id)?;
+            buf.put_i32(self.generation_id);
         } else {
             if self.generation_id != -1 {
                 return Err(EncodeError)
@@ -378,7 +378,7 @@ impl Encodable for TxnOffsetCommitRequest {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -397,9 +397,9 @@ impl Encodable for TxnOffsetCommitRequest {
             total_size += types::String.compute_size(&self.group_id)?;
         }
         total_size += types::Int64.compute_size(&self.producer_id)?;
-        total_size += types::Int16.compute_size(&self.producer_epoch)?;
+        total_size += 2;
         if version >= 3 {
-            total_size += types::Int32.compute_size(&self.generation_id)?;
+            total_size += 4;
         } else {
             if self.generation_id != -1 {
                 return Err(EncodeError)
@@ -451,9 +451,9 @@ impl Decodable for TxnOffsetCommitRequest {
             types::String.decode(buf)?
         };
         let producer_id = types::Int64.decode(buf)?;
-        let producer_epoch = types::Int16.decode(buf)?;
+        let producer_epoch = buf.try_get_i16()?;
         let generation_id = if version >= 3 {
-            types::Int32.decode(buf)?
+            buf.try_get_i32()?
         } else {
             -1
         };

--- a/src/messages/txn_offset_commit_response.rs
+++ b/src/messages/txn_offset_commit_response.rs
@@ -46,15 +46,15 @@ impl Builder for TxnOffsetCommitResponsePartition {
 
 impl Encodable for TxnOffsetCommitResponsePartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.partition_index)?;
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i32(self.partition_index);
+        buf.put_i16(self.error_code);
         if version >= 3 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -62,8 +62,8 @@ impl Encodable for TxnOffsetCommitResponsePartition {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.partition_index)?;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 4;
+        total_size += 2;
         if version >= 3 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
@@ -80,8 +80,8 @@ impl Encodable for TxnOffsetCommitResponsePartition {
 
 impl Decodable for TxnOffsetCommitResponsePartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let partition_index = types::Int32.decode(buf)?;
-        let error_code = types::Int16.decode(buf)?;
+        let partition_index = buf.try_get_i32()?;
+        let error_code = buf.try_get_i16()?;
         let mut unknown_tagged_fields = BTreeMap::new();
         if version >= 3 {
             let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
@@ -159,7 +159,7 @@ impl Encodable for TxnOffsetCommitResponseTopic {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -264,7 +264,7 @@ impl Builder for TxnOffsetCommitResponse {
 
 impl Encodable for TxnOffsetCommitResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.throttle_time_ms)?;
+        buf.put_i32(self.throttle_time_ms);
         if version >= 3 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
         } else {
@@ -276,7 +276,7 @@ impl Encodable for TxnOffsetCommitResponse {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -284,7 +284,7 @@ impl Encodable for TxnOffsetCommitResponse {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
+        total_size += 4;
         if version >= 3 {
             total_size += types::CompactArray(types::Struct { version }).compute_size(&self.topics)?;
         } else {
@@ -306,7 +306,7 @@ impl Encodable for TxnOffsetCommitResponse {
 
 impl Decodable for TxnOffsetCommitResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let throttle_time_ms = types::Int32.decode(buf)?;
+        let throttle_time_ms = buf.try_get_i32()?;
         let topics = if version >= 3 {
             types::CompactArray(types::Struct { version }).decode(buf)?
         } else {

--- a/src/messages/unregister_broker_request.rs
+++ b/src/messages/unregister_broker_request.rs
@@ -47,7 +47,7 @@ impl Encodable for UnregisterBrokerRequest {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())

--- a/src/messages/unregister_broker_response.rs
+++ b/src/messages/unregister_broker_response.rs
@@ -51,23 +51,23 @@ impl Builder for UnregisterBrokerResponse {
 
 impl Encodable for UnregisterBrokerResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.throttle_time_ms)?;
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i32(self.throttle_time_ms);
+        buf.put_i16(self.error_code);
         types::CompactString.encode(buf, &self.error_message)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 4;
+        total_size += 2;
         total_size += types::CompactString.compute_size(&self.error_message)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
@@ -83,8 +83,8 @@ impl Encodable for UnregisterBrokerResponse {
 
 impl Decodable for UnregisterBrokerResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let throttle_time_ms = types::Int32.decode(buf)?;
-        let error_code = types::Int16.decode(buf)?;
+        let throttle_time_ms = buf.try_get_i32()?;
+        let error_code = buf.try_get_i16()?;
         let error_message = types::CompactString.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
         let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;

--- a/src/messages/update_features_response.rs
+++ b/src/messages/update_features_response.rs
@@ -48,14 +48,14 @@ impl MapEncodable for UpdatableFeatureResult {
     type Key = StrBytes;
     fn encode<B: ByteBufMut>(&self, key: &Self::Key, buf: &mut B, version: i16) -> Result<(), EncodeError> {
         types::CompactString.encode(buf, key)?;
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i16(self.error_code);
         types::CompactString.encode(buf, &self.error_message)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
@@ -63,7 +63,7 @@ impl MapEncodable for UpdatableFeatureResult {
     fn compute_size(&self, key: &Self::Key, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
         total_size += types::CompactString.compute_size(key)?;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 2;
         total_size += types::CompactString.compute_size(&self.error_message)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
@@ -81,7 +81,7 @@ impl MapDecodable for UpdatableFeatureResult {
     type Key = StrBytes;
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<(Self::Key, Self), DecodeError> {
         let key_field = types::CompactString.decode(buf)?;
-        let error_code = types::Int16.decode(buf)?;
+        let error_code = buf.try_get_i16()?;
         let error_message = types::CompactString.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
         let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
@@ -152,8 +152,8 @@ impl Builder for UpdateFeaturesResponse {
 
 impl Encodable for UpdateFeaturesResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.throttle_time_ms)?;
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i32(self.throttle_time_ms);
+        buf.put_i16(self.error_code);
         types::CompactString.encode(buf, &self.error_message)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.results)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -161,15 +161,15 @@ impl Encodable for UpdateFeaturesResponse {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 4;
+        total_size += 2;
         total_size += types::CompactString.compute_size(&self.error_message)?;
         total_size += types::CompactArray(types::Struct { version }).compute_size(&self.results)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -186,8 +186,8 @@ impl Encodable for UpdateFeaturesResponse {
 
 impl Decodable for UpdateFeaturesResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let throttle_time_ms = types::Int32.decode(buf)?;
-        let error_code = types::Int16.decode(buf)?;
+        let throttle_time_ms = buf.try_get_i32()?;
+        let error_code = buf.try_get_i16()?;
         let error_message = types::CompactString.decode(buf)?;
         let results = types::CompactArray(types::Struct { version }).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();

--- a/src/messages/update_metadata_request.rs
+++ b/src/messages/update_metadata_request.rs
@@ -84,16 +84,16 @@ impl Encodable for UpdateMetadataPartitionState {
         if version <= 4 {
             types::String.encode(buf, &self.topic_name)?;
         }
-        types::Int32.encode(buf, &self.partition_index)?;
-        types::Int32.encode(buf, &self.controller_epoch)?;
+        buf.put_i32(self.partition_index);
+        buf.put_i32(self.controller_epoch);
         types::Int32.encode(buf, &self.leader)?;
-        types::Int32.encode(buf, &self.leader_epoch)?;
+        buf.put_i32(self.leader_epoch);
         if version >= 6 {
             types::CompactArray(types::Int32).encode(buf, &self.isr)?;
         } else {
             types::Array(types::Int32).encode(buf, &self.isr)?;
         }
-        types::Int32.encode(buf, &self.zk_version)?;
+        buf.put_i32(self.zk_version);
         if version >= 6 {
             types::CompactArray(types::Int32).encode(buf, &self.replicas)?;
         } else {
@@ -112,7 +112,7 @@ impl Encodable for UpdateMetadataPartitionState {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -123,16 +123,16 @@ impl Encodable for UpdateMetadataPartitionState {
         if version <= 4 {
             total_size += types::String.compute_size(&self.topic_name)?;
         }
-        total_size += types::Int32.compute_size(&self.partition_index)?;
-        total_size += types::Int32.compute_size(&self.controller_epoch)?;
+        total_size += 4;
+        total_size += 4;
         total_size += types::Int32.compute_size(&self.leader)?;
-        total_size += types::Int32.compute_size(&self.leader_epoch)?;
+        total_size += 4;
         if version >= 6 {
             total_size += types::CompactArray(types::Int32).compute_size(&self.isr)?;
         } else {
             total_size += types::Array(types::Int32).compute_size(&self.isr)?;
         }
-        total_size += types::Int32.compute_size(&self.zk_version)?;
+        total_size += 4;
         if version >= 6 {
             total_size += types::CompactArray(types::Int32).compute_size(&self.replicas)?;
         } else {
@@ -166,16 +166,16 @@ impl Decodable for UpdateMetadataPartitionState {
         } else {
             Default::default()
         };
-        let partition_index = types::Int32.decode(buf)?;
-        let controller_epoch = types::Int32.decode(buf)?;
+        let partition_index = buf.try_get_i32()?;
+        let controller_epoch = buf.try_get_i32()?;
         let leader = types::Int32.decode(buf)?;
-        let leader_epoch = types::Int32.decode(buf)?;
+        let leader_epoch = buf.try_get_i32()?;
         let isr = if version >= 6 {
             types::CompactArray(types::Int32).decode(buf)?
         } else {
             types::Array(types::Int32).decode(buf)?
         };
-        let zk_version = types::Int32.decode(buf)?;
+        let zk_version = buf.try_get_i32()?;
         let replicas = if version >= 6 {
             types::CompactArray(types::Int32).decode(buf)?
         } else {
@@ -282,7 +282,7 @@ impl Encodable for UpdateMetadataTopicState {
             }
         }
         if version >= 7 {
-            types::Uuid.encode(buf, &self.topic_id)?;
+            types::Uuid.encode(buf, self.topic_id)?;
         }
         if version >= 5 {
             if version >= 6 {
@@ -301,7 +301,7 @@ impl Encodable for UpdateMetadataTopicState {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -321,7 +321,7 @@ impl Encodable for UpdateMetadataTopicState {
             }
         }
         if version >= 7 {
-            total_size += types::Uuid.compute_size(&self.topic_id)?;
+            total_size += types::Uuid.compute_size(self.topic_id)?;
         }
         if version >= 5 {
             if version >= 6 {
@@ -447,7 +447,7 @@ impl Builder for UpdateMetadataEndpoint {
 impl Encodable for UpdateMetadataEndpoint {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
         if version >= 1 {
-            types::Int32.encode(buf, &self.port)?;
+            buf.put_i32(self.port);
         } else {
             if self.port != 0 {
                 return Err(EncodeError)
@@ -472,7 +472,7 @@ impl Encodable for UpdateMetadataEndpoint {
             }
         }
         if version >= 1 {
-            types::Int16.encode(buf, &self.security_protocol)?;
+            buf.put_i16(self.security_protocol);
         } else {
             if self.security_protocol != 0 {
                 return Err(EncodeError)
@@ -484,7 +484,7 @@ impl Encodable for UpdateMetadataEndpoint {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -493,7 +493,7 @@ impl Encodable for UpdateMetadataEndpoint {
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
         if version >= 1 {
-            total_size += types::Int32.compute_size(&self.port)?;
+            total_size += 4;
         } else {
             if self.port != 0 {
                 return Err(EncodeError)
@@ -518,7 +518,7 @@ impl Encodable for UpdateMetadataEndpoint {
             }
         }
         if version >= 1 {
-            total_size += types::Int16.compute_size(&self.security_protocol)?;
+            total_size += 2;
         } else {
             if self.security_protocol != 0 {
                 return Err(EncodeError)
@@ -541,7 +541,7 @@ impl Encodable for UpdateMetadataEndpoint {
 impl Decodable for UpdateMetadataEndpoint {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
         let port = if version >= 1 {
-            types::Int32.decode(buf)?
+            buf.try_get_i32()?
         } else {
             0
         };
@@ -564,7 +564,7 @@ impl Decodable for UpdateMetadataEndpoint {
             Default::default()
         };
         let security_protocol = if version >= 1 {
-            types::Int16.decode(buf)?
+            buf.try_get_i16()?
         } else {
             0
         };
@@ -653,7 +653,7 @@ impl Encodable for UpdateMetadataBroker {
             types::String.encode(buf, &self.v0_host)?;
         }
         if version == 0 {
-            types::Int32.encode(buf, &self.v0_port)?;
+            buf.put_i32(self.v0_port);
         }
         if version >= 1 {
             if version >= 6 {
@@ -675,7 +675,7 @@ impl Encodable for UpdateMetadataBroker {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -688,7 +688,7 @@ impl Encodable for UpdateMetadataBroker {
             total_size += types::String.compute_size(&self.v0_host)?;
         }
         if version == 0 {
-            total_size += types::Int32.compute_size(&self.v0_port)?;
+            total_size += 4;
         }
         if version >= 1 {
             if version >= 6 {
@@ -727,7 +727,7 @@ impl Decodable for UpdateMetadataBroker {
             Default::default()
         };
         let v0_port = if version == 0 {
-            types::Int32.decode(buf)?
+            buf.try_get_i32()?
         } else {
             0
         };
@@ -837,9 +837,9 @@ impl Builder for UpdateMetadataRequest {
 impl Encodable for UpdateMetadataRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
         types::Int32.encode(buf, &self.controller_id)?;
-        types::Int32.encode(buf, &self.controller_epoch)?;
+        buf.put_i32(self.controller_epoch);
         if version >= 5 {
-            types::Int64.encode(buf, &self.broker_epoch)?;
+            buf.put_i64(self.broker_epoch);
         }
         if version <= 4 {
             types::Array(types::Struct { version }).encode(buf, &self.ungrouped_partition_states)?;
@@ -870,7 +870,7 @@ impl Encodable for UpdateMetadataRequest {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -879,9 +879,9 @@ impl Encodable for UpdateMetadataRequest {
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
         total_size += types::Int32.compute_size(&self.controller_id)?;
-        total_size += types::Int32.compute_size(&self.controller_epoch)?;
+        total_size += 4;
         if version >= 5 {
-            total_size += types::Int64.compute_size(&self.broker_epoch)?;
+            total_size += 8;
         }
         if version <= 4 {
             total_size += types::Array(types::Struct { version }).compute_size(&self.ungrouped_partition_states)?;
@@ -923,9 +923,9 @@ impl Encodable for UpdateMetadataRequest {
 impl Decodable for UpdateMetadataRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
         let controller_id = types::Int32.decode(buf)?;
-        let controller_epoch = types::Int32.decode(buf)?;
+        let controller_epoch = buf.try_get_i32()?;
         let broker_epoch = if version >= 5 {
-            types::Int64.decode(buf)?
+            buf.try_get_i64()?
         } else {
             -1
         };

--- a/src/messages/update_metadata_response.rs
+++ b/src/messages/update_metadata_response.rs
@@ -41,14 +41,14 @@ impl Builder for UpdateMetadataResponse {
 
 impl Encodable for UpdateMetadataResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i16(self.error_code);
         if version >= 6 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -56,7 +56,7 @@ impl Encodable for UpdateMetadataResponse {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 2;
         if version >= 6 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
@@ -73,7 +73,7 @@ impl Encodable for UpdateMetadataResponse {
 
 impl Decodable for UpdateMetadataResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let error_code = types::Int16.decode(buf)?;
+        let error_code = buf.try_get_i16()?;
         let mut unknown_tagged_fields = BTreeMap::new();
         if version >= 6 {
             let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;

--- a/src/messages/vote_request.rs
+++ b/src/messages/vote_request.rs
@@ -61,28 +61,28 @@ impl Builder for PartitionData {
 
 impl Encodable for PartitionData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.partition_index)?;
-        types::Int32.encode(buf, &self.candidate_epoch)?;
+        buf.put_i32(self.partition_index);
+        buf.put_i32(self.candidate_epoch);
         types::Int32.encode(buf, &self.candidate_id)?;
-        types::Int32.encode(buf, &self.last_offset_epoch)?;
-        types::Int64.encode(buf, &self.last_offset)?;
+        buf.put_i32(self.last_offset_epoch);
+        buf.put_i64(self.last_offset);
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.partition_index)?;
-        total_size += types::Int32.compute_size(&self.candidate_epoch)?;
+        total_size += 4;
+        total_size += 4;
         total_size += types::Int32.compute_size(&self.candidate_id)?;
-        total_size += types::Int32.compute_size(&self.last_offset_epoch)?;
-        total_size += types::Int64.compute_size(&self.last_offset)?;
+        total_size += 4;
+        total_size += 8;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
@@ -97,11 +97,11 @@ impl Encodable for PartitionData {
 
 impl Decodable for PartitionData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let partition_index = types::Int32.decode(buf)?;
-        let candidate_epoch = types::Int32.decode(buf)?;
+        let partition_index = buf.try_get_i32()?;
+        let candidate_epoch = buf.try_get_i32()?;
         let candidate_id = types::Int32.decode(buf)?;
-        let last_offset_epoch = types::Int32.decode(buf)?;
-        let last_offset = types::Int64.decode(buf)?;
+        let last_offset_epoch = buf.try_get_i32()?;
+        let last_offset = buf.try_get_i64()?;
         let mut unknown_tagged_fields = BTreeMap::new();
         let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
         for _ in 0..num_tagged_fields {
@@ -174,7 +174,7 @@ impl Encodable for TopicData {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
@@ -265,7 +265,7 @@ impl Encodable for VoteRequest {
             error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
             return Err(EncodeError);
         }
-        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+        types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())

--- a/src/messages/write_txn_markers_response.rs
+++ b/src/messages/write_txn_markers_response.rs
@@ -46,15 +46,15 @@ impl Builder for WritableTxnMarkerPartitionResult {
 
 impl Encodable for WritableTxnMarkerPartitionResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<(), EncodeError> {
-        types::Int32.encode(buf, &self.partition_index)?;
-        types::Int16.encode(buf, &self.error_code)?;
+        buf.put_i32(self.partition_index);
+        buf.put_i16(self.error_code);
         if version >= 1 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -62,8 +62,8 @@ impl Encodable for WritableTxnMarkerPartitionResult {
     }
     fn compute_size(&self, version: i16) -> Result<usize, EncodeError> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(&self.partition_index)?;
-        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += 4;
+        total_size += 2;
         if version >= 1 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
             if num_tagged_fields > std::u32::MAX as usize {
@@ -80,8 +80,8 @@ impl Encodable for WritableTxnMarkerPartitionResult {
 
 impl Decodable for WritableTxnMarkerPartitionResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self, DecodeError> {
-        let partition_index = types::Int32.decode(buf)?;
-        let error_code = types::Int16.decode(buf)?;
+        let partition_index = buf.try_get_i32()?;
+        let error_code = buf.try_get_i16()?;
         let mut unknown_tagged_fields = BTreeMap::new();
         if version >= 1 {
             let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
@@ -159,7 +159,7 @@ impl Encodable for WritableTxnMarkerTopicResult {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -276,7 +276,7 @@ impl Encodable for WritableTxnMarkerResult {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }
@@ -379,7 +379,7 @@ impl Encodable for WriteTxnMarkersResponse {
                 error!("Too many tagged fields to encode ({} fields)", num_tagged_fields);
                 return Err(EncodeError);
             }
-            types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+            types::UnsignedVarInt::put_u32(buf, num_tagged_fields as u32);
 
             write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         }

--- a/src/protocol/types.rs
+++ b/src/protocol/types.rs
@@ -101,6 +101,16 @@ define_simple_ints! {
 #[derive(Debug, Copy, Clone, Default)]
 pub struct UnsignedVarInt;
 
+impl UnsignedVarInt {
+    pub(crate) fn put_u32<B: ByteBufMut>(buf: &mut B, mut value: u32) {
+        while value >= 0x80 {
+            buf.put_u8((value as u8) | 0x80);
+            value >>= 7;
+        }
+        buf.put_u8(value as u8);
+    }
+}
+
 impl<T: NewType<u32>> Encoder<&T> for UnsignedVarInt {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, value: &T) -> Result<(), EncodeError> {
         let mut value = *value.borrow();


### PR DESCRIPTION
Just a heads up that I'm working on this, in case you wanted to include it in the next release.
It should be non-breaking so you could go ahead and release 0.9 and then include this in 0.9.1

This PR alters codegen so that we directly encode/decode some primitive types, this has a few advantages:
* Improves build time
   + on my full LTO release profile on my project, this PR has so far cut 3 seconds off the build time, I'm hoping to get even more with some more effort.
   + this was the driving factor behind this PR.
* Makes the code easier to read
   + less layers makes it easier for a user to examine the implementation to see what its doing
   + removes the `?` making it clearer to the user that those lines are not actually fallible.