### PR TITLE
fix lz4 compression

### DIFF
--- a/src/compression/lz4.rs
+++ b/src/compression/lz4.rs
@@ -26,6 +26,7 @@ impl<B: ByteBufMut> Compressor<B> for Lz4 {
 
         let mut encoder = EncoderBuilder::new()
             .level(COMPRESSION_LEVEL)
+            .block_mode(BlockMode::Independent)
             .build(buf.writer())
             .context("Failed to compress lz4")?;
 

--- a/src/compression/lz4.rs
+++ b/src/compression/lz4.rs
@@ -3,7 +3,7 @@ use crate::protocol::{DecodeError, EncodeError};
 use anyhow::Context;
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use std::io;
-
+use lz4::BlockMode;
 use lz4::{Decoder, EncoderBuilder};
 
 use super::{Compressor, Decompressor};


### PR DESCRIPTION
kafka java client doesnt support depedent blocks. without the fix in this PR, the kafka java client will throw an exception.

https://github.com/a0x8o/kafka/blob/54eff6af115ee647f60129f2ce6a044cb17215d0/clients/src/main/java/org/apache/kafka/common/record/KafkaLZ4BlockOutputStream.java#L344