### PR TITLE
Use `IntoIterator` instead of `Iterator` for `RecordBatchEncoder::encode`

### DIFF
--- a/src/records.rs
+++ b/src/records.rs
@@ -158,8 +158,10 @@ impl RecordBatchEncoder {
     ) -> Result<(), EncodeError>
     where
         B: ByteBufMut,
-        I: Iterator<Item = &'a Record> + Clone,
+        I: IntoIterator<Item = &'a Record>,
+        I::IntoIter: Clone,
     {
+        let records = records.into_iter();
         match options.version {
             0..=1 => Self::encode_legacy(buf, records, options),
             2 => Self::encode_new(buf, records, options),

--- a/tests/produce_fetch.rs
+++ b/tests/produce_fetch.rs
@@ -35,7 +35,7 @@ fn record_batch_produce_fetch() {
     let mut encoded = BytesMut::new();
     RecordBatchEncoder::encode(
         &mut encoded,
-        records.iter(),
+        &records,
         &RecordEncodeOptions {
             version: 2,
             compression: Compression::None,
@@ -69,7 +69,7 @@ fn message_set_v1_produce_fetch() {
     let mut encoded = BytesMut::new();
     RecordBatchEncoder::encode(
         &mut encoded,
-        records.iter(),
+        &records,
         &RecordEncodeOptions {
             version: 1,
             compression: Compression::None,


### PR DESCRIPTION
Just a small change to make the library slightly easier to use.