### PR TITLE
use CRC-32 ISO/HDLC instead of CRC-32 CKSUM

### DIFF
--- a/src/records.rs
+++ b/src/records.rs
@@ -32,7 +32,7 @@
 //! ```
 use anyhow::{anyhow, bail};
 use bytes::Bytes;
-use crc::{Crc, CRC_32_CKSUM};
+use crc::{Crc, CRC_32_ISO_HDLC};
 use crc32c::crc32c;
 use indexmap::IndexMap;
 
@@ -46,7 +46,7 @@ use std::cmp::Ordering;
 use std::convert::TryFrom;
 
 /// IEEE (checksum) cyclic redundancy check.
-pub const IEEE: Crc<u32> = Crc::<u32>::new(&CRC_32_CKSUM);
+pub const IEEE: Crc<u32> = Crc::<u32>::new(&CRC_32_ISO_HDLC);
 
 /// The different types of compression supported by Kafka.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]


### PR DESCRIPTION
For v0/v1 message sets, [Kafka uses `java.util.zip.CRC32`](https://github.com/apache/kafka/blob/a66a59f427b30611175fd029d86832d00aa5aabd/clients/src/main/java/org/apache/kafka/common/record/LegacyRecord.java#L29) which is `CRC_32_ISO_HDLC`, not `CRC_32_CKSUM`.

This will successfully decode message sets from Kafka v3.7. However, I have not yet tried to encode message sets and send them to Kafka.