### PR TITLE
Update to kafka 3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Update protocol to kafka 3.8.0
+
 ## v0.12.0
 
 - Add `client` feature to enable encoding of requests and decoding of responses (enabled by default)
@@ -40,12 +44,15 @@ and other misc improvements.
 - Update `derive-builder`.
 
 ## v0.8.2
+
 - Expose protocol::buf::gap module.
 
 ## v0.8.1
+
 - Re-export `indexmap` as part of the public api.
 
 ## v0.8.0
+
 - Implement Zstd and Lz4 compression.
 
 ## v0.7.0
@@ -85,17 +92,16 @@ with protocol upgrades.
 
 - Add utilities for dealing with response error codes.
 
-## v0.3.0 
+## v0.3.0
 
-#### Enhancements:
+#### Enhancements
 
 - Build messages from crate root.
 - Upgrade to latest version of Kafka protocol.
 
+## v0.2.0
 
-## v0.2.0 
-
-#### Enhancements:
+#### Enhancements
 
 - Add derive builder for all messages.
 

--- a/protocol_codegen/src/generate_messages.rs
+++ b/protocol_codegen/src/generate_messages.rs
@@ -40,9 +40,9 @@ pub fn run() -> Result<(), Error> {
     };
 
     // Checkout the release commit
-    // https://github.com/apache/kafka/releases/tag/3.7.0
+    // https://github.com/apache/kafka/releases/tag/3.8.0
     // checking out a tag with git2 is annoying -- we pin to the tag's commit sha instead
-    let release_commit = "2ae524ed625438c5fee89e78648bd73e64a3ada0";
+    let release_commit = "771b9576b00ecf5b64ab6e8bedf04156fbdb5cd6";
     println!("Checking out release {}", release_commit);
     let oid = Oid::from_str(release_commit).unwrap();
     let commit = repo

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -27,6 +27,9 @@ pub use consumer_protocol_subscription::ConsumerProtocolSubscription;
 pub mod default_principal_data;
 pub use default_principal_data::DefaultPrincipalData;
 
+pub mod k_raft_version_record;
+pub use k_raft_version_record::KRaftVersionRecord;
+
 pub mod leader_change_message;
 pub use leader_change_message::LeaderChangeMessage;
 
@@ -41,6 +44,9 @@ pub use snapshot_footer_record::SnapshotFooterRecord;
 
 pub mod snapshot_header_record;
 pub use snapshot_header_record::SnapshotHeaderRecord;
+
+pub mod voters_record;
+pub use voters_record::VotersRecord;
 
 pub mod produce_request;
 pub use produce_request::ProduceRequest;
@@ -249,6 +255,9 @@ pub use allocate_producer_ids_request::AllocateProducerIdsRequest;
 pub mod consumer_group_heartbeat_request;
 pub use consumer_group_heartbeat_request::ConsumerGroupHeartbeatRequest;
 
+pub mod consumer_group_describe_request;
+pub use consumer_group_describe_request::ConsumerGroupDescribeRequest;
+
 pub mod controller_registration_request;
 pub use controller_registration_request::ControllerRegistrationRequest;
 
@@ -263,6 +272,9 @@ pub use assign_replicas_to_dirs_request::AssignReplicasToDirsRequest;
 
 pub mod list_client_metrics_resources_request;
 pub use list_client_metrics_resources_request::ListClientMetricsResourcesRequest;
+
+pub mod describe_topic_partitions_request;
+pub use describe_topic_partitions_request::DescribeTopicPartitionsRequest;
 
 pub mod produce_response;
 pub use produce_response::ProduceResponse;
@@ -471,6 +483,9 @@ pub use allocate_producer_ids_response::AllocateProducerIdsResponse;
 pub mod consumer_group_heartbeat_response;
 pub use consumer_group_heartbeat_response::ConsumerGroupHeartbeatResponse;
 
+pub mod consumer_group_describe_response;
+pub use consumer_group_describe_response::ConsumerGroupDescribeResponse;
+
 pub mod controller_registration_response;
 pub use controller_registration_response::ControllerRegistrationResponse;
 
@@ -485,6 +500,9 @@ pub use assign_replicas_to_dirs_response::AssignReplicasToDirsResponse;
 
 pub mod list_client_metrics_resources_response;
 pub use list_client_metrics_resources_response::ListClientMetricsResourcesResponse;
+
+pub mod describe_topic_partitions_response;
+pub use describe_topic_partitions_response::DescribeTopicPartitionsResponse;
 
 #[cfg(all(feature = "client", feature = "broker"))]
 impl Request for ProduceRequest {
@@ -901,6 +919,12 @@ impl Request for ConsumerGroupHeartbeatRequest {
 }
 
 #[cfg(all(feature = "client", feature = "broker"))]
+impl Request for ConsumerGroupDescribeRequest {
+    const KEY: i16 = 69;
+    type Response = ConsumerGroupDescribeResponse;
+}
+
+#[cfg(all(feature = "client", feature = "broker"))]
 impl Request for ControllerRegistrationRequest {
     const KEY: i16 = 70;
     type Response = ControllerRegistrationResponse;
@@ -928,6 +952,12 @@ impl Request for AssignReplicasToDirsRequest {
 impl Request for ListClientMetricsResourcesRequest {
     const KEY: i16 = 74;
     type Response = ListClientMetricsResourcesResponse;
+}
+
+#[cfg(all(feature = "client", feature = "broker"))]
+impl Request for DescribeTopicPartitionsRequest {
+    const KEY: i16 = 75;
+    type Response = DescribeTopicPartitionsResponse;
 }
 
 /// Valid API keys in the Kafka protocol.
@@ -1071,6 +1101,8 @@ pub enum ApiKey {
     AllocateProducerIdsKey = 67,
     /// API key for request ConsumerGroupHeartbeatRequest
     ConsumerGroupHeartbeatKey = 68,
+    /// API key for request ConsumerGroupDescribeRequest
+    ConsumerGroupDescribeKey = 69,
     /// API key for request ControllerRegistrationRequest
     ControllerRegistrationKey = 70,
     /// API key for request GetTelemetrySubscriptionsRequest
@@ -1081,6 +1113,8 @@ pub enum ApiKey {
     AssignReplicasToDirsKey = 73,
     /// API key for request ListClientMetricsResourcesRequest
     ListClientMetricsResourcesKey = 74,
+    /// API key for request DescribeTopicPartitionsRequest
+    DescribeTopicPartitionsKey = 75,
 }
 
 impl ApiKey {
@@ -1174,6 +1208,9 @@ impl ApiKey {
             ApiKey::ConsumerGroupHeartbeatKey => {
                 ConsumerGroupHeartbeatRequest::header_version(version)
             }
+            ApiKey::ConsumerGroupDescribeKey => {
+                ConsumerGroupDescribeRequest::header_version(version)
+            }
             ApiKey::ControllerRegistrationKey => {
                 ControllerRegistrationRequest::header_version(version)
             }
@@ -1184,6 +1221,9 @@ impl ApiKey {
             ApiKey::AssignReplicasToDirsKey => AssignReplicasToDirsRequest::header_version(version),
             ApiKey::ListClientMetricsResourcesKey => {
                 ListClientMetricsResourcesRequest::header_version(version)
+            }
+            ApiKey::DescribeTopicPartitionsKey => {
+                DescribeTopicPartitionsRequest::header_version(version)
             }
         }
     }
@@ -1285,6 +1325,9 @@ impl ApiKey {
             ApiKey::ConsumerGroupHeartbeatKey => {
                 ConsumerGroupHeartbeatResponse::header_version(version)
             }
+            ApiKey::ConsumerGroupDescribeKey => {
+                ConsumerGroupDescribeResponse::header_version(version)
+            }
             ApiKey::ControllerRegistrationKey => {
                 ControllerRegistrationResponse::header_version(version)
             }
@@ -1297,6 +1340,9 @@ impl ApiKey {
             }
             ApiKey::ListClientMetricsResourcesKey => {
                 ListClientMetricsResourcesResponse::header_version(version)
+            }
+            ApiKey::DescribeTopicPartitionsKey => {
+                DescribeTopicPartitionsResponse::header_version(version)
             }
         }
     }
@@ -1393,6 +1439,9 @@ impl TryFrom<i16> for ApiKey {
             x if x == ApiKey::ConsumerGroupHeartbeatKey as i16 => {
                 Ok(ApiKey::ConsumerGroupHeartbeatKey)
             }
+            x if x == ApiKey::ConsumerGroupDescribeKey as i16 => {
+                Ok(ApiKey::ConsumerGroupDescribeKey)
+            }
             x if x == ApiKey::ControllerRegistrationKey as i16 => {
                 Ok(ApiKey::ControllerRegistrationKey)
             }
@@ -1403,6 +1452,9 @@ impl TryFrom<i16> for ApiKey {
             x if x == ApiKey::AssignReplicasToDirsKey as i16 => Ok(ApiKey::AssignReplicasToDirsKey),
             x if x == ApiKey::ListClientMetricsResourcesKey as i16 => {
                 Ok(ApiKey::ListClientMetricsResourcesKey)
+            }
+            x if x == ApiKey::DescribeTopicPartitionsKey as i16 => {
+                Ok(ApiKey::DescribeTopicPartitionsKey)
             }
             _ => Err(()),
         }
@@ -1552,6 +1604,8 @@ pub enum RequestKind {
     AllocateProducerIds(AllocateProducerIdsRequest),
     /// ConsumerGroupHeartbeatRequest,
     ConsumerGroupHeartbeat(ConsumerGroupHeartbeatRequest),
+    /// ConsumerGroupDescribeRequest,
+    ConsumerGroupDescribe(ConsumerGroupDescribeRequest),
     /// ControllerRegistrationRequest,
     ControllerRegistration(ControllerRegistrationRequest),
     /// GetTelemetrySubscriptionsRequest,
@@ -1562,6 +1616,8 @@ pub enum RequestKind {
     AssignReplicasToDirs(AssignReplicasToDirsRequest),
     /// ListClientMetricsResourcesRequest,
     ListClientMetricsResources(ListClientMetricsResourcesRequest),
+    /// DescribeTopicPartitionsRequest,
+    DescribeTopicPartitions(DescribeTopicPartitionsRequest),
 }
 
 #[cfg(feature = "messages_enums")]
@@ -1639,11 +1695,13 @@ impl RequestKind {
             RequestKind::ListTransactions(x) => encode(x, bytes, version),
             RequestKind::AllocateProducerIds(x) => encode(x, bytes, version),
             RequestKind::ConsumerGroupHeartbeat(x) => encode(x, bytes, version),
+            RequestKind::ConsumerGroupDescribe(x) => encode(x, bytes, version),
             RequestKind::ControllerRegistration(x) => encode(x, bytes, version),
             RequestKind::GetTelemetrySubscriptions(x) => encode(x, bytes, version),
             RequestKind::PushTelemetry(x) => encode(x, bytes, version),
             RequestKind::AssignReplicasToDirs(x) => encode(x, bytes, version),
             RequestKind::ListClientMetricsResources(x) => encode(x, bytes, version),
+            RequestKind::DescribeTopicPartitions(x) => encode(x, bytes, version),
         }
     }
     /// Decode the message from the provided buffer and version
@@ -1773,6 +1831,9 @@ impl RequestKind {
             ApiKey::ConsumerGroupHeartbeatKey => {
                 Ok(RequestKind::ConsumerGroupHeartbeat(decode(bytes, version)?))
             }
+            ApiKey::ConsumerGroupDescribeKey => {
+                Ok(RequestKind::ConsumerGroupDescribe(decode(bytes, version)?))
+            }
             ApiKey::ControllerRegistrationKey => {
                 Ok(RequestKind::ControllerRegistration(decode(bytes, version)?))
             }
@@ -1786,6 +1847,9 @@ impl RequestKind {
             ApiKey::ListClientMetricsResourcesKey => Ok(RequestKind::ListClientMetricsResources(
                 decode(bytes, version)?,
             )),
+            ApiKey::DescribeTopicPartitionsKey => Ok(RequestKind::DescribeTopicPartitions(decode(
+                bytes, version,
+            )?)),
         }
     }
 }
@@ -2273,6 +2337,13 @@ impl From<ConsumerGroupHeartbeatRequest> for RequestKind {
 }
 
 #[cfg(feature = "messages_enums")]
+impl From<ConsumerGroupDescribeRequest> for RequestKind {
+    fn from(value: ConsumerGroupDescribeRequest) -> RequestKind {
+        RequestKind::ConsumerGroupDescribe(value)
+    }
+}
+
+#[cfg(feature = "messages_enums")]
 impl From<ControllerRegistrationRequest> for RequestKind {
     fn from(value: ControllerRegistrationRequest) -> RequestKind {
         RequestKind::ControllerRegistration(value)
@@ -2304,6 +2375,13 @@ impl From<AssignReplicasToDirsRequest> for RequestKind {
 impl From<ListClientMetricsResourcesRequest> for RequestKind {
     fn from(value: ListClientMetricsResourcesRequest) -> RequestKind {
         RequestKind::ListClientMetricsResources(value)
+    }
+}
+
+#[cfg(feature = "messages_enums")]
+impl From<DescribeTopicPartitionsRequest> for RequestKind {
+    fn from(value: DescribeTopicPartitionsRequest) -> RequestKind {
+        RequestKind::DescribeTopicPartitions(value)
     }
 }
 
@@ -2474,6 +2552,8 @@ pub enum ResponseKind {
     AllocateProducerIds(AllocateProducerIdsResponse),
     /// ConsumerGroupHeartbeatResponse,
     ConsumerGroupHeartbeat(ConsumerGroupHeartbeatResponse),
+    /// ConsumerGroupDescribeResponse,
+    ConsumerGroupDescribe(ConsumerGroupDescribeResponse),
     /// ControllerRegistrationResponse,
     ControllerRegistration(ControllerRegistrationResponse),
     /// GetTelemetrySubscriptionsResponse,
@@ -2484,6 +2564,8 @@ pub enum ResponseKind {
     AssignReplicasToDirs(AssignReplicasToDirsResponse),
     /// ListClientMetricsResourcesResponse,
     ListClientMetricsResources(ListClientMetricsResourcesResponse),
+    /// DescribeTopicPartitionsResponse,
+    DescribeTopicPartitions(DescribeTopicPartitionsResponse),
 }
 
 #[cfg(feature = "messages_enums")]
@@ -2561,11 +2643,13 @@ impl ResponseKind {
             ResponseKind::ListTransactions(x) => encode(x, bytes, version),
             ResponseKind::AllocateProducerIds(x) => encode(x, bytes, version),
             ResponseKind::ConsumerGroupHeartbeat(x) => encode(x, bytes, version),
+            ResponseKind::ConsumerGroupDescribe(x) => encode(x, bytes, version),
             ResponseKind::ControllerRegistration(x) => encode(x, bytes, version),
             ResponseKind::GetTelemetrySubscriptions(x) => encode(x, bytes, version),
             ResponseKind::PushTelemetry(x) => encode(x, bytes, version),
             ResponseKind::AssignReplicasToDirs(x) => encode(x, bytes, version),
             ResponseKind::ListClientMetricsResources(x) => encode(x, bytes, version),
+            ResponseKind::DescribeTopicPartitions(x) => encode(x, bytes, version),
         }
     }
     /// Decode the message from the provided buffer and version
@@ -2711,6 +2795,9 @@ impl ResponseKind {
             ApiKey::ConsumerGroupHeartbeatKey => Ok(ResponseKind::ConsumerGroupHeartbeat(decode(
                 bytes, version,
             )?)),
+            ApiKey::ConsumerGroupDescribeKey => {
+                Ok(ResponseKind::ConsumerGroupDescribe(decode(bytes, version)?))
+            }
             ApiKey::ControllerRegistrationKey => Ok(ResponseKind::ControllerRegistration(decode(
                 bytes, version,
             )?)),
@@ -2722,6 +2809,9 @@ impl ResponseKind {
                 Ok(ResponseKind::AssignReplicasToDirs(decode(bytes, version)?))
             }
             ApiKey::ListClientMetricsResourcesKey => Ok(ResponseKind::ListClientMetricsResources(
+                decode(bytes, version)?,
+            )),
+            ApiKey::DescribeTopicPartitionsKey => Ok(ResponseKind::DescribeTopicPartitions(
                 decode(bytes, version)?,
             )),
         }
@@ -2838,6 +2928,9 @@ impl ResponseKind {
             ResponseKind::ConsumerGroupHeartbeat(_) => {
                 ConsumerGroupHeartbeatResponse::header_version(version)
             }
+            ResponseKind::ConsumerGroupDescribe(_) => {
+                ConsumerGroupDescribeResponse::header_version(version)
+            }
             ResponseKind::ControllerRegistration(_) => {
                 ControllerRegistrationResponse::header_version(version)
             }
@@ -2850,6 +2943,9 @@ impl ResponseKind {
             }
             ResponseKind::ListClientMetricsResources(_) => {
                 ListClientMetricsResourcesResponse::header_version(version)
+            }
+            ResponseKind::DescribeTopicPartitions(_) => {
+                DescribeTopicPartitionsResponse::header_version(version)
             }
         }
     }
@@ -3339,6 +3435,13 @@ impl From<ConsumerGroupHeartbeatResponse> for ResponseKind {
 }
 
 #[cfg(feature = "messages_enums")]
+impl From<ConsumerGroupDescribeResponse> for ResponseKind {
+    fn from(value: ConsumerGroupDescribeResponse) -> ResponseKind {
+        ResponseKind::ConsumerGroupDescribe(value)
+    }
+}
+
+#[cfg(feature = "messages_enums")]
 impl From<ControllerRegistrationResponse> for ResponseKind {
     fn from(value: ControllerRegistrationResponse) -> ResponseKind {
         ResponseKind::ControllerRegistration(value)
@@ -3373,7 +3476,14 @@ impl From<ListClientMetricsResourcesResponse> for ResponseKind {
     }
 }
 
-/// The ID of the controller broker.
+#[cfg(feature = "messages_enums")]
+impl From<DescribeTopicPartitionsResponse> for ResponseKind {
+    fn from(value: DescribeTopicPartitionsResponse) -> ResponseKind {
+        ResponseKind::DescribeTopicPartitions(value)
+    }
+}
+
+/// The ID of the leader broker.
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default, Copy)]
 pub struct BrokerId(pub i32);
 
@@ -3410,7 +3520,7 @@ impl std::cmp::PartialEq<BrokerId> for i32 {
 }
 impl NewType<i32> for BrokerId {}
 
-/// The group id
+/// The group ID string.
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
 pub struct GroupId(pub StrBytes);
 
@@ -3484,7 +3594,7 @@ impl std::cmp::PartialEq<ProducerId> for i64 {
 }
 impl NewType<i64> for ProducerId {}
 
-///
+/// The topic name.
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
 pub struct TopicName(pub StrBytes);
 

--- a/src/messages/add_offsets_to_txn_request.rs
+++ b/src/messages/add_offsets_to_txn_request.rs
@@ -17,28 +17,28 @@ use crate::protocol::{
     Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
 };
 
-/// Valid versions: 0-3
+/// Valid versions: 0-4
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct AddOffsetsToTxnRequest {
     /// The transactional id corresponding to the transaction.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub transactional_id: super::TransactionalId,
 
     /// Current producer id in use by the transactional id.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub producer_id: super::ProducerId,
 
     /// Current epoch associated with the producer id.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub producer_epoch: i16,
 
     /// The unique group identifier.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub group_id: super::GroupId,
 
     /// Other tagged fields
@@ -50,7 +50,7 @@ impl AddOffsetsToTxnRequest {
     ///
     /// The transactional id corresponding to the transaction.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub fn with_transactional_id(mut self, value: super::TransactionalId) -> Self {
         self.transactional_id = value;
         self
@@ -59,7 +59,7 @@ impl AddOffsetsToTxnRequest {
     ///
     /// Current producer id in use by the transactional id.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub fn with_producer_id(mut self, value: super::ProducerId) -> Self {
         self.producer_id = value;
         self
@@ -68,7 +68,7 @@ impl AddOffsetsToTxnRequest {
     ///
     /// Current epoch associated with the producer id.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub fn with_producer_epoch(mut self, value: i16) -> Self {
         self.producer_epoch = value;
         self
@@ -77,7 +77,7 @@ impl AddOffsetsToTxnRequest {
     ///
     /// The unique group identifier.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub fn with_group_id(mut self, value: super::GroupId) -> Self {
         self.group_id = value;
         self
@@ -201,7 +201,7 @@ impl Default for AddOffsetsToTxnRequest {
 }
 
 impl Message for AddOffsetsToTxnRequest {
-    const VERSIONS: VersionRange = VersionRange { min: 0, max: 3 };
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 4 };
     const DEPRECATED_VERSIONS: Option<VersionRange> = None;
 }
 

--- a/src/messages/add_offsets_to_txn_response.rs
+++ b/src/messages/add_offsets_to_txn_response.rs
@@ -17,18 +17,18 @@ use crate::protocol::{
     Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
 };
 
-/// Valid versions: 0-3
+/// Valid versions: 0-4
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct AddOffsetsToTxnResponse {
     /// Duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub throttle_time_ms: i32,
 
     /// The response error code, or 0 if there was no error.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub error_code: i16,
 
     /// Other tagged fields
@@ -40,7 +40,7 @@ impl AddOffsetsToTxnResponse {
     ///
     /// Duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub fn with_throttle_time_ms(mut self, value: i32) -> Self {
         self.throttle_time_ms = value;
         self
@@ -49,7 +49,7 @@ impl AddOffsetsToTxnResponse {
     ///
     /// The response error code, or 0 if there was no error.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub fn with_error_code(mut self, value: i16) -> Self {
         self.error_code = value;
         self
@@ -139,7 +139,7 @@ impl Default for AddOffsetsToTxnResponse {
 }
 
 impl Message for AddOffsetsToTxnResponse {
-    const VERSIONS: VersionRange = VersionRange { min: 0, max: 3 };
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 4 };
     const DEPRECATED_VERSIONS: Option<VersionRange> = None;
 }
 

--- a/src/messages/add_partitions_to_txn_request.rs
+++ b/src/messages/add_partitions_to_txn_request.rs
@@ -17,13 +17,13 @@ use crate::protocol::{
     Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
 };
 
-/// Valid versions: 0-4
+/// Valid versions: 0-5
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct AddPartitionsToTxnRequest {
     /// List of transactions to add partitions to.
     ///
-    /// Supported API versions: 4
+    /// Supported API versions: 4-5
     pub transactions: indexmap::IndexMap<super::TransactionalId, AddPartitionsToTxnTransaction>,
 
     /// The transactional id corresponding to the transaction.
@@ -55,7 +55,7 @@ impl AddPartitionsToTxnRequest {
     ///
     /// List of transactions to add partitions to.
     ///
-    /// Supported API versions: 4
+    /// Supported API versions: 4-5
     pub fn with_transactions(
         mut self,
         value: indexmap::IndexMap<super::TransactionalId, AddPartitionsToTxnTransaction>,
@@ -311,17 +311,17 @@ impl Default for AddPartitionsToTxnRequest {
 }
 
 impl Message for AddPartitionsToTxnRequest {
-    const VERSIONS: VersionRange = VersionRange { min: 0, max: 4 };
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 5 };
     const DEPRECATED_VERSIONS: Option<VersionRange> = None;
 }
 
-/// Valid versions: 0-4
+/// Valid versions: 0-5
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct AddPartitionsToTxnTopic {
     /// The partition indexes to add to the transaction
     ///
-    /// Supported API versions: 0-4
+    /// Supported API versions: 0-5
     pub partitions: Vec<i32>,
 
     /// Other tagged fields
@@ -333,7 +333,7 @@ impl AddPartitionsToTxnTopic {
     ///
     /// The partition indexes to add to the transaction
     ///
-    /// Supported API versions: 0-4
+    /// Supported API versions: 0-5
     pub fn with_partitions(mut self, value: Vec<i32>) -> Self {
         self.partitions = value;
         self
@@ -450,32 +450,32 @@ impl Default for AddPartitionsToTxnTopic {
 }
 
 impl Message for AddPartitionsToTxnTopic {
-    const VERSIONS: VersionRange = VersionRange { min: 0, max: 4 };
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 5 };
     const DEPRECATED_VERSIONS: Option<VersionRange> = None;
 }
 
-/// Valid versions: 0-4
+/// Valid versions: 0-5
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct AddPartitionsToTxnTransaction {
     /// Current producer id in use by the transactional id.
     ///
-    /// Supported API versions: 4
+    /// Supported API versions: 4-5
     pub producer_id: super::ProducerId,
 
     /// Current epoch associated with the producer id.
     ///
-    /// Supported API versions: 4
+    /// Supported API versions: 4-5
     pub producer_epoch: i16,
 
     /// Boolean to signify if we want to check if the partition is in the transaction rather than add it.
     ///
-    /// Supported API versions: 4
+    /// Supported API versions: 4-5
     pub verify_only: bool,
 
     /// The partitions to add to the transaction.
     ///
-    /// Supported API versions: 4
+    /// Supported API versions: 4-5
     pub topics: indexmap::IndexMap<super::TopicName, AddPartitionsToTxnTopic>,
 
     /// Other tagged fields
@@ -487,7 +487,7 @@ impl AddPartitionsToTxnTransaction {
     ///
     /// Current producer id in use by the transactional id.
     ///
-    /// Supported API versions: 4
+    /// Supported API versions: 4-5
     pub fn with_producer_id(mut self, value: super::ProducerId) -> Self {
         self.producer_id = value;
         self
@@ -496,7 +496,7 @@ impl AddPartitionsToTxnTransaction {
     ///
     /// Current epoch associated with the producer id.
     ///
-    /// Supported API versions: 4
+    /// Supported API versions: 4-5
     pub fn with_producer_epoch(mut self, value: i16) -> Self {
         self.producer_epoch = value;
         self
@@ -505,7 +505,7 @@ impl AddPartitionsToTxnTransaction {
     ///
     /// Boolean to signify if we want to check if the partition is in the transaction rather than add it.
     ///
-    /// Supported API versions: 4
+    /// Supported API versions: 4-5
     pub fn with_verify_only(mut self, value: bool) -> Self {
         self.verify_only = value;
         self
@@ -514,7 +514,7 @@ impl AddPartitionsToTxnTransaction {
     ///
     /// The partitions to add to the transaction.
     ///
-    /// Supported API versions: 4
+    /// Supported API versions: 4-5
     pub fn with_topics(
         mut self,
         value: indexmap::IndexMap<super::TopicName, AddPartitionsToTxnTopic>,
@@ -706,7 +706,7 @@ impl Default for AddPartitionsToTxnTransaction {
 }
 
 impl Message for AddPartitionsToTxnTransaction {
-    const VERSIONS: VersionRange = VersionRange { min: 0, max: 4 };
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 5 };
     const DEPRECATED_VERSIONS: Option<VersionRange> = None;
 }
 

--- a/src/messages/add_partitions_to_txn_response.rs
+++ b/src/messages/add_partitions_to_txn_response.rs
@@ -17,13 +17,13 @@ use crate::protocol::{
     Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
 };
 
-/// Valid versions: 0-4
+/// Valid versions: 0-5
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct AddPartitionsToTxnPartitionResult {
     /// The response error code.
     ///
-    /// Supported API versions: 0-4
+    /// Supported API versions: 0-5
     pub partition_error_code: i16,
 
     /// Other tagged fields
@@ -35,7 +35,7 @@ impl AddPartitionsToTxnPartitionResult {
     ///
     /// The response error code.
     ///
-    /// Supported API versions: 0-4
+    /// Supported API versions: 0-5
     pub fn with_partition_error_code(mut self, value: i16) -> Self {
         self.partition_error_code = value;
         self
@@ -128,27 +128,27 @@ impl Default for AddPartitionsToTxnPartitionResult {
 }
 
 impl Message for AddPartitionsToTxnPartitionResult {
-    const VERSIONS: VersionRange = VersionRange { min: 0, max: 4 };
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 5 };
     const DEPRECATED_VERSIONS: Option<VersionRange> = None;
 }
 
-/// Valid versions: 0-4
+/// Valid versions: 0-5
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct AddPartitionsToTxnResponse {
     /// Duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota.
     ///
-    /// Supported API versions: 0-4
+    /// Supported API versions: 0-5
     pub throttle_time_ms: i32,
 
     /// The response top level error code.
     ///
-    /// Supported API versions: 4
+    /// Supported API versions: 4-5
     pub error_code: i16,
 
     /// Results categorized by transactional ID.
     ///
-    /// Supported API versions: 4
+    /// Supported API versions: 4-5
     pub results_by_transaction:
         indexmap::IndexMap<super::TransactionalId, AddPartitionsToTxnResult>,
 
@@ -167,7 +167,7 @@ impl AddPartitionsToTxnResponse {
     ///
     /// Duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota.
     ///
-    /// Supported API versions: 0-4
+    /// Supported API versions: 0-5
     pub fn with_throttle_time_ms(mut self, value: i32) -> Self {
         self.throttle_time_ms = value;
         self
@@ -176,7 +176,7 @@ impl AddPartitionsToTxnResponse {
     ///
     /// The response top level error code.
     ///
-    /// Supported API versions: 4
+    /// Supported API versions: 4-5
     pub fn with_error_code(mut self, value: i16) -> Self {
         self.error_code = value;
         self
@@ -185,7 +185,7 @@ impl AddPartitionsToTxnResponse {
     ///
     /// Results categorized by transactional ID.
     ///
-    /// Supported API versions: 4
+    /// Supported API versions: 4-5
     pub fn with_results_by_transaction(
         mut self,
         value: indexmap::IndexMap<super::TransactionalId, AddPartitionsToTxnResult>,
@@ -358,17 +358,17 @@ impl Default for AddPartitionsToTxnResponse {
 }
 
 impl Message for AddPartitionsToTxnResponse {
-    const VERSIONS: VersionRange = VersionRange { min: 0, max: 4 };
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 5 };
     const DEPRECATED_VERSIONS: Option<VersionRange> = None;
 }
 
-/// Valid versions: 0-4
+/// Valid versions: 0-5
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct AddPartitionsToTxnResult {
     /// The results for each topic.
     ///
-    /// Supported API versions: 4
+    /// Supported API versions: 4-5
     pub topic_results: indexmap::IndexMap<super::TopicName, AddPartitionsToTxnTopicResult>,
 
     /// Other tagged fields
@@ -380,7 +380,7 @@ impl AddPartitionsToTxnResult {
     ///
     /// The results for each topic.
     ///
-    /// Supported API versions: 4
+    /// Supported API versions: 4-5
     pub fn with_topic_results(
         mut self,
         value: indexmap::IndexMap<super::TopicName, AddPartitionsToTxnTopicResult>,
@@ -509,17 +509,17 @@ impl Default for AddPartitionsToTxnResult {
 }
 
 impl Message for AddPartitionsToTxnResult {
-    const VERSIONS: VersionRange = VersionRange { min: 0, max: 4 };
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 5 };
     const DEPRECATED_VERSIONS: Option<VersionRange> = None;
 }
 
-/// Valid versions: 0-4
+/// Valid versions: 0-5
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct AddPartitionsToTxnTopicResult {
     /// The results for each partition
     ///
-    /// Supported API versions: 0-4
+    /// Supported API versions: 0-5
     pub results_by_partition: indexmap::IndexMap<i32, AddPartitionsToTxnPartitionResult>,
 
     /// Other tagged fields
@@ -531,7 +531,7 @@ impl AddPartitionsToTxnTopicResult {
     ///
     /// The results for each partition
     ///
-    /// Supported API versions: 0-4
+    /// Supported API versions: 0-5
     pub fn with_results_by_partition(
         mut self,
         value: indexmap::IndexMap<i32, AddPartitionsToTxnPartitionResult>,
@@ -654,7 +654,7 @@ impl Default for AddPartitionsToTxnTopicResult {
 }
 
 impl Message for AddPartitionsToTxnTopicResult {
-    const VERSIONS: VersionRange = VersionRange { min: 0, max: 4 };
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 5 };
     const DEPRECATED_VERSIONS: Option<VersionRange> = None;
 }
 

--- a/src/messages/consumer_group_describe_request.rs
+++ b/src/messages/consumer_group_describe_request.rs
@@ -1,0 +1,144 @@
+//! ConsumerGroupDescribeRequest
+//!
+//! See the schema for this message [here](https://github.com/apache/kafka/blob/trunk/clients/src/main/resources/common/message/ConsumerGroupDescribeRequest.json).
+// WARNING: the items of this module are generated and should not be edited directly
+#![allow(unused)]
+
+use std::borrow::Borrow;
+use std::collections::BTreeMap;
+
+use anyhow::{bail, Result};
+use bytes::Bytes;
+use uuid::Uuid;
+
+use crate::protocol::{
+    buf::{ByteBuf, ByteBufMut},
+    compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
+    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+};
+
+/// Valid versions: 0
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq)]
+pub struct ConsumerGroupDescribeRequest {
+    /// The ids of the groups to describe
+    ///
+    /// Supported API versions: 0
+    pub group_ids: Vec<super::GroupId>,
+
+    /// Whether to include authorized operations.
+    ///
+    /// Supported API versions: 0
+    pub include_authorized_operations: bool,
+
+    /// Other tagged fields
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
+}
+
+impl ConsumerGroupDescribeRequest {
+    /// Sets `group_ids` to the passed value.
+    ///
+    /// The ids of the groups to describe
+    ///
+    /// Supported API versions: 0
+    pub fn with_group_ids(mut self, value: Vec<super::GroupId>) -> Self {
+        self.group_ids = value;
+        self
+    }
+    /// Sets `include_authorized_operations` to the passed value.
+    ///
+    /// Whether to include authorized operations.
+    ///
+    /// Supported API versions: 0
+    pub fn with_include_authorized_operations(mut self, value: bool) -> Self {
+        self.include_authorized_operations = value;
+        self
+    }
+    /// Sets unknown_tagged_fields to the passed value.
+    pub fn with_unknown_tagged_fields(mut self, value: BTreeMap<i32, Bytes>) -> Self {
+        self.unknown_tagged_fields = value;
+        self
+    }
+    /// Inserts an entry into unknown_tagged_fields.
+    pub fn with_unknown_tagged_field(mut self, key: i32, value: Bytes) -> Self {
+        self.unknown_tagged_fields.insert(key, value);
+        self
+    }
+}
+
+#[cfg(feature = "client")]
+impl Encodable for ConsumerGroupDescribeRequest {
+    fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        types::CompactArray(types::CompactString).encode(buf, &self.group_ids)?;
+        types::Boolean.encode(buf, &self.include_authorized_operations)?;
+        let num_tagged_fields = self.unknown_tagged_fields.len();
+        if num_tagged_fields > std::u32::MAX as usize {
+            bail!(
+                "Too many tagged fields to encode ({} fields)",
+                num_tagged_fields
+            );
+        }
+        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+
+        write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
+        Ok(())
+    }
+    fn compute_size(&self, version: i16) -> Result<usize> {
+        let mut total_size = 0;
+        total_size += types::CompactArray(types::CompactString).compute_size(&self.group_ids)?;
+        total_size += types::Boolean.compute_size(&self.include_authorized_operations)?;
+        let num_tagged_fields = self.unknown_tagged_fields.len();
+        if num_tagged_fields > std::u32::MAX as usize {
+            bail!(
+                "Too many tagged fields to encode ({} fields)",
+                num_tagged_fields
+            );
+        }
+        total_size += types::UnsignedVarInt.compute_size(num_tagged_fields as u32)?;
+
+        total_size += compute_unknown_tagged_fields_size(&self.unknown_tagged_fields)?;
+        Ok(total_size)
+    }
+}
+
+#[cfg(feature = "broker")]
+impl Decodable for ConsumerGroupDescribeRequest {
+    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        let group_ids = types::CompactArray(types::CompactString).decode(buf)?;
+        let include_authorized_operations = types::Boolean.decode(buf)?;
+        let mut unknown_tagged_fields = BTreeMap::new();
+        let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
+        for _ in 0..num_tagged_fields {
+            let tag: u32 = types::UnsignedVarInt.decode(buf)?;
+            let size: u32 = types::UnsignedVarInt.decode(buf)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
+            unknown_tagged_fields.insert(tag as i32, unknown_value);
+        }
+        Ok(Self {
+            group_ids,
+            include_authorized_operations,
+            unknown_tagged_fields,
+        })
+    }
+}
+
+impl Default for ConsumerGroupDescribeRequest {
+    fn default() -> Self {
+        Self {
+            group_ids: Default::default(),
+            include_authorized_operations: false,
+            unknown_tagged_fields: BTreeMap::new(),
+        }
+    }
+}
+
+impl Message for ConsumerGroupDescribeRequest {
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 0 };
+    const DEPRECATED_VERSIONS: Option<VersionRange> = None;
+}
+
+impl HeaderVersion for ConsumerGroupDescribeRequest {
+    fn header_version(version: i16) -> i16 {
+        2
+    }
+}

--- a/src/messages/consumer_group_describe_response.rs
+++ b/src/messages/consumer_group_describe_response.rs
@@ -1,0 +1,911 @@
+//! ConsumerGroupDescribeResponse
+//!
+//! See the schema for this message [here](https://github.com/apache/kafka/blob/trunk/clients/src/main/resources/common/message/ConsumerGroupDescribeResponse.json).
+// WARNING: the items of this module are generated and should not be edited directly
+#![allow(unused)]
+
+use std::borrow::Borrow;
+use std::collections::BTreeMap;
+
+use anyhow::{bail, Result};
+use bytes::Bytes;
+use uuid::Uuid;
+
+use crate::protocol::{
+    buf::{ByteBuf, ByteBufMut},
+    compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
+    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+};
+
+/// Valid versions: 0
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq)]
+pub struct Assignment {
+    /// The assigned topic-partitions to the member.
+    ///
+    /// Supported API versions: 0
+    pub topic_partitions: Vec<TopicPartitions>,
+
+    /// Other tagged fields
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
+}
+
+impl Assignment {
+    /// Sets `topic_partitions` to the passed value.
+    ///
+    /// The assigned topic-partitions to the member.
+    ///
+    /// Supported API versions: 0
+    pub fn with_topic_partitions(mut self, value: Vec<TopicPartitions>) -> Self {
+        self.topic_partitions = value;
+        self
+    }
+    /// Sets unknown_tagged_fields to the passed value.
+    pub fn with_unknown_tagged_fields(mut self, value: BTreeMap<i32, Bytes>) -> Self {
+        self.unknown_tagged_fields = value;
+        self
+    }
+    /// Inserts an entry into unknown_tagged_fields.
+    pub fn with_unknown_tagged_field(mut self, key: i32, value: Bytes) -> Self {
+        self.unknown_tagged_fields.insert(key, value);
+        self
+    }
+}
+
+#[cfg(feature = "broker")]
+impl Encodable for Assignment {
+    fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        types::CompactArray(types::Struct { version }).encode(buf, &self.topic_partitions)?;
+        let num_tagged_fields = self.unknown_tagged_fields.len();
+        if num_tagged_fields > std::u32::MAX as usize {
+            bail!(
+                "Too many tagged fields to encode ({} fields)",
+                num_tagged_fields
+            );
+        }
+        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+
+        write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
+        Ok(())
+    }
+    fn compute_size(&self, version: i16) -> Result<usize> {
+        let mut total_size = 0;
+        total_size +=
+            types::CompactArray(types::Struct { version }).compute_size(&self.topic_partitions)?;
+        let num_tagged_fields = self.unknown_tagged_fields.len();
+        if num_tagged_fields > std::u32::MAX as usize {
+            bail!(
+                "Too many tagged fields to encode ({} fields)",
+                num_tagged_fields
+            );
+        }
+        total_size += types::UnsignedVarInt.compute_size(num_tagged_fields as u32)?;
+
+        total_size += compute_unknown_tagged_fields_size(&self.unknown_tagged_fields)?;
+        Ok(total_size)
+    }
+}
+
+#[cfg(feature = "client")]
+impl Decodable for Assignment {
+    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        let topic_partitions = types::CompactArray(types::Struct { version }).decode(buf)?;
+        let mut unknown_tagged_fields = BTreeMap::new();
+        let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
+        for _ in 0..num_tagged_fields {
+            let tag: u32 = types::UnsignedVarInt.decode(buf)?;
+            let size: u32 = types::UnsignedVarInt.decode(buf)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
+            unknown_tagged_fields.insert(tag as i32, unknown_value);
+        }
+        Ok(Self {
+            topic_partitions,
+            unknown_tagged_fields,
+        })
+    }
+}
+
+impl Default for Assignment {
+    fn default() -> Self {
+        Self {
+            topic_partitions: Default::default(),
+            unknown_tagged_fields: BTreeMap::new(),
+        }
+    }
+}
+
+impl Message for Assignment {
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 0 };
+    const DEPRECATED_VERSIONS: Option<VersionRange> = None;
+}
+
+/// Valid versions: 0
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq)]
+pub struct ConsumerGroupDescribeResponse {
+    /// The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota.
+    ///
+    /// Supported API versions: 0
+    pub throttle_time_ms: i32,
+
+    /// Each described group.
+    ///
+    /// Supported API versions: 0
+    pub groups: Vec<DescribedGroup>,
+
+    /// Other tagged fields
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
+}
+
+impl ConsumerGroupDescribeResponse {
+    /// Sets `throttle_time_ms` to the passed value.
+    ///
+    /// The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota.
+    ///
+    /// Supported API versions: 0
+    pub fn with_throttle_time_ms(mut self, value: i32) -> Self {
+        self.throttle_time_ms = value;
+        self
+    }
+    /// Sets `groups` to the passed value.
+    ///
+    /// Each described group.
+    ///
+    /// Supported API versions: 0
+    pub fn with_groups(mut self, value: Vec<DescribedGroup>) -> Self {
+        self.groups = value;
+        self
+    }
+    /// Sets unknown_tagged_fields to the passed value.
+    pub fn with_unknown_tagged_fields(mut self, value: BTreeMap<i32, Bytes>) -> Self {
+        self.unknown_tagged_fields = value;
+        self
+    }
+    /// Inserts an entry into unknown_tagged_fields.
+    pub fn with_unknown_tagged_field(mut self, key: i32, value: Bytes) -> Self {
+        self.unknown_tagged_fields.insert(key, value);
+        self
+    }
+}
+
+#[cfg(feature = "broker")]
+impl Encodable for ConsumerGroupDescribeResponse {
+    fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        types::Int32.encode(buf, &self.throttle_time_ms)?;
+        types::CompactArray(types::Struct { version }).encode(buf, &self.groups)?;
+        let num_tagged_fields = self.unknown_tagged_fields.len();
+        if num_tagged_fields > std::u32::MAX as usize {
+            bail!(
+                "Too many tagged fields to encode ({} fields)",
+                num_tagged_fields
+            );
+        }
+        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+
+        write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
+        Ok(())
+    }
+    fn compute_size(&self, version: i16) -> Result<usize> {
+        let mut total_size = 0;
+        total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
+        total_size += types::CompactArray(types::Struct { version }).compute_size(&self.groups)?;
+        let num_tagged_fields = self.unknown_tagged_fields.len();
+        if num_tagged_fields > std::u32::MAX as usize {
+            bail!(
+                "Too many tagged fields to encode ({} fields)",
+                num_tagged_fields
+            );
+        }
+        total_size += types::UnsignedVarInt.compute_size(num_tagged_fields as u32)?;
+
+        total_size += compute_unknown_tagged_fields_size(&self.unknown_tagged_fields)?;
+        Ok(total_size)
+    }
+}
+
+#[cfg(feature = "client")]
+impl Decodable for ConsumerGroupDescribeResponse {
+    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        let throttle_time_ms = types::Int32.decode(buf)?;
+        let groups = types::CompactArray(types::Struct { version }).decode(buf)?;
+        let mut unknown_tagged_fields = BTreeMap::new();
+        let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
+        for _ in 0..num_tagged_fields {
+            let tag: u32 = types::UnsignedVarInt.decode(buf)?;
+            let size: u32 = types::UnsignedVarInt.decode(buf)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
+            unknown_tagged_fields.insert(tag as i32, unknown_value);
+        }
+        Ok(Self {
+            throttle_time_ms,
+            groups,
+            unknown_tagged_fields,
+        })
+    }
+}
+
+impl Default for ConsumerGroupDescribeResponse {
+    fn default() -> Self {
+        Self {
+            throttle_time_ms: 0,
+            groups: Default::default(),
+            unknown_tagged_fields: BTreeMap::new(),
+        }
+    }
+}
+
+impl Message for ConsumerGroupDescribeResponse {
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 0 };
+    const DEPRECATED_VERSIONS: Option<VersionRange> = None;
+}
+
+/// Valid versions: 0
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq)]
+pub struct DescribedGroup {
+    /// The describe error, or 0 if there was no error.
+    ///
+    /// Supported API versions: 0
+    pub error_code: i16,
+
+    /// The top-level error message, or null if there was no error.
+    ///
+    /// Supported API versions: 0
+    pub error_message: Option<StrBytes>,
+
+    /// The group ID string.
+    ///
+    /// Supported API versions: 0
+    pub group_id: super::GroupId,
+
+    /// The group state string, or the empty string.
+    ///
+    /// Supported API versions: 0
+    pub group_state: StrBytes,
+
+    /// The group epoch.
+    ///
+    /// Supported API versions: 0
+    pub group_epoch: i32,
+
+    /// The assignment epoch.
+    ///
+    /// Supported API versions: 0
+    pub assignment_epoch: i32,
+
+    /// The selected assignor.
+    ///
+    /// Supported API versions: 0
+    pub assignor_name: StrBytes,
+
+    /// The members.
+    ///
+    /// Supported API versions: 0
+    pub members: Vec<Member>,
+
+    /// 32-bit bitfield to represent authorized operations for this group.
+    ///
+    /// Supported API versions: 0
+    pub authorized_operations: i32,
+
+    /// Other tagged fields
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
+}
+
+impl DescribedGroup {
+    /// Sets `error_code` to the passed value.
+    ///
+    /// The describe error, or 0 if there was no error.
+    ///
+    /// Supported API versions: 0
+    pub fn with_error_code(mut self, value: i16) -> Self {
+        self.error_code = value;
+        self
+    }
+    /// Sets `error_message` to the passed value.
+    ///
+    /// The top-level error message, or null if there was no error.
+    ///
+    /// Supported API versions: 0
+    pub fn with_error_message(mut self, value: Option<StrBytes>) -> Self {
+        self.error_message = value;
+        self
+    }
+    /// Sets `group_id` to the passed value.
+    ///
+    /// The group ID string.
+    ///
+    /// Supported API versions: 0
+    pub fn with_group_id(mut self, value: super::GroupId) -> Self {
+        self.group_id = value;
+        self
+    }
+    /// Sets `group_state` to the passed value.
+    ///
+    /// The group state string, or the empty string.
+    ///
+    /// Supported API versions: 0
+    pub fn with_group_state(mut self, value: StrBytes) -> Self {
+        self.group_state = value;
+        self
+    }
+    /// Sets `group_epoch` to the passed value.
+    ///
+    /// The group epoch.
+    ///
+    /// Supported API versions: 0
+    pub fn with_group_epoch(mut self, value: i32) -> Self {
+        self.group_epoch = value;
+        self
+    }
+    /// Sets `assignment_epoch` to the passed value.
+    ///
+    /// The assignment epoch.
+    ///
+    /// Supported API versions: 0
+    pub fn with_assignment_epoch(mut self, value: i32) -> Self {
+        self.assignment_epoch = value;
+        self
+    }
+    /// Sets `assignor_name` to the passed value.
+    ///
+    /// The selected assignor.
+    ///
+    /// Supported API versions: 0
+    pub fn with_assignor_name(mut self, value: StrBytes) -> Self {
+        self.assignor_name = value;
+        self
+    }
+    /// Sets `members` to the passed value.
+    ///
+    /// The members.
+    ///
+    /// Supported API versions: 0
+    pub fn with_members(mut self, value: Vec<Member>) -> Self {
+        self.members = value;
+        self
+    }
+    /// Sets `authorized_operations` to the passed value.
+    ///
+    /// 32-bit bitfield to represent authorized operations for this group.
+    ///
+    /// Supported API versions: 0
+    pub fn with_authorized_operations(mut self, value: i32) -> Self {
+        self.authorized_operations = value;
+        self
+    }
+    /// Sets unknown_tagged_fields to the passed value.
+    pub fn with_unknown_tagged_fields(mut self, value: BTreeMap<i32, Bytes>) -> Self {
+        self.unknown_tagged_fields = value;
+        self
+    }
+    /// Inserts an entry into unknown_tagged_fields.
+    pub fn with_unknown_tagged_field(mut self, key: i32, value: Bytes) -> Self {
+        self.unknown_tagged_fields.insert(key, value);
+        self
+    }
+}
+
+#[cfg(feature = "broker")]
+impl Encodable for DescribedGroup {
+    fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        types::Int16.encode(buf, &self.error_code)?;
+        types::CompactString.encode(buf, &self.error_message)?;
+        types::CompactString.encode(buf, &self.group_id)?;
+        types::CompactString.encode(buf, &self.group_state)?;
+        types::Int32.encode(buf, &self.group_epoch)?;
+        types::Int32.encode(buf, &self.assignment_epoch)?;
+        types::CompactString.encode(buf, &self.assignor_name)?;
+        types::CompactArray(types::Struct { version }).encode(buf, &self.members)?;
+        types::Int32.encode(buf, &self.authorized_operations)?;
+        let num_tagged_fields = self.unknown_tagged_fields.len();
+        if num_tagged_fields > std::u32::MAX as usize {
+            bail!(
+                "Too many tagged fields to encode ({} fields)",
+                num_tagged_fields
+            );
+        }
+        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+
+        write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
+        Ok(())
+    }
+    fn compute_size(&self, version: i16) -> Result<usize> {
+        let mut total_size = 0;
+        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += types::CompactString.compute_size(&self.error_message)?;
+        total_size += types::CompactString.compute_size(&self.group_id)?;
+        total_size += types::CompactString.compute_size(&self.group_state)?;
+        total_size += types::Int32.compute_size(&self.group_epoch)?;
+        total_size += types::Int32.compute_size(&self.assignment_epoch)?;
+        total_size += types::CompactString.compute_size(&self.assignor_name)?;
+        total_size += types::CompactArray(types::Struct { version }).compute_size(&self.members)?;
+        total_size += types::Int32.compute_size(&self.authorized_operations)?;
+        let num_tagged_fields = self.unknown_tagged_fields.len();
+        if num_tagged_fields > std::u32::MAX as usize {
+            bail!(
+                "Too many tagged fields to encode ({} fields)",
+                num_tagged_fields
+            );
+        }
+        total_size += types::UnsignedVarInt.compute_size(num_tagged_fields as u32)?;
+
+        total_size += compute_unknown_tagged_fields_size(&self.unknown_tagged_fields)?;
+        Ok(total_size)
+    }
+}
+
+#[cfg(feature = "client")]
+impl Decodable for DescribedGroup {
+    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        let error_code = types::Int16.decode(buf)?;
+        let error_message = types::CompactString.decode(buf)?;
+        let group_id = types::CompactString.decode(buf)?;
+        let group_state = types::CompactString.decode(buf)?;
+        let group_epoch = types::Int32.decode(buf)?;
+        let assignment_epoch = types::Int32.decode(buf)?;
+        let assignor_name = types::CompactString.decode(buf)?;
+        let members = types::CompactArray(types::Struct { version }).decode(buf)?;
+        let authorized_operations = types::Int32.decode(buf)?;
+        let mut unknown_tagged_fields = BTreeMap::new();
+        let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
+        for _ in 0..num_tagged_fields {
+            let tag: u32 = types::UnsignedVarInt.decode(buf)?;
+            let size: u32 = types::UnsignedVarInt.decode(buf)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
+            unknown_tagged_fields.insert(tag as i32, unknown_value);
+        }
+        Ok(Self {
+            error_code,
+            error_message,
+            group_id,
+            group_state,
+            group_epoch,
+            assignment_epoch,
+            assignor_name,
+            members,
+            authorized_operations,
+            unknown_tagged_fields,
+        })
+    }
+}
+
+impl Default for DescribedGroup {
+    fn default() -> Self {
+        Self {
+            error_code: 0,
+            error_message: None,
+            group_id: Default::default(),
+            group_state: Default::default(),
+            group_epoch: 0,
+            assignment_epoch: 0,
+            assignor_name: Default::default(),
+            members: Default::default(),
+            authorized_operations: -2147483648,
+            unknown_tagged_fields: BTreeMap::new(),
+        }
+    }
+}
+
+impl Message for DescribedGroup {
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 0 };
+    const DEPRECATED_VERSIONS: Option<VersionRange> = None;
+}
+
+/// Valid versions: 0
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq)]
+pub struct Member {
+    /// The member ID.
+    ///
+    /// Supported API versions: 0
+    pub member_id: StrBytes,
+
+    /// The member instance ID.
+    ///
+    /// Supported API versions: 0
+    pub instance_id: Option<StrBytes>,
+
+    /// The member rack ID.
+    ///
+    /// Supported API versions: 0
+    pub rack_id: Option<StrBytes>,
+
+    /// The current member epoch.
+    ///
+    /// Supported API versions: 0
+    pub member_epoch: i32,
+
+    /// The client ID.
+    ///
+    /// Supported API versions: 0
+    pub client_id: StrBytes,
+
+    /// The client host.
+    ///
+    /// Supported API versions: 0
+    pub client_host: StrBytes,
+
+    /// The subscribed topic names.
+    ///
+    /// Supported API versions: 0
+    pub subscribed_topic_names: Vec<super::TopicName>,
+
+    /// the subscribed topic regex otherwise or null of not provided.
+    ///
+    /// Supported API versions: 0
+    pub subscribed_topic_regex: Option<StrBytes>,
+
+    /// The current assignment.
+    ///
+    /// Supported API versions: 0
+    pub assignment: Assignment,
+
+    /// The target assignment.
+    ///
+    /// Supported API versions: 0
+    pub target_assignment: Assignment,
+
+    /// Other tagged fields
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
+}
+
+impl Member {
+    /// Sets `member_id` to the passed value.
+    ///
+    /// The member ID.
+    ///
+    /// Supported API versions: 0
+    pub fn with_member_id(mut self, value: StrBytes) -> Self {
+        self.member_id = value;
+        self
+    }
+    /// Sets `instance_id` to the passed value.
+    ///
+    /// The member instance ID.
+    ///
+    /// Supported API versions: 0
+    pub fn with_instance_id(mut self, value: Option<StrBytes>) -> Self {
+        self.instance_id = value;
+        self
+    }
+    /// Sets `rack_id` to the passed value.
+    ///
+    /// The member rack ID.
+    ///
+    /// Supported API versions: 0
+    pub fn with_rack_id(mut self, value: Option<StrBytes>) -> Self {
+        self.rack_id = value;
+        self
+    }
+    /// Sets `member_epoch` to the passed value.
+    ///
+    /// The current member epoch.
+    ///
+    /// Supported API versions: 0
+    pub fn with_member_epoch(mut self, value: i32) -> Self {
+        self.member_epoch = value;
+        self
+    }
+    /// Sets `client_id` to the passed value.
+    ///
+    /// The client ID.
+    ///
+    /// Supported API versions: 0
+    pub fn with_client_id(mut self, value: StrBytes) -> Self {
+        self.client_id = value;
+        self
+    }
+    /// Sets `client_host` to the passed value.
+    ///
+    /// The client host.
+    ///
+    /// Supported API versions: 0
+    pub fn with_client_host(mut self, value: StrBytes) -> Self {
+        self.client_host = value;
+        self
+    }
+    /// Sets `subscribed_topic_names` to the passed value.
+    ///
+    /// The subscribed topic names.
+    ///
+    /// Supported API versions: 0
+    pub fn with_subscribed_topic_names(mut self, value: Vec<super::TopicName>) -> Self {
+        self.subscribed_topic_names = value;
+        self
+    }
+    /// Sets `subscribed_topic_regex` to the passed value.
+    ///
+    /// the subscribed topic regex otherwise or null of not provided.
+    ///
+    /// Supported API versions: 0
+    pub fn with_subscribed_topic_regex(mut self, value: Option<StrBytes>) -> Self {
+        self.subscribed_topic_regex = value;
+        self
+    }
+    /// Sets `assignment` to the passed value.
+    ///
+    /// The current assignment.
+    ///
+    /// Supported API versions: 0
+    pub fn with_assignment(mut self, value: Assignment) -> Self {
+        self.assignment = value;
+        self
+    }
+    /// Sets `target_assignment` to the passed value.
+    ///
+    /// The target assignment.
+    ///
+    /// Supported API versions: 0
+    pub fn with_target_assignment(mut self, value: Assignment) -> Self {
+        self.target_assignment = value;
+        self
+    }
+    /// Sets unknown_tagged_fields to the passed value.
+    pub fn with_unknown_tagged_fields(mut self, value: BTreeMap<i32, Bytes>) -> Self {
+        self.unknown_tagged_fields = value;
+        self
+    }
+    /// Inserts an entry into unknown_tagged_fields.
+    pub fn with_unknown_tagged_field(mut self, key: i32, value: Bytes) -> Self {
+        self.unknown_tagged_fields.insert(key, value);
+        self
+    }
+}
+
+#[cfg(feature = "broker")]
+impl Encodable for Member {
+    fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        types::CompactString.encode(buf, &self.member_id)?;
+        types::CompactString.encode(buf, &self.instance_id)?;
+        types::CompactString.encode(buf, &self.rack_id)?;
+        types::Int32.encode(buf, &self.member_epoch)?;
+        types::CompactString.encode(buf, &self.client_id)?;
+        types::CompactString.encode(buf, &self.client_host)?;
+        types::CompactArray(types::CompactString).encode(buf, &self.subscribed_topic_names)?;
+        types::CompactString.encode(buf, &self.subscribed_topic_regex)?;
+        types::Struct { version }.encode(buf, &self.assignment)?;
+        types::Struct { version }.encode(buf, &self.target_assignment)?;
+        let num_tagged_fields = self.unknown_tagged_fields.len();
+        if num_tagged_fields > std::u32::MAX as usize {
+            bail!(
+                "Too many tagged fields to encode ({} fields)",
+                num_tagged_fields
+            );
+        }
+        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+
+        write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
+        Ok(())
+    }
+    fn compute_size(&self, version: i16) -> Result<usize> {
+        let mut total_size = 0;
+        total_size += types::CompactString.compute_size(&self.member_id)?;
+        total_size += types::CompactString.compute_size(&self.instance_id)?;
+        total_size += types::CompactString.compute_size(&self.rack_id)?;
+        total_size += types::Int32.compute_size(&self.member_epoch)?;
+        total_size += types::CompactString.compute_size(&self.client_id)?;
+        total_size += types::CompactString.compute_size(&self.client_host)?;
+        total_size +=
+            types::CompactArray(types::CompactString).compute_size(&self.subscribed_topic_names)?;
+        total_size += types::CompactString.compute_size(&self.subscribed_topic_regex)?;
+        total_size += types::Struct { version }.compute_size(&self.assignment)?;
+        total_size += types::Struct { version }.compute_size(&self.target_assignment)?;
+        let num_tagged_fields = self.unknown_tagged_fields.len();
+        if num_tagged_fields > std::u32::MAX as usize {
+            bail!(
+                "Too many tagged fields to encode ({} fields)",
+                num_tagged_fields
+            );
+        }
+        total_size += types::UnsignedVarInt.compute_size(num_tagged_fields as u32)?;
+
+        total_size += compute_unknown_tagged_fields_size(&self.unknown_tagged_fields)?;
+        Ok(total_size)
+    }
+}
+
+#[cfg(feature = "client")]
+impl Decodable for Member {
+    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        let member_id = types::CompactString.decode(buf)?;
+        let instance_id = types::CompactString.decode(buf)?;
+        let rack_id = types::CompactString.decode(buf)?;
+        let member_epoch = types::Int32.decode(buf)?;
+        let client_id = types::CompactString.decode(buf)?;
+        let client_host = types::CompactString.decode(buf)?;
+        let subscribed_topic_names = types::CompactArray(types::CompactString).decode(buf)?;
+        let subscribed_topic_regex = types::CompactString.decode(buf)?;
+        let assignment = types::Struct { version }.decode(buf)?;
+        let target_assignment = types::Struct { version }.decode(buf)?;
+        let mut unknown_tagged_fields = BTreeMap::new();
+        let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
+        for _ in 0..num_tagged_fields {
+            let tag: u32 = types::UnsignedVarInt.decode(buf)?;
+            let size: u32 = types::UnsignedVarInt.decode(buf)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
+            unknown_tagged_fields.insert(tag as i32, unknown_value);
+        }
+        Ok(Self {
+            member_id,
+            instance_id,
+            rack_id,
+            member_epoch,
+            client_id,
+            client_host,
+            subscribed_topic_names,
+            subscribed_topic_regex,
+            assignment,
+            target_assignment,
+            unknown_tagged_fields,
+        })
+    }
+}
+
+impl Default for Member {
+    fn default() -> Self {
+        Self {
+            member_id: Default::default(),
+            instance_id: None,
+            rack_id: None,
+            member_epoch: 0,
+            client_id: Default::default(),
+            client_host: Default::default(),
+            subscribed_topic_names: Default::default(),
+            subscribed_topic_regex: None,
+            assignment: Default::default(),
+            target_assignment: Default::default(),
+            unknown_tagged_fields: BTreeMap::new(),
+        }
+    }
+}
+
+impl Message for Member {
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 0 };
+    const DEPRECATED_VERSIONS: Option<VersionRange> = None;
+}
+
+/// Valid versions: 0
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq)]
+pub struct TopicPartitions {
+    /// The topic ID.
+    ///
+    /// Supported API versions: 0
+    pub topic_id: Uuid,
+
+    /// The topic name.
+    ///
+    /// Supported API versions: 0
+    pub topic_name: super::TopicName,
+
+    /// The partitions.
+    ///
+    /// Supported API versions: 0
+    pub partitions: Vec<i32>,
+
+    /// Other tagged fields
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
+}
+
+impl TopicPartitions {
+    /// Sets `topic_id` to the passed value.
+    ///
+    /// The topic ID.
+    ///
+    /// Supported API versions: 0
+    pub fn with_topic_id(mut self, value: Uuid) -> Self {
+        self.topic_id = value;
+        self
+    }
+    /// Sets `topic_name` to the passed value.
+    ///
+    /// The topic name.
+    ///
+    /// Supported API versions: 0
+    pub fn with_topic_name(mut self, value: super::TopicName) -> Self {
+        self.topic_name = value;
+        self
+    }
+    /// Sets `partitions` to the passed value.
+    ///
+    /// The partitions.
+    ///
+    /// Supported API versions: 0
+    pub fn with_partitions(mut self, value: Vec<i32>) -> Self {
+        self.partitions = value;
+        self
+    }
+    /// Sets unknown_tagged_fields to the passed value.
+    pub fn with_unknown_tagged_fields(mut self, value: BTreeMap<i32, Bytes>) -> Self {
+        self.unknown_tagged_fields = value;
+        self
+    }
+    /// Inserts an entry into unknown_tagged_fields.
+    pub fn with_unknown_tagged_field(mut self, key: i32, value: Bytes) -> Self {
+        self.unknown_tagged_fields.insert(key, value);
+        self
+    }
+}
+
+#[cfg(feature = "broker")]
+impl Encodable for TopicPartitions {
+    fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        types::Uuid.encode(buf, &self.topic_id)?;
+        types::CompactString.encode(buf, &self.topic_name)?;
+        types::CompactArray(types::Int32).encode(buf, &self.partitions)?;
+        let num_tagged_fields = self.unknown_tagged_fields.len();
+        if num_tagged_fields > std::u32::MAX as usize {
+            bail!(
+                "Too many tagged fields to encode ({} fields)",
+                num_tagged_fields
+            );
+        }
+        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+
+        write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
+        Ok(())
+    }
+    fn compute_size(&self, version: i16) -> Result<usize> {
+        let mut total_size = 0;
+        total_size += types::Uuid.compute_size(&self.topic_id)?;
+        total_size += types::CompactString.compute_size(&self.topic_name)?;
+        total_size += types::CompactArray(types::Int32).compute_size(&self.partitions)?;
+        let num_tagged_fields = self.unknown_tagged_fields.len();
+        if num_tagged_fields > std::u32::MAX as usize {
+            bail!(
+                "Too many tagged fields to encode ({} fields)",
+                num_tagged_fields
+            );
+        }
+        total_size += types::UnsignedVarInt.compute_size(num_tagged_fields as u32)?;
+
+        total_size += compute_unknown_tagged_fields_size(&self.unknown_tagged_fields)?;
+        Ok(total_size)
+    }
+}
+
+#[cfg(feature = "client")]
+impl Decodable for TopicPartitions {
+    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        let topic_id = types::Uuid.decode(buf)?;
+        let topic_name = types::CompactString.decode(buf)?;
+        let partitions = types::CompactArray(types::Int32).decode(buf)?;
+        let mut unknown_tagged_fields = BTreeMap::new();
+        let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
+        for _ in 0..num_tagged_fields {
+            let tag: u32 = types::UnsignedVarInt.decode(buf)?;
+            let size: u32 = types::UnsignedVarInt.decode(buf)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
+            unknown_tagged_fields.insert(tag as i32, unknown_value);
+        }
+        Ok(Self {
+            topic_id,
+            topic_name,
+            partitions,
+            unknown_tagged_fields,
+        })
+    }
+}
+
+impl Default for TopicPartitions {
+    fn default() -> Self {
+        Self {
+            topic_id: Uuid::nil(),
+            topic_name: Default::default(),
+            partitions: Default::default(),
+            unknown_tagged_fields: BTreeMap::new(),
+        }
+    }
+}
+
+impl Message for TopicPartitions {
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 0 };
+    const DEPRECATED_VERSIONS: Option<VersionRange> = None;
+}
+
+impl HeaderVersion for ConsumerGroupDescribeResponse {
+    fn header_version(version: i16) -> i16 {
+        1
+    }
+}

--- a/src/messages/describe_topic_partitions_request.rs
+++ b/src/messages/describe_topic_partitions_request.rs
@@ -1,0 +1,384 @@
+//! DescribeTopicPartitionsRequest
+//!
+//! See the schema for this message [here](https://github.com/apache/kafka/blob/trunk/clients/src/main/resources/common/message/DescribeTopicPartitionsRequest.json).
+// WARNING: the items of this module are generated and should not be edited directly
+#![allow(unused)]
+
+use std::borrow::Borrow;
+use std::collections::BTreeMap;
+
+use anyhow::{bail, Result};
+use bytes::Bytes;
+use uuid::Uuid;
+
+use crate::protocol::{
+    buf::{ByteBuf, ByteBufMut},
+    compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
+    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+};
+
+/// Valid versions: 0
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq)]
+pub struct Cursor {
+    /// The name for the first topic to process
+    ///
+    /// Supported API versions: 0
+    pub topic_name: super::TopicName,
+
+    /// The partition index to start with
+    ///
+    /// Supported API versions: 0
+    pub partition_index: i32,
+
+    /// Other tagged fields
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
+}
+
+impl Cursor {
+    /// Sets `topic_name` to the passed value.
+    ///
+    /// The name for the first topic to process
+    ///
+    /// Supported API versions: 0
+    pub fn with_topic_name(mut self, value: super::TopicName) -> Self {
+        self.topic_name = value;
+        self
+    }
+    /// Sets `partition_index` to the passed value.
+    ///
+    /// The partition index to start with
+    ///
+    /// Supported API versions: 0
+    pub fn with_partition_index(mut self, value: i32) -> Self {
+        self.partition_index = value;
+        self
+    }
+    /// Sets unknown_tagged_fields to the passed value.
+    pub fn with_unknown_tagged_fields(mut self, value: BTreeMap<i32, Bytes>) -> Self {
+        self.unknown_tagged_fields = value;
+        self
+    }
+    /// Inserts an entry into unknown_tagged_fields.
+    pub fn with_unknown_tagged_field(mut self, key: i32, value: Bytes) -> Self {
+        self.unknown_tagged_fields.insert(key, value);
+        self
+    }
+}
+
+#[cfg(feature = "client")]
+impl Encodable for Cursor {
+    fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        types::CompactString.encode(buf, &self.topic_name)?;
+        types::Int32.encode(buf, &self.partition_index)?;
+        let num_tagged_fields = self.unknown_tagged_fields.len();
+        if num_tagged_fields > std::u32::MAX as usize {
+            bail!(
+                "Too many tagged fields to encode ({} fields)",
+                num_tagged_fields
+            );
+        }
+        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+
+        write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
+        Ok(())
+    }
+    fn compute_size(&self, version: i16) -> Result<usize> {
+        let mut total_size = 0;
+        total_size += types::CompactString.compute_size(&self.topic_name)?;
+        total_size += types::Int32.compute_size(&self.partition_index)?;
+        let num_tagged_fields = self.unknown_tagged_fields.len();
+        if num_tagged_fields > std::u32::MAX as usize {
+            bail!(
+                "Too many tagged fields to encode ({} fields)",
+                num_tagged_fields
+            );
+        }
+        total_size += types::UnsignedVarInt.compute_size(num_tagged_fields as u32)?;
+
+        total_size += compute_unknown_tagged_fields_size(&self.unknown_tagged_fields)?;
+        Ok(total_size)
+    }
+}
+
+#[cfg(feature = "broker")]
+impl Decodable for Cursor {
+    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        let topic_name = types::CompactString.decode(buf)?;
+        let partition_index = types::Int32.decode(buf)?;
+        let mut unknown_tagged_fields = BTreeMap::new();
+        let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
+        for _ in 0..num_tagged_fields {
+            let tag: u32 = types::UnsignedVarInt.decode(buf)?;
+            let size: u32 = types::UnsignedVarInt.decode(buf)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
+            unknown_tagged_fields.insert(tag as i32, unknown_value);
+        }
+        Ok(Self {
+            topic_name,
+            partition_index,
+            unknown_tagged_fields,
+        })
+    }
+}
+
+impl Default for Cursor {
+    fn default() -> Self {
+        Self {
+            topic_name: Default::default(),
+            partition_index: 0,
+            unknown_tagged_fields: BTreeMap::new(),
+        }
+    }
+}
+
+impl Message for Cursor {
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 0 };
+    const DEPRECATED_VERSIONS: Option<VersionRange> = None;
+}
+
+/// Valid versions: 0
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq)]
+pub struct DescribeTopicPartitionsRequest {
+    /// The topics to fetch details for.
+    ///
+    /// Supported API versions: 0
+    pub topics: Vec<TopicRequest>,
+
+    /// The maximum number of partitions included in the response.
+    ///
+    /// Supported API versions: 0
+    pub response_partition_limit: i32,
+
+    /// The first topic and partition index to fetch details for.
+    ///
+    /// Supported API versions: 0
+    pub cursor: Option<Cursor>,
+
+    /// Other tagged fields
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
+}
+
+impl DescribeTopicPartitionsRequest {
+    /// Sets `topics` to the passed value.
+    ///
+    /// The topics to fetch details for.
+    ///
+    /// Supported API versions: 0
+    pub fn with_topics(mut self, value: Vec<TopicRequest>) -> Self {
+        self.topics = value;
+        self
+    }
+    /// Sets `response_partition_limit` to the passed value.
+    ///
+    /// The maximum number of partitions included in the response.
+    ///
+    /// Supported API versions: 0
+    pub fn with_response_partition_limit(mut self, value: i32) -> Self {
+        self.response_partition_limit = value;
+        self
+    }
+    /// Sets `cursor` to the passed value.
+    ///
+    /// The first topic and partition index to fetch details for.
+    ///
+    /// Supported API versions: 0
+    pub fn with_cursor(mut self, value: Option<Cursor>) -> Self {
+        self.cursor = value;
+        self
+    }
+    /// Sets unknown_tagged_fields to the passed value.
+    pub fn with_unknown_tagged_fields(mut self, value: BTreeMap<i32, Bytes>) -> Self {
+        self.unknown_tagged_fields = value;
+        self
+    }
+    /// Inserts an entry into unknown_tagged_fields.
+    pub fn with_unknown_tagged_field(mut self, key: i32, value: Bytes) -> Self {
+        self.unknown_tagged_fields.insert(key, value);
+        self
+    }
+}
+
+#[cfg(feature = "client")]
+impl Encodable for DescribeTopicPartitionsRequest {
+    fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
+        types::Int32.encode(buf, &self.response_partition_limit)?;
+        types::OptionStruct { version }.encode(buf, &self.cursor)?;
+        let num_tagged_fields = self.unknown_tagged_fields.len();
+        if num_tagged_fields > std::u32::MAX as usize {
+            bail!(
+                "Too many tagged fields to encode ({} fields)",
+                num_tagged_fields
+            );
+        }
+        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+
+        write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
+        Ok(())
+    }
+    fn compute_size(&self, version: i16) -> Result<usize> {
+        let mut total_size = 0;
+        total_size += types::CompactArray(types::Struct { version }).compute_size(&self.topics)?;
+        total_size += types::Int32.compute_size(&self.response_partition_limit)?;
+        total_size += types::OptionStruct { version }.compute_size(&self.cursor)?;
+        let num_tagged_fields = self.unknown_tagged_fields.len();
+        if num_tagged_fields > std::u32::MAX as usize {
+            bail!(
+                "Too many tagged fields to encode ({} fields)",
+                num_tagged_fields
+            );
+        }
+        total_size += types::UnsignedVarInt.compute_size(num_tagged_fields as u32)?;
+
+        total_size += compute_unknown_tagged_fields_size(&self.unknown_tagged_fields)?;
+        Ok(total_size)
+    }
+}
+
+#[cfg(feature = "broker")]
+impl Decodable for DescribeTopicPartitionsRequest {
+    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        let topics = types::CompactArray(types::Struct { version }).decode(buf)?;
+        let response_partition_limit = types::Int32.decode(buf)?;
+        let cursor = types::OptionStruct { version }.decode(buf)?;
+        let mut unknown_tagged_fields = BTreeMap::new();
+        let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
+        for _ in 0..num_tagged_fields {
+            let tag: u32 = types::UnsignedVarInt.decode(buf)?;
+            let size: u32 = types::UnsignedVarInt.decode(buf)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
+            unknown_tagged_fields.insert(tag as i32, unknown_value);
+        }
+        Ok(Self {
+            topics,
+            response_partition_limit,
+            cursor,
+            unknown_tagged_fields,
+        })
+    }
+}
+
+impl Default for DescribeTopicPartitionsRequest {
+    fn default() -> Self {
+        Self {
+            topics: Default::default(),
+            response_partition_limit: 2000,
+            cursor: None,
+            unknown_tagged_fields: BTreeMap::new(),
+        }
+    }
+}
+
+impl Message for DescribeTopicPartitionsRequest {
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 0 };
+    const DEPRECATED_VERSIONS: Option<VersionRange> = None;
+}
+
+/// Valid versions: 0
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq)]
+pub struct TopicRequest {
+    /// The topic name
+    ///
+    /// Supported API versions: 0
+    pub name: super::TopicName,
+
+    /// Other tagged fields
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
+}
+
+impl TopicRequest {
+    /// Sets `name` to the passed value.
+    ///
+    /// The topic name
+    ///
+    /// Supported API versions: 0
+    pub fn with_name(mut self, value: super::TopicName) -> Self {
+        self.name = value;
+        self
+    }
+    /// Sets unknown_tagged_fields to the passed value.
+    pub fn with_unknown_tagged_fields(mut self, value: BTreeMap<i32, Bytes>) -> Self {
+        self.unknown_tagged_fields = value;
+        self
+    }
+    /// Inserts an entry into unknown_tagged_fields.
+    pub fn with_unknown_tagged_field(mut self, key: i32, value: Bytes) -> Self {
+        self.unknown_tagged_fields.insert(key, value);
+        self
+    }
+}
+
+#[cfg(feature = "client")]
+impl Encodable for TopicRequest {
+    fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        types::CompactString.encode(buf, &self.name)?;
+        let num_tagged_fields = self.unknown_tagged_fields.len();
+        if num_tagged_fields > std::u32::MAX as usize {
+            bail!(
+                "Too many tagged fields to encode ({} fields)",
+                num_tagged_fields
+            );
+        }
+        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+
+        write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
+        Ok(())
+    }
+    fn compute_size(&self, version: i16) -> Result<usize> {
+        let mut total_size = 0;
+        total_size += types::CompactString.compute_size(&self.name)?;
+        let num_tagged_fields = self.unknown_tagged_fields.len();
+        if num_tagged_fields > std::u32::MAX as usize {
+            bail!(
+                "Too many tagged fields to encode ({} fields)",
+                num_tagged_fields
+            );
+        }
+        total_size += types::UnsignedVarInt.compute_size(num_tagged_fields as u32)?;
+
+        total_size += compute_unknown_tagged_fields_size(&self.unknown_tagged_fields)?;
+        Ok(total_size)
+    }
+}
+
+#[cfg(feature = "broker")]
+impl Decodable for TopicRequest {
+    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        let name = types::CompactString.decode(buf)?;
+        let mut unknown_tagged_fields = BTreeMap::new();
+        let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
+        for _ in 0..num_tagged_fields {
+            let tag: u32 = types::UnsignedVarInt.decode(buf)?;
+            let size: u32 = types::UnsignedVarInt.decode(buf)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
+            unknown_tagged_fields.insert(tag as i32, unknown_value);
+        }
+        Ok(Self {
+            name,
+            unknown_tagged_fields,
+        })
+    }
+}
+
+impl Default for TopicRequest {
+    fn default() -> Self {
+        Self {
+            name: Default::default(),
+            unknown_tagged_fields: BTreeMap::new(),
+        }
+    }
+}
+
+impl Message for TopicRequest {
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 0 };
+    const DEPRECATED_VERSIONS: Option<VersionRange> = None;
+}
+
+impl HeaderVersion for DescribeTopicPartitionsRequest {
+    fn header_version(version: i16) -> i16 {
+        2
+    }
+}

--- a/src/messages/describe_topic_partitions_response.rs
+++ b/src/messages/describe_topic_partitions_response.rs
@@ -1,0 +1,726 @@
+//! DescribeTopicPartitionsResponse
+//!
+//! See the schema for this message [here](https://github.com/apache/kafka/blob/trunk/clients/src/main/resources/common/message/DescribeTopicPartitionsResponse.json).
+// WARNING: the items of this module are generated and should not be edited directly
+#![allow(unused)]
+
+use std::borrow::Borrow;
+use std::collections::BTreeMap;
+
+use anyhow::{bail, Result};
+use bytes::Bytes;
+use uuid::Uuid;
+
+use crate::protocol::{
+    buf::{ByteBuf, ByteBufMut},
+    compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
+    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+};
+
+/// Valid versions: 0
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq)]
+pub struct Cursor {
+    /// The name for the first topic to process
+    ///
+    /// Supported API versions: 0
+    pub topic_name: super::TopicName,
+
+    /// The partition index to start with
+    ///
+    /// Supported API versions: 0
+    pub partition_index: i32,
+
+    /// Other tagged fields
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
+}
+
+impl Cursor {
+    /// Sets `topic_name` to the passed value.
+    ///
+    /// The name for the first topic to process
+    ///
+    /// Supported API versions: 0
+    pub fn with_topic_name(mut self, value: super::TopicName) -> Self {
+        self.topic_name = value;
+        self
+    }
+    /// Sets `partition_index` to the passed value.
+    ///
+    /// The partition index to start with
+    ///
+    /// Supported API versions: 0
+    pub fn with_partition_index(mut self, value: i32) -> Self {
+        self.partition_index = value;
+        self
+    }
+    /// Sets unknown_tagged_fields to the passed value.
+    pub fn with_unknown_tagged_fields(mut self, value: BTreeMap<i32, Bytes>) -> Self {
+        self.unknown_tagged_fields = value;
+        self
+    }
+    /// Inserts an entry into unknown_tagged_fields.
+    pub fn with_unknown_tagged_field(mut self, key: i32, value: Bytes) -> Self {
+        self.unknown_tagged_fields.insert(key, value);
+        self
+    }
+}
+
+#[cfg(feature = "broker")]
+impl Encodable for Cursor {
+    fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        types::CompactString.encode(buf, &self.topic_name)?;
+        types::Int32.encode(buf, &self.partition_index)?;
+        let num_tagged_fields = self.unknown_tagged_fields.len();
+        if num_tagged_fields > std::u32::MAX as usize {
+            bail!(
+                "Too many tagged fields to encode ({} fields)",
+                num_tagged_fields
+            );
+        }
+        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+
+        write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
+        Ok(())
+    }
+    fn compute_size(&self, version: i16) -> Result<usize> {
+        let mut total_size = 0;
+        total_size += types::CompactString.compute_size(&self.topic_name)?;
+        total_size += types::Int32.compute_size(&self.partition_index)?;
+        let num_tagged_fields = self.unknown_tagged_fields.len();
+        if num_tagged_fields > std::u32::MAX as usize {
+            bail!(
+                "Too many tagged fields to encode ({} fields)",
+                num_tagged_fields
+            );
+        }
+        total_size += types::UnsignedVarInt.compute_size(num_tagged_fields as u32)?;
+
+        total_size += compute_unknown_tagged_fields_size(&self.unknown_tagged_fields)?;
+        Ok(total_size)
+    }
+}
+
+#[cfg(feature = "client")]
+impl Decodable for Cursor {
+    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        let topic_name = types::CompactString.decode(buf)?;
+        let partition_index = types::Int32.decode(buf)?;
+        let mut unknown_tagged_fields = BTreeMap::new();
+        let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
+        for _ in 0..num_tagged_fields {
+            let tag: u32 = types::UnsignedVarInt.decode(buf)?;
+            let size: u32 = types::UnsignedVarInt.decode(buf)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
+            unknown_tagged_fields.insert(tag as i32, unknown_value);
+        }
+        Ok(Self {
+            topic_name,
+            partition_index,
+            unknown_tagged_fields,
+        })
+    }
+}
+
+impl Default for Cursor {
+    fn default() -> Self {
+        Self {
+            topic_name: Default::default(),
+            partition_index: 0,
+            unknown_tagged_fields: BTreeMap::new(),
+        }
+    }
+}
+
+impl Message for Cursor {
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 0 };
+    const DEPRECATED_VERSIONS: Option<VersionRange> = None;
+}
+
+/// Valid versions: 0
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq)]
+pub struct DescribeTopicPartitionsResponse {
+    /// The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota.
+    ///
+    /// Supported API versions: 0
+    pub throttle_time_ms: i32,
+
+    /// Each topic in the response.
+    ///
+    /// Supported API versions: 0
+    pub topics: indexmap::IndexMap<super::TopicName, DescribeTopicPartitionsResponseTopic>,
+
+    /// The next topic and partition index to fetch details for.
+    ///
+    /// Supported API versions: 0
+    pub next_cursor: Option<Cursor>,
+
+    /// Other tagged fields
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
+}
+
+impl DescribeTopicPartitionsResponse {
+    /// Sets `throttle_time_ms` to the passed value.
+    ///
+    /// The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota.
+    ///
+    /// Supported API versions: 0
+    pub fn with_throttle_time_ms(mut self, value: i32) -> Self {
+        self.throttle_time_ms = value;
+        self
+    }
+    /// Sets `topics` to the passed value.
+    ///
+    /// Each topic in the response.
+    ///
+    /// Supported API versions: 0
+    pub fn with_topics(
+        mut self,
+        value: indexmap::IndexMap<super::TopicName, DescribeTopicPartitionsResponseTopic>,
+    ) -> Self {
+        self.topics = value;
+        self
+    }
+    /// Sets `next_cursor` to the passed value.
+    ///
+    /// The next topic and partition index to fetch details for.
+    ///
+    /// Supported API versions: 0
+    pub fn with_next_cursor(mut self, value: Option<Cursor>) -> Self {
+        self.next_cursor = value;
+        self
+    }
+    /// Sets unknown_tagged_fields to the passed value.
+    pub fn with_unknown_tagged_fields(mut self, value: BTreeMap<i32, Bytes>) -> Self {
+        self.unknown_tagged_fields = value;
+        self
+    }
+    /// Inserts an entry into unknown_tagged_fields.
+    pub fn with_unknown_tagged_field(mut self, key: i32, value: Bytes) -> Self {
+        self.unknown_tagged_fields.insert(key, value);
+        self
+    }
+}
+
+#[cfg(feature = "broker")]
+impl Encodable for DescribeTopicPartitionsResponse {
+    fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        types::Int32.encode(buf, &self.throttle_time_ms)?;
+        types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
+        types::OptionStruct { version }.encode(buf, &self.next_cursor)?;
+        let num_tagged_fields = self.unknown_tagged_fields.len();
+        if num_tagged_fields > std::u32::MAX as usize {
+            bail!(
+                "Too many tagged fields to encode ({} fields)",
+                num_tagged_fields
+            );
+        }
+        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+
+        write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
+        Ok(())
+    }
+    fn compute_size(&self, version: i16) -> Result<usize> {
+        let mut total_size = 0;
+        total_size += types::Int32.compute_size(&self.throttle_time_ms)?;
+        total_size += types::CompactArray(types::Struct { version }).compute_size(&self.topics)?;
+        total_size += types::OptionStruct { version }.compute_size(&self.next_cursor)?;
+        let num_tagged_fields = self.unknown_tagged_fields.len();
+        if num_tagged_fields > std::u32::MAX as usize {
+            bail!(
+                "Too many tagged fields to encode ({} fields)",
+                num_tagged_fields
+            );
+        }
+        total_size += types::UnsignedVarInt.compute_size(num_tagged_fields as u32)?;
+
+        total_size += compute_unknown_tagged_fields_size(&self.unknown_tagged_fields)?;
+        Ok(total_size)
+    }
+}
+
+#[cfg(feature = "client")]
+impl Decodable for DescribeTopicPartitionsResponse {
+    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        let throttle_time_ms = types::Int32.decode(buf)?;
+        let topics = types::CompactArray(types::Struct { version }).decode(buf)?;
+        let next_cursor = types::OptionStruct { version }.decode(buf)?;
+        let mut unknown_tagged_fields = BTreeMap::new();
+        let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
+        for _ in 0..num_tagged_fields {
+            let tag: u32 = types::UnsignedVarInt.decode(buf)?;
+            let size: u32 = types::UnsignedVarInt.decode(buf)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
+            unknown_tagged_fields.insert(tag as i32, unknown_value);
+        }
+        Ok(Self {
+            throttle_time_ms,
+            topics,
+            next_cursor,
+            unknown_tagged_fields,
+        })
+    }
+}
+
+impl Default for DescribeTopicPartitionsResponse {
+    fn default() -> Self {
+        Self {
+            throttle_time_ms: 0,
+            topics: Default::default(),
+            next_cursor: None,
+            unknown_tagged_fields: BTreeMap::new(),
+        }
+    }
+}
+
+impl Message for DescribeTopicPartitionsResponse {
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 0 };
+    const DEPRECATED_VERSIONS: Option<VersionRange> = None;
+}
+
+/// Valid versions: 0
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq)]
+pub struct DescribeTopicPartitionsResponsePartition {
+    /// The partition error, or 0 if there was no error.
+    ///
+    /// Supported API versions: 0
+    pub error_code: i16,
+
+    /// The partition index.
+    ///
+    /// Supported API versions: 0
+    pub partition_index: i32,
+
+    /// The ID of the leader broker.
+    ///
+    /// Supported API versions: 0
+    pub leader_id: super::BrokerId,
+
+    /// The leader epoch of this partition.
+    ///
+    /// Supported API versions: 0
+    pub leader_epoch: i32,
+
+    /// The set of all nodes that host this partition.
+    ///
+    /// Supported API versions: 0
+    pub replica_nodes: Vec<super::BrokerId>,
+
+    /// The set of nodes that are in sync with the leader for this partition.
+    ///
+    /// Supported API versions: 0
+    pub isr_nodes: Vec<super::BrokerId>,
+
+    /// The new eligible leader replicas otherwise.
+    ///
+    /// Supported API versions: 0
+    pub eligible_leader_replicas: Option<Vec<super::BrokerId>>,
+
+    /// The last known ELR.
+    ///
+    /// Supported API versions: 0
+    pub last_known_elr: Option<Vec<super::BrokerId>>,
+
+    /// The set of offline replicas of this partition.
+    ///
+    /// Supported API versions: 0
+    pub offline_replicas: Vec<super::BrokerId>,
+
+    /// Other tagged fields
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
+}
+
+impl DescribeTopicPartitionsResponsePartition {
+    /// Sets `error_code` to the passed value.
+    ///
+    /// The partition error, or 0 if there was no error.
+    ///
+    /// Supported API versions: 0
+    pub fn with_error_code(mut self, value: i16) -> Self {
+        self.error_code = value;
+        self
+    }
+    /// Sets `partition_index` to the passed value.
+    ///
+    /// The partition index.
+    ///
+    /// Supported API versions: 0
+    pub fn with_partition_index(mut self, value: i32) -> Self {
+        self.partition_index = value;
+        self
+    }
+    /// Sets `leader_id` to the passed value.
+    ///
+    /// The ID of the leader broker.
+    ///
+    /// Supported API versions: 0
+    pub fn with_leader_id(mut self, value: super::BrokerId) -> Self {
+        self.leader_id = value;
+        self
+    }
+    /// Sets `leader_epoch` to the passed value.
+    ///
+    /// The leader epoch of this partition.
+    ///
+    /// Supported API versions: 0
+    pub fn with_leader_epoch(mut self, value: i32) -> Self {
+        self.leader_epoch = value;
+        self
+    }
+    /// Sets `replica_nodes` to the passed value.
+    ///
+    /// The set of all nodes that host this partition.
+    ///
+    /// Supported API versions: 0
+    pub fn with_replica_nodes(mut self, value: Vec<super::BrokerId>) -> Self {
+        self.replica_nodes = value;
+        self
+    }
+    /// Sets `isr_nodes` to the passed value.
+    ///
+    /// The set of nodes that are in sync with the leader for this partition.
+    ///
+    /// Supported API versions: 0
+    pub fn with_isr_nodes(mut self, value: Vec<super::BrokerId>) -> Self {
+        self.isr_nodes = value;
+        self
+    }
+    /// Sets `eligible_leader_replicas` to the passed value.
+    ///
+    /// The new eligible leader replicas otherwise.
+    ///
+    /// Supported API versions: 0
+    pub fn with_eligible_leader_replicas(mut self, value: Option<Vec<super::BrokerId>>) -> Self {
+        self.eligible_leader_replicas = value;
+        self
+    }
+    /// Sets `last_known_elr` to the passed value.
+    ///
+    /// The last known ELR.
+    ///
+    /// Supported API versions: 0
+    pub fn with_last_known_elr(mut self, value: Option<Vec<super::BrokerId>>) -> Self {
+        self.last_known_elr = value;
+        self
+    }
+    /// Sets `offline_replicas` to the passed value.
+    ///
+    /// The set of offline replicas of this partition.
+    ///
+    /// Supported API versions: 0
+    pub fn with_offline_replicas(mut self, value: Vec<super::BrokerId>) -> Self {
+        self.offline_replicas = value;
+        self
+    }
+    /// Sets unknown_tagged_fields to the passed value.
+    pub fn with_unknown_tagged_fields(mut self, value: BTreeMap<i32, Bytes>) -> Self {
+        self.unknown_tagged_fields = value;
+        self
+    }
+    /// Inserts an entry into unknown_tagged_fields.
+    pub fn with_unknown_tagged_field(mut self, key: i32, value: Bytes) -> Self {
+        self.unknown_tagged_fields.insert(key, value);
+        self
+    }
+}
+
+#[cfg(feature = "broker")]
+impl Encodable for DescribeTopicPartitionsResponsePartition {
+    fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        types::Int16.encode(buf, &self.error_code)?;
+        types::Int32.encode(buf, &self.partition_index)?;
+        types::Int32.encode(buf, &self.leader_id)?;
+        types::Int32.encode(buf, &self.leader_epoch)?;
+        types::CompactArray(types::Int32).encode(buf, &self.replica_nodes)?;
+        types::CompactArray(types::Int32).encode(buf, &self.isr_nodes)?;
+        types::CompactArray(types::Int32).encode(buf, &self.eligible_leader_replicas)?;
+        types::CompactArray(types::Int32).encode(buf, &self.last_known_elr)?;
+        types::CompactArray(types::Int32).encode(buf, &self.offline_replicas)?;
+        let num_tagged_fields = self.unknown_tagged_fields.len();
+        if num_tagged_fields > std::u32::MAX as usize {
+            bail!(
+                "Too many tagged fields to encode ({} fields)",
+                num_tagged_fields
+            );
+        }
+        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+
+        write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
+        Ok(())
+    }
+    fn compute_size(&self, version: i16) -> Result<usize> {
+        let mut total_size = 0;
+        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += types::Int32.compute_size(&self.partition_index)?;
+        total_size += types::Int32.compute_size(&self.leader_id)?;
+        total_size += types::Int32.compute_size(&self.leader_epoch)?;
+        total_size += types::CompactArray(types::Int32).compute_size(&self.replica_nodes)?;
+        total_size += types::CompactArray(types::Int32).compute_size(&self.isr_nodes)?;
+        total_size +=
+            types::CompactArray(types::Int32).compute_size(&self.eligible_leader_replicas)?;
+        total_size += types::CompactArray(types::Int32).compute_size(&self.last_known_elr)?;
+        total_size += types::CompactArray(types::Int32).compute_size(&self.offline_replicas)?;
+        let num_tagged_fields = self.unknown_tagged_fields.len();
+        if num_tagged_fields > std::u32::MAX as usize {
+            bail!(
+                "Too many tagged fields to encode ({} fields)",
+                num_tagged_fields
+            );
+        }
+        total_size += types::UnsignedVarInt.compute_size(num_tagged_fields as u32)?;
+
+        total_size += compute_unknown_tagged_fields_size(&self.unknown_tagged_fields)?;
+        Ok(total_size)
+    }
+}
+
+#[cfg(feature = "client")]
+impl Decodable for DescribeTopicPartitionsResponsePartition {
+    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        let error_code = types::Int16.decode(buf)?;
+        let partition_index = types::Int32.decode(buf)?;
+        let leader_id = types::Int32.decode(buf)?;
+        let leader_epoch = types::Int32.decode(buf)?;
+        let replica_nodes = types::CompactArray(types::Int32).decode(buf)?;
+        let isr_nodes = types::CompactArray(types::Int32).decode(buf)?;
+        let eligible_leader_replicas = types::CompactArray(types::Int32).decode(buf)?;
+        let last_known_elr = types::CompactArray(types::Int32).decode(buf)?;
+        let offline_replicas = types::CompactArray(types::Int32).decode(buf)?;
+        let mut unknown_tagged_fields = BTreeMap::new();
+        let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
+        for _ in 0..num_tagged_fields {
+            let tag: u32 = types::UnsignedVarInt.decode(buf)?;
+            let size: u32 = types::UnsignedVarInt.decode(buf)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
+            unknown_tagged_fields.insert(tag as i32, unknown_value);
+        }
+        Ok(Self {
+            error_code,
+            partition_index,
+            leader_id,
+            leader_epoch,
+            replica_nodes,
+            isr_nodes,
+            eligible_leader_replicas,
+            last_known_elr,
+            offline_replicas,
+            unknown_tagged_fields,
+        })
+    }
+}
+
+impl Default for DescribeTopicPartitionsResponsePartition {
+    fn default() -> Self {
+        Self {
+            error_code: 0,
+            partition_index: 0,
+            leader_id: (0).into(),
+            leader_epoch: -1,
+            replica_nodes: Default::default(),
+            isr_nodes: Default::default(),
+            eligible_leader_replicas: None,
+            last_known_elr: None,
+            offline_replicas: Default::default(),
+            unknown_tagged_fields: BTreeMap::new(),
+        }
+    }
+}
+
+impl Message for DescribeTopicPartitionsResponsePartition {
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 0 };
+    const DEPRECATED_VERSIONS: Option<VersionRange> = None;
+}
+
+/// Valid versions: 0
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq)]
+pub struct DescribeTopicPartitionsResponseTopic {
+    /// The topic error, or 0 if there was no error.
+    ///
+    /// Supported API versions: 0
+    pub error_code: i16,
+
+    /// The topic id.
+    ///
+    /// Supported API versions: 0
+    pub topic_id: Uuid,
+
+    /// True if the topic is internal.
+    ///
+    /// Supported API versions: 0
+    pub is_internal: bool,
+
+    /// Each partition in the topic.
+    ///
+    /// Supported API versions: 0
+    pub partitions: Vec<DescribeTopicPartitionsResponsePartition>,
+
+    /// 32-bit bitfield to represent authorized operations for this topic.
+    ///
+    /// Supported API versions: 0
+    pub topic_authorized_operations: i32,
+
+    /// Other tagged fields
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
+}
+
+impl DescribeTopicPartitionsResponseTopic {
+    /// Sets `error_code` to the passed value.
+    ///
+    /// The topic error, or 0 if there was no error.
+    ///
+    /// Supported API versions: 0
+    pub fn with_error_code(mut self, value: i16) -> Self {
+        self.error_code = value;
+        self
+    }
+    /// Sets `topic_id` to the passed value.
+    ///
+    /// The topic id.
+    ///
+    /// Supported API versions: 0
+    pub fn with_topic_id(mut self, value: Uuid) -> Self {
+        self.topic_id = value;
+        self
+    }
+    /// Sets `is_internal` to the passed value.
+    ///
+    /// True if the topic is internal.
+    ///
+    /// Supported API versions: 0
+    pub fn with_is_internal(mut self, value: bool) -> Self {
+        self.is_internal = value;
+        self
+    }
+    /// Sets `partitions` to the passed value.
+    ///
+    /// Each partition in the topic.
+    ///
+    /// Supported API versions: 0
+    pub fn with_partitions(mut self, value: Vec<DescribeTopicPartitionsResponsePartition>) -> Self {
+        self.partitions = value;
+        self
+    }
+    /// Sets `topic_authorized_operations` to the passed value.
+    ///
+    /// 32-bit bitfield to represent authorized operations for this topic.
+    ///
+    /// Supported API versions: 0
+    pub fn with_topic_authorized_operations(mut self, value: i32) -> Self {
+        self.topic_authorized_operations = value;
+        self
+    }
+    /// Sets unknown_tagged_fields to the passed value.
+    pub fn with_unknown_tagged_fields(mut self, value: BTreeMap<i32, Bytes>) -> Self {
+        self.unknown_tagged_fields = value;
+        self
+    }
+    /// Inserts an entry into unknown_tagged_fields.
+    pub fn with_unknown_tagged_field(mut self, key: i32, value: Bytes) -> Self {
+        self.unknown_tagged_fields.insert(key, value);
+        self
+    }
+}
+
+#[cfg(feature = "broker")]
+impl MapEncodable for DescribeTopicPartitionsResponseTopic {
+    type Key = super::TopicName;
+    fn encode<B: ByteBufMut>(&self, key: &Self::Key, buf: &mut B, version: i16) -> Result<()> {
+        types::Int16.encode(buf, &self.error_code)?;
+        types::CompactString.encode(buf, key)?;
+        types::Uuid.encode(buf, &self.topic_id)?;
+        types::Boolean.encode(buf, &self.is_internal)?;
+        types::CompactArray(types::Struct { version }).encode(buf, &self.partitions)?;
+        types::Int32.encode(buf, &self.topic_authorized_operations)?;
+        let num_tagged_fields = self.unknown_tagged_fields.len();
+        if num_tagged_fields > std::u32::MAX as usize {
+            bail!(
+                "Too many tagged fields to encode ({} fields)",
+                num_tagged_fields
+            );
+        }
+        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+
+        write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
+        Ok(())
+    }
+    fn compute_size(&self, key: &Self::Key, version: i16) -> Result<usize> {
+        let mut total_size = 0;
+        total_size += types::Int16.compute_size(&self.error_code)?;
+        total_size += types::CompactString.compute_size(key)?;
+        total_size += types::Uuid.compute_size(&self.topic_id)?;
+        total_size += types::Boolean.compute_size(&self.is_internal)?;
+        total_size +=
+            types::CompactArray(types::Struct { version }).compute_size(&self.partitions)?;
+        total_size += types::Int32.compute_size(&self.topic_authorized_operations)?;
+        let num_tagged_fields = self.unknown_tagged_fields.len();
+        if num_tagged_fields > std::u32::MAX as usize {
+            bail!(
+                "Too many tagged fields to encode ({} fields)",
+                num_tagged_fields
+            );
+        }
+        total_size += types::UnsignedVarInt.compute_size(num_tagged_fields as u32)?;
+
+        total_size += compute_unknown_tagged_fields_size(&self.unknown_tagged_fields)?;
+        Ok(total_size)
+    }
+}
+
+#[cfg(feature = "client")]
+impl MapDecodable for DescribeTopicPartitionsResponseTopic {
+    type Key = super::TopicName;
+    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<(Self::Key, Self)> {
+        let error_code = types::Int16.decode(buf)?;
+        let key_field = types::CompactString.decode(buf)?;
+        let topic_id = types::Uuid.decode(buf)?;
+        let is_internal = types::Boolean.decode(buf)?;
+        let partitions = types::CompactArray(types::Struct { version }).decode(buf)?;
+        let topic_authorized_operations = types::Int32.decode(buf)?;
+        let mut unknown_tagged_fields = BTreeMap::new();
+        let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
+        for _ in 0..num_tagged_fields {
+            let tag: u32 = types::UnsignedVarInt.decode(buf)?;
+            let size: u32 = types::UnsignedVarInt.decode(buf)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
+            unknown_tagged_fields.insert(tag as i32, unknown_value);
+        }
+        Ok((
+            key_field,
+            Self {
+                error_code,
+                topic_id,
+                is_internal,
+                partitions,
+                topic_authorized_operations,
+                unknown_tagged_fields,
+            },
+        ))
+    }
+}
+
+impl Default for DescribeTopicPartitionsResponseTopic {
+    fn default() -> Self {
+        Self {
+            error_code: 0,
+            topic_id: Uuid::nil(),
+            is_internal: false,
+            partitions: Default::default(),
+            topic_authorized_operations: -2147483648,
+            unknown_tagged_fields: BTreeMap::new(),
+        }
+    }
+}
+
+impl Message for DescribeTopicPartitionsResponseTopic {
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 0 };
+    const DEPRECATED_VERSIONS: Option<VersionRange> = None;
+}
+
+impl HeaderVersion for DescribeTopicPartitionsResponse {
+    fn header_version(version: i16) -> i16 {
+        1
+    }
+}

--- a/src/messages/end_txn_request.rs
+++ b/src/messages/end_txn_request.rs
@@ -17,28 +17,28 @@ use crate::protocol::{
     Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
 };
 
-/// Valid versions: 0-3
+/// Valid versions: 0-4
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct EndTxnRequest {
     /// The ID of the transaction to end.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub transactional_id: super::TransactionalId,
 
     /// The producer ID.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub producer_id: super::ProducerId,
 
     /// The current epoch associated with the producer.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub producer_epoch: i16,
 
     /// True if the transaction was committed, false if it was aborted.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub committed: bool,
 
     /// Other tagged fields
@@ -50,7 +50,7 @@ impl EndTxnRequest {
     ///
     /// The ID of the transaction to end.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub fn with_transactional_id(mut self, value: super::TransactionalId) -> Self {
         self.transactional_id = value;
         self
@@ -59,7 +59,7 @@ impl EndTxnRequest {
     ///
     /// The producer ID.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub fn with_producer_id(mut self, value: super::ProducerId) -> Self {
         self.producer_id = value;
         self
@@ -68,7 +68,7 @@ impl EndTxnRequest {
     ///
     /// The current epoch associated with the producer.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub fn with_producer_epoch(mut self, value: i16) -> Self {
         self.producer_epoch = value;
         self
@@ -77,7 +77,7 @@ impl EndTxnRequest {
     ///
     /// True if the transaction was committed, false if it was aborted.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub fn with_committed(mut self, value: bool) -> Self {
         self.committed = value;
         self
@@ -189,7 +189,7 @@ impl Default for EndTxnRequest {
 }
 
 impl Message for EndTxnRequest {
-    const VERSIONS: VersionRange = VersionRange { min: 0, max: 3 };
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 4 };
     const DEPRECATED_VERSIONS: Option<VersionRange> = None;
 }
 

--- a/src/messages/end_txn_response.rs
+++ b/src/messages/end_txn_response.rs
@@ -17,18 +17,18 @@ use crate::protocol::{
     Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
 };
 
-/// Valid versions: 0-3
+/// Valid versions: 0-4
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct EndTxnResponse {
     /// The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub throttle_time_ms: i32,
 
     /// The error code, or 0 if there was no error.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub error_code: i16,
 
     /// Other tagged fields
@@ -40,7 +40,7 @@ impl EndTxnResponse {
     ///
     /// The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub fn with_throttle_time_ms(mut self, value: i32) -> Self {
         self.throttle_time_ms = value;
         self
@@ -49,7 +49,7 @@ impl EndTxnResponse {
     ///
     /// The error code, or 0 if there was no error.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub fn with_error_code(mut self, value: i16) -> Self {
         self.error_code = value;
         self
@@ -139,7 +139,7 @@ impl Default for EndTxnResponse {
 }
 
 impl Message for EndTxnResponse {
-    const VERSIONS: VersionRange = VersionRange { min: 0, max: 3 };
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 4 };
     const DEPRECATED_VERSIONS: Option<VersionRange> = None;
 }
 

--- a/src/messages/find_coordinator_request.rs
+++ b/src/messages/find_coordinator_request.rs
@@ -17,7 +17,7 @@ use crate::protocol::{
     Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
 };
 
-/// Valid versions: 0-4
+/// Valid versions: 0-5
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct FindCoordinatorRequest {
@@ -28,12 +28,12 @@ pub struct FindCoordinatorRequest {
 
     /// The coordinator key type. (Group, transaction, etc.)
     ///
-    /// Supported API versions: 1-4
+    /// Supported API versions: 1-5
     pub key_type: i8,
 
     /// The coordinator keys.
     ///
-    /// Supported API versions: 4
+    /// Supported API versions: 4-5
     pub coordinator_keys: Vec<StrBytes>,
 
     /// Other tagged fields
@@ -54,7 +54,7 @@ impl FindCoordinatorRequest {
     ///
     /// The coordinator key type. (Group, transaction, etc.)
     ///
-    /// Supported API versions: 1-4
+    /// Supported API versions: 1-5
     pub fn with_key_type(mut self, value: i8) -> Self {
         self.key_type = value;
         self
@@ -63,7 +63,7 @@ impl FindCoordinatorRequest {
     ///
     /// The coordinator keys.
     ///
-    /// Supported API versions: 4
+    /// Supported API versions: 4-5
     pub fn with_coordinator_keys(mut self, value: Vec<StrBytes>) -> Self {
         self.coordinator_keys = value;
         self
@@ -219,7 +219,7 @@ impl Default for FindCoordinatorRequest {
 }
 
 impl Message for FindCoordinatorRequest {
-    const VERSIONS: VersionRange = VersionRange { min: 0, max: 4 };
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 5 };
     const DEPRECATED_VERSIONS: Option<VersionRange> = Some(VersionRange { min: 0, max: 0 });
 }
 

--- a/src/messages/find_coordinator_response.rs
+++ b/src/messages/find_coordinator_response.rs
@@ -17,38 +17,38 @@ use crate::protocol::{
     Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
 };
 
-/// Valid versions: 0-4
+/// Valid versions: 0-5
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct Coordinator {
     /// The coordinator key.
     ///
-    /// Supported API versions: 4
+    /// Supported API versions: 4-5
     pub key: StrBytes,
 
     /// The node id.
     ///
-    /// Supported API versions: 4
+    /// Supported API versions: 4-5
     pub node_id: super::BrokerId,
 
     /// The host name.
     ///
-    /// Supported API versions: 4
+    /// Supported API versions: 4-5
     pub host: StrBytes,
 
     /// The port.
     ///
-    /// Supported API versions: 4
+    /// Supported API versions: 4-5
     pub port: i32,
 
     /// The error code, or 0 if there was no error.
     ///
-    /// Supported API versions: 4
+    /// Supported API versions: 4-5
     pub error_code: i16,
 
     /// The error message, or null if there was no error.
     ///
-    /// Supported API versions: 4
+    /// Supported API versions: 4-5
     pub error_message: Option<StrBytes>,
 
     /// Other tagged fields
@@ -60,7 +60,7 @@ impl Coordinator {
     ///
     /// The coordinator key.
     ///
-    /// Supported API versions: 4
+    /// Supported API versions: 4-5
     pub fn with_key(mut self, value: StrBytes) -> Self {
         self.key = value;
         self
@@ -69,7 +69,7 @@ impl Coordinator {
     ///
     /// The node id.
     ///
-    /// Supported API versions: 4
+    /// Supported API versions: 4-5
     pub fn with_node_id(mut self, value: super::BrokerId) -> Self {
         self.node_id = value;
         self
@@ -78,7 +78,7 @@ impl Coordinator {
     ///
     /// The host name.
     ///
-    /// Supported API versions: 4
+    /// Supported API versions: 4-5
     pub fn with_host(mut self, value: StrBytes) -> Self {
         self.host = value;
         self
@@ -87,7 +87,7 @@ impl Coordinator {
     ///
     /// The port.
     ///
-    /// Supported API versions: 4
+    /// Supported API versions: 4-5
     pub fn with_port(mut self, value: i32) -> Self {
         self.port = value;
         self
@@ -96,7 +96,7 @@ impl Coordinator {
     ///
     /// The error code, or 0 if there was no error.
     ///
-    /// Supported API versions: 4
+    /// Supported API versions: 4-5
     pub fn with_error_code(mut self, value: i16) -> Self {
         self.error_code = value;
         self
@@ -105,7 +105,7 @@ impl Coordinator {
     ///
     /// The error message, or null if there was no error.
     ///
-    /// Supported API versions: 4
+    /// Supported API versions: 4-5
     pub fn with_error_message(mut self, value: Option<StrBytes>) -> Self {
         self.error_message = value;
         self
@@ -303,17 +303,17 @@ impl Default for Coordinator {
 }
 
 impl Message for Coordinator {
-    const VERSIONS: VersionRange = VersionRange { min: 0, max: 4 };
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 5 };
     const DEPRECATED_VERSIONS: Option<VersionRange> = None;
 }
 
-/// Valid versions: 0-4
+/// Valid versions: 0-5
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct FindCoordinatorResponse {
     /// The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota.
     ///
-    /// Supported API versions: 1-4
+    /// Supported API versions: 1-5
     pub throttle_time_ms: i32,
 
     /// The error code, or 0 if there was no error.
@@ -343,7 +343,7 @@ pub struct FindCoordinatorResponse {
 
     /// Each coordinator result in the response
     ///
-    /// Supported API versions: 4
+    /// Supported API versions: 4-5
     pub coordinators: Vec<Coordinator>,
 
     /// Other tagged fields
@@ -355,7 +355,7 @@ impl FindCoordinatorResponse {
     ///
     /// The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota.
     ///
-    /// Supported API versions: 1-4
+    /// Supported API versions: 1-5
     pub fn with_throttle_time_ms(mut self, value: i32) -> Self {
         self.throttle_time_ms = value;
         self
@@ -409,7 +409,7 @@ impl FindCoordinatorResponse {
     ///
     /// Each coordinator result in the response
     ///
-    /// Supported API versions: 4
+    /// Supported API versions: 4-5
     pub fn with_coordinators(mut self, value: Vec<Coordinator>) -> Self {
         self.coordinators = value;
         self
@@ -645,7 +645,7 @@ impl Default for FindCoordinatorResponse {
 }
 
 impl Message for FindCoordinatorResponse {
-    const VERSIONS: VersionRange = VersionRange { min: 0, max: 4 };
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 5 };
     const DEPRECATED_VERSIONS: Option<VersionRange> = None;
 }
 

--- a/src/messages/init_producer_id_request.rs
+++ b/src/messages/init_producer_id_request.rs
@@ -17,28 +17,28 @@ use crate::protocol::{
     Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
 };
 
-/// Valid versions: 0-4
+/// Valid versions: 0-5
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct InitProducerIdRequest {
     /// The transactional id, or null if the producer is not transactional.
     ///
-    /// Supported API versions: 0-4
+    /// Supported API versions: 0-5
     pub transactional_id: Option<super::TransactionalId>,
 
     /// The time in ms to wait before aborting idle transactions sent by this producer. This is only relevant if a TransactionalId has been defined.
     ///
-    /// Supported API versions: 0-4
+    /// Supported API versions: 0-5
     pub transaction_timeout_ms: i32,
 
     /// The producer id. This is used to disambiguate requests if a transactional id is reused following its expiration.
     ///
-    /// Supported API versions: 3-4
+    /// Supported API versions: 3-5
     pub producer_id: super::ProducerId,
 
     /// The producer's current epoch. This will be checked against the producer epoch on the broker, and the request will return an error if they do not match.
     ///
-    /// Supported API versions: 3-4
+    /// Supported API versions: 3-5
     pub producer_epoch: i16,
 
     /// Other tagged fields
@@ -50,7 +50,7 @@ impl InitProducerIdRequest {
     ///
     /// The transactional id, or null if the producer is not transactional.
     ///
-    /// Supported API versions: 0-4
+    /// Supported API versions: 0-5
     pub fn with_transactional_id(mut self, value: Option<super::TransactionalId>) -> Self {
         self.transactional_id = value;
         self
@@ -59,7 +59,7 @@ impl InitProducerIdRequest {
     ///
     /// The time in ms to wait before aborting idle transactions sent by this producer. This is only relevant if a TransactionalId has been defined.
     ///
-    /// Supported API versions: 0-4
+    /// Supported API versions: 0-5
     pub fn with_transaction_timeout_ms(mut self, value: i32) -> Self {
         self.transaction_timeout_ms = value;
         self
@@ -68,7 +68,7 @@ impl InitProducerIdRequest {
     ///
     /// The producer id. This is used to disambiguate requests if a transactional id is reused following its expiration.
     ///
-    /// Supported API versions: 3-4
+    /// Supported API versions: 3-5
     pub fn with_producer_id(mut self, value: super::ProducerId) -> Self {
         self.producer_id = value;
         self
@@ -77,7 +77,7 @@ impl InitProducerIdRequest {
     ///
     /// The producer's current epoch. This will be checked against the producer epoch on the broker, and the request will return an error if they do not match.
     ///
-    /// Supported API versions: 3-4
+    /// Supported API versions: 3-5
     pub fn with_producer_epoch(mut self, value: i16) -> Self {
         self.producer_epoch = value;
         self
@@ -221,7 +221,7 @@ impl Default for InitProducerIdRequest {
 }
 
 impl Message for InitProducerIdRequest {
-    const VERSIONS: VersionRange = VersionRange { min: 0, max: 4 };
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 5 };
     const DEPRECATED_VERSIONS: Option<VersionRange> = None;
 }
 

--- a/src/messages/init_producer_id_response.rs
+++ b/src/messages/init_producer_id_response.rs
@@ -17,28 +17,28 @@ use crate::protocol::{
     Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
 };
 
-/// Valid versions: 0-4
+/// Valid versions: 0-5
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct InitProducerIdResponse {
     /// The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota.
     ///
-    /// Supported API versions: 0-4
+    /// Supported API versions: 0-5
     pub throttle_time_ms: i32,
 
     /// The error code, or 0 if there was no error.
     ///
-    /// Supported API versions: 0-4
+    /// Supported API versions: 0-5
     pub error_code: i16,
 
     /// The current producer id.
     ///
-    /// Supported API versions: 0-4
+    /// Supported API versions: 0-5
     pub producer_id: super::ProducerId,
 
     /// The current epoch associated with the producer id.
     ///
-    /// Supported API versions: 0-4
+    /// Supported API versions: 0-5
     pub producer_epoch: i16,
 
     /// Other tagged fields
@@ -50,7 +50,7 @@ impl InitProducerIdResponse {
     ///
     /// The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota.
     ///
-    /// Supported API versions: 0-4
+    /// Supported API versions: 0-5
     pub fn with_throttle_time_ms(mut self, value: i32) -> Self {
         self.throttle_time_ms = value;
         self
@@ -59,7 +59,7 @@ impl InitProducerIdResponse {
     ///
     /// The error code, or 0 if there was no error.
     ///
-    /// Supported API versions: 0-4
+    /// Supported API versions: 0-5
     pub fn with_error_code(mut self, value: i16) -> Self {
         self.error_code = value;
         self
@@ -68,7 +68,7 @@ impl InitProducerIdResponse {
     ///
     /// The current producer id.
     ///
-    /// Supported API versions: 0-4
+    /// Supported API versions: 0-5
     pub fn with_producer_id(mut self, value: super::ProducerId) -> Self {
         self.producer_id = value;
         self
@@ -77,7 +77,7 @@ impl InitProducerIdResponse {
     ///
     /// The current epoch associated with the producer id.
     ///
-    /// Supported API versions: 0-4
+    /// Supported API versions: 0-5
     pub fn with_producer_epoch(mut self, value: i16) -> Self {
         self.producer_epoch = value;
         self
@@ -177,7 +177,7 @@ impl Default for InitProducerIdResponse {
 }
 
 impl Message for InitProducerIdResponse {
-    const VERSIONS: VersionRange = VersionRange { min: 0, max: 4 };
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 5 };
     const DEPRECATED_VERSIONS: Option<VersionRange> = None;
 }
 

--- a/src/messages/k_raft_version_record.rs
+++ b/src/messages/k_raft_version_record.rs
@@ -1,0 +1,136 @@
+//! KRaftVersionRecord
+//!
+//! See the schema for this message [here](https://github.com/apache/kafka/blob/trunk/clients/src/main/resources/common/message/KRaftVersionRecord.json).
+// WARNING: the items of this module are generated and should not be edited directly
+#![allow(unused)]
+
+use std::borrow::Borrow;
+use std::collections::BTreeMap;
+
+use anyhow::{bail, Result};
+use bytes::Bytes;
+use uuid::Uuid;
+
+use crate::protocol::{
+    buf::{ByteBuf, ByteBufMut},
+    compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
+    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+};
+
+/// Valid versions: 0
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq)]
+pub struct KRaftVersionRecord {
+    /// The version of the kraft version record
+    ///
+    /// Supported API versions: 0
+    pub version: i16,
+
+    /// The kraft protocol version
+    ///
+    /// Supported API versions: 0
+    pub k_raft_version: i16,
+
+    /// Other tagged fields
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
+}
+
+impl KRaftVersionRecord {
+    /// Sets `version` to the passed value.
+    ///
+    /// The version of the kraft version record
+    ///
+    /// Supported API versions: 0
+    pub fn with_version(mut self, value: i16) -> Self {
+        self.version = value;
+        self
+    }
+    /// Sets `k_raft_version` to the passed value.
+    ///
+    /// The kraft protocol version
+    ///
+    /// Supported API versions: 0
+    pub fn with_k_raft_version(mut self, value: i16) -> Self {
+        self.k_raft_version = value;
+        self
+    }
+    /// Sets unknown_tagged_fields to the passed value.
+    pub fn with_unknown_tagged_fields(mut self, value: BTreeMap<i32, Bytes>) -> Self {
+        self.unknown_tagged_fields = value;
+        self
+    }
+    /// Inserts an entry into unknown_tagged_fields.
+    pub fn with_unknown_tagged_field(mut self, key: i32, value: Bytes) -> Self {
+        self.unknown_tagged_fields.insert(key, value);
+        self
+    }
+}
+
+impl Encodable for KRaftVersionRecord {
+    fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        types::Int16.encode(buf, &self.version)?;
+        types::Int16.encode(buf, &self.k_raft_version)?;
+        let num_tagged_fields = self.unknown_tagged_fields.len();
+        if num_tagged_fields > std::u32::MAX as usize {
+            bail!(
+                "Too many tagged fields to encode ({} fields)",
+                num_tagged_fields
+            );
+        }
+        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+
+        write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
+        Ok(())
+    }
+    fn compute_size(&self, version: i16) -> Result<usize> {
+        let mut total_size = 0;
+        total_size += types::Int16.compute_size(&self.version)?;
+        total_size += types::Int16.compute_size(&self.k_raft_version)?;
+        let num_tagged_fields = self.unknown_tagged_fields.len();
+        if num_tagged_fields > std::u32::MAX as usize {
+            bail!(
+                "Too many tagged fields to encode ({} fields)",
+                num_tagged_fields
+            );
+        }
+        total_size += types::UnsignedVarInt.compute_size(num_tagged_fields as u32)?;
+
+        total_size += compute_unknown_tagged_fields_size(&self.unknown_tagged_fields)?;
+        Ok(total_size)
+    }
+}
+
+impl Decodable for KRaftVersionRecord {
+    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        let version = types::Int16.decode(buf)?;
+        let k_raft_version = types::Int16.decode(buf)?;
+        let mut unknown_tagged_fields = BTreeMap::new();
+        let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
+        for _ in 0..num_tagged_fields {
+            let tag: u32 = types::UnsignedVarInt.decode(buf)?;
+            let size: u32 = types::UnsignedVarInt.decode(buf)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
+            unknown_tagged_fields.insert(tag as i32, unknown_value);
+        }
+        Ok(Self {
+            version,
+            k_raft_version,
+            unknown_tagged_fields,
+        })
+    }
+}
+
+impl Default for KRaftVersionRecord {
+    fn default() -> Self {
+        Self {
+            version: 0,
+            k_raft_version: 0,
+            unknown_tagged_fields: BTreeMap::new(),
+        }
+    }
+}
+
+impl Message for KRaftVersionRecord {
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 0 };
+    const DEPRECATED_VERSIONS: Option<VersionRange> = None;
+}

--- a/src/messages/list_client_metrics_resources_response.rs
+++ b/src/messages/list_client_metrics_resources_response.rs
@@ -21,7 +21,7 @@ use crate::protocol::{
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct ClientMetricsResource {
-    ///
+    /// The resource name.
     ///
     /// Supported API versions: 0
     pub name: StrBytes,
@@ -33,7 +33,7 @@ pub struct ClientMetricsResource {
 impl ClientMetricsResource {
     /// Sets `name` to the passed value.
     ///
-    ///
+    /// The resource name.
     ///
     /// Supported API versions: 0
     pub fn with_name(mut self, value: StrBytes) -> Self {
@@ -127,12 +127,12 @@ pub struct ListClientMetricsResourcesResponse {
     /// Supported API versions: 0
     pub throttle_time_ms: i32,
 
-    ///
+    /// The error code, or 0 if there was no error.
     ///
     /// Supported API versions: 0
     pub error_code: i16,
 
-    ///
+    /// Each client metrics resource in the response.
     ///
     /// Supported API versions: 0
     pub client_metrics_resources: Vec<ClientMetricsResource>,
@@ -153,7 +153,7 @@ impl ListClientMetricsResourcesResponse {
     }
     /// Sets `error_code` to the passed value.
     ///
-    ///
+    /// The error code, or 0 if there was no error.
     ///
     /// Supported API versions: 0
     pub fn with_error_code(mut self, value: i16) -> Self {
@@ -162,7 +162,7 @@ impl ListClientMetricsResourcesResponse {
     }
     /// Sets `client_metrics_resources` to the passed value.
     ///
-    ///
+    /// Each client metrics resource in the response.
     ///
     /// Supported API versions: 0
     pub fn with_client_metrics_resources(mut self, value: Vec<ClientMetricsResource>) -> Self {

--- a/src/messages/list_transactions_response.rs
+++ b/src/messages/list_transactions_response.rs
@@ -17,28 +17,28 @@ use crate::protocol::{
     Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
 };
 
-/// Valid versions: 0
+/// Valid versions: 0-1
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct ListTransactionsResponse {
     /// The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota.
     ///
-    /// Supported API versions: 0
+    /// Supported API versions: 0-1
     pub throttle_time_ms: i32,
 
     ///
     ///
-    /// Supported API versions: 0
+    /// Supported API versions: 0-1
     pub error_code: i16,
 
     /// Set of state filters provided in the request which were unknown to the transaction coordinator
     ///
-    /// Supported API versions: 0
+    /// Supported API versions: 0-1
     pub unknown_state_filters: Vec<StrBytes>,
 
     ///
     ///
-    /// Supported API versions: 0
+    /// Supported API versions: 0-1
     pub transaction_states: Vec<TransactionState>,
 
     /// Other tagged fields
@@ -50,7 +50,7 @@ impl ListTransactionsResponse {
     ///
     /// The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota.
     ///
-    /// Supported API versions: 0
+    /// Supported API versions: 0-1
     pub fn with_throttle_time_ms(mut self, value: i32) -> Self {
         self.throttle_time_ms = value;
         self
@@ -59,7 +59,7 @@ impl ListTransactionsResponse {
     ///
     ///
     ///
-    /// Supported API versions: 0
+    /// Supported API versions: 0-1
     pub fn with_error_code(mut self, value: i16) -> Self {
         self.error_code = value;
         self
@@ -68,7 +68,7 @@ impl ListTransactionsResponse {
     ///
     /// Set of state filters provided in the request which were unknown to the transaction coordinator
     ///
-    /// Supported API versions: 0
+    /// Supported API versions: 0-1
     pub fn with_unknown_state_filters(mut self, value: Vec<StrBytes>) -> Self {
         self.unknown_state_filters = value;
         self
@@ -77,7 +77,7 @@ impl ListTransactionsResponse {
     ///
     ///
     ///
-    /// Supported API versions: 0
+    /// Supported API versions: 0-1
     pub fn with_transaction_states(mut self, value: Vec<TransactionState>) -> Self {
         self.transaction_states = value;
         self
@@ -173,27 +173,27 @@ impl Default for ListTransactionsResponse {
 }
 
 impl Message for ListTransactionsResponse {
-    const VERSIONS: VersionRange = VersionRange { min: 0, max: 0 };
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 1 };
     const DEPRECATED_VERSIONS: Option<VersionRange> = None;
 }
 
-/// Valid versions: 0
+/// Valid versions: 0-1
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct TransactionState {
     ///
     ///
-    /// Supported API versions: 0
+    /// Supported API versions: 0-1
     pub transactional_id: super::TransactionalId,
 
     ///
     ///
-    /// Supported API versions: 0
+    /// Supported API versions: 0-1
     pub producer_id: super::ProducerId,
 
     /// The current transaction state of the producer
     ///
-    /// Supported API versions: 0
+    /// Supported API versions: 0-1
     pub transaction_state: StrBytes,
 
     /// Other tagged fields
@@ -205,7 +205,7 @@ impl TransactionState {
     ///
     ///
     ///
-    /// Supported API versions: 0
+    /// Supported API versions: 0-1
     pub fn with_transactional_id(mut self, value: super::TransactionalId) -> Self {
         self.transactional_id = value;
         self
@@ -214,7 +214,7 @@ impl TransactionState {
     ///
     ///
     ///
-    /// Supported API versions: 0
+    /// Supported API versions: 0-1
     pub fn with_producer_id(mut self, value: super::ProducerId) -> Self {
         self.producer_id = value;
         self
@@ -223,7 +223,7 @@ impl TransactionState {
     ///
     /// The current transaction state of the producer
     ///
-    /// Supported API versions: 0
+    /// Supported API versions: 0-1
     pub fn with_transaction_state(mut self, value: StrBytes) -> Self {
         self.transaction_state = value;
         self
@@ -312,7 +312,7 @@ impl Default for TransactionState {
 }
 
 impl Message for TransactionState {
-    const VERSIONS: VersionRange = VersionRange { min: 0, max: 0 };
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 1 };
     const DEPRECATED_VERSIONS: Option<VersionRange> = None;
 }
 

--- a/src/messages/metadata_response.rs
+++ b/src/messages/metadata_response.rs
@@ -26,7 +26,7 @@ pub struct MetadataResponse {
     /// Supported API versions: 3-12
     pub throttle_time_ms: i32,
 
-    /// Each broker in the response.
+    /// A list of brokers present in the cluster.
     ///
     /// Supported API versions: 0-12
     pub brokers: indexmap::IndexMap<super::BrokerId, MetadataResponseBroker>,
@@ -67,7 +67,7 @@ impl MetadataResponse {
     }
     /// Sets `brokers` to the passed value.
     ///
-    /// Each broker in the response.
+    /// A list of brokers present in the cluster.
     ///
     /// Supported API versions: 0-12
     pub fn with_brokers(
@@ -771,7 +771,7 @@ pub struct MetadataResponseTopic {
     /// Supported API versions: 0-12
     pub error_code: i16,
 
-    /// The topic id.
+    /// The topic id. Zero for non-existing topics queried by name. This is never zero when ErrorCode is zero. One of Name and TopicId is always populated.
     ///
     /// Supported API versions: 10-12
     pub topic_id: Uuid,
@@ -807,7 +807,7 @@ impl MetadataResponseTopic {
     }
     /// Sets `topic_id` to the passed value.
     ///
-    /// The topic id.
+    /// The topic id. Zero for non-existing topics queried by name. This is never zero when ErrorCode is zero. One of Name and TopicId is always populated.
     ///
     /// Supported API versions: 10-12
     pub fn with_topic_id(mut self, value: Uuid) -> Self {

--- a/src/messages/produce_request.rs
+++ b/src/messages/produce_request.rs
@@ -17,18 +17,18 @@ use crate::protocol::{
     Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
 };
 
-/// Valid versions: 0-10
+/// Valid versions: 0-11
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct PartitionProduceData {
     /// The partition index.
     ///
-    /// Supported API versions: 0-10
+    /// Supported API versions: 0-11
     pub index: i32,
 
     /// The record data to be produced.
     ///
-    /// Supported API versions: 0-10
+    /// Supported API versions: 0-11
     pub records: Option<Bytes>,
 
     /// Other tagged fields
@@ -40,7 +40,7 @@ impl PartitionProduceData {
     ///
     /// The partition index.
     ///
-    /// Supported API versions: 0-10
+    /// Supported API versions: 0-11
     pub fn with_index(mut self, value: i32) -> Self {
         self.index = value;
         self
@@ -49,7 +49,7 @@ impl PartitionProduceData {
     ///
     /// The record data to be produced.
     ///
-    /// Supported API versions: 0-10
+    /// Supported API versions: 0-11
     pub fn with_records(mut self, value: Option<Bytes>) -> Self {
         self.records = value;
         self
@@ -151,32 +151,32 @@ impl Default for PartitionProduceData {
 }
 
 impl Message for PartitionProduceData {
-    const VERSIONS: VersionRange = VersionRange { min: 0, max: 10 };
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 11 };
     const DEPRECATED_VERSIONS: Option<VersionRange> = Some(VersionRange { min: 0, max: 6 });
 }
 
-/// Valid versions: 0-10
+/// Valid versions: 0-11
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct ProduceRequest {
     /// The transactional ID, or null if the producer is not transactional.
     ///
-    /// Supported API versions: 3-10
+    /// Supported API versions: 3-11
     pub transactional_id: Option<super::TransactionalId>,
 
     /// The number of acknowledgments the producer requires the leader to have received before considering a request complete. Allowed values: 0 for no acknowledgments, 1 for only the leader and -1 for the full ISR.
     ///
-    /// Supported API versions: 0-10
+    /// Supported API versions: 0-11
     pub acks: i16,
 
     /// The timeout to await a response in milliseconds.
     ///
-    /// Supported API versions: 0-10
+    /// Supported API versions: 0-11
     pub timeout_ms: i32,
 
     /// Each topic to produce to.
     ///
-    /// Supported API versions: 0-10
+    /// Supported API versions: 0-11
     pub topic_data: indexmap::IndexMap<super::TopicName, TopicProduceData>,
 
     /// Other tagged fields
@@ -188,7 +188,7 @@ impl ProduceRequest {
     ///
     /// The transactional ID, or null if the producer is not transactional.
     ///
-    /// Supported API versions: 3-10
+    /// Supported API versions: 3-11
     pub fn with_transactional_id(mut self, value: Option<super::TransactionalId>) -> Self {
         self.transactional_id = value;
         self
@@ -197,7 +197,7 @@ impl ProduceRequest {
     ///
     /// The number of acknowledgments the producer requires the leader to have received before considering a request complete. Allowed values: 0 for no acknowledgments, 1 for only the leader and -1 for the full ISR.
     ///
-    /// Supported API versions: 0-10
+    /// Supported API versions: 0-11
     pub fn with_acks(mut self, value: i16) -> Self {
         self.acks = value;
         self
@@ -206,7 +206,7 @@ impl ProduceRequest {
     ///
     /// The timeout to await a response in milliseconds.
     ///
-    /// Supported API versions: 0-10
+    /// Supported API versions: 0-11
     pub fn with_timeout_ms(mut self, value: i32) -> Self {
         self.timeout_ms = value;
         self
@@ -215,7 +215,7 @@ impl ProduceRequest {
     ///
     /// Each topic to produce to.
     ///
-    /// Supported API versions: 0-10
+    /// Supported API versions: 0-11
     pub fn with_topic_data(
         mut self,
         value: indexmap::IndexMap<super::TopicName, TopicProduceData>,
@@ -359,17 +359,17 @@ impl Default for ProduceRequest {
 }
 
 impl Message for ProduceRequest {
-    const VERSIONS: VersionRange = VersionRange { min: 0, max: 10 };
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 11 };
     const DEPRECATED_VERSIONS: Option<VersionRange> = Some(VersionRange { min: 0, max: 6 });
 }
 
-/// Valid versions: 0-10
+/// Valid versions: 0-11
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct TopicProduceData {
     /// Each partition to produce to.
     ///
-    /// Supported API versions: 0-10
+    /// Supported API versions: 0-11
     pub partition_data: Vec<PartitionProduceData>,
 
     /// Other tagged fields
@@ -381,7 +381,7 @@ impl TopicProduceData {
     ///
     /// Each partition to produce to.
     ///
-    /// Supported API versions: 0-10
+    /// Supported API versions: 0-11
     pub fn with_partition_data(mut self, value: Vec<PartitionProduceData>) -> Self {
         self.partition_data = value;
         self
@@ -500,7 +500,7 @@ impl Default for TopicProduceData {
 }
 
 impl Message for TopicProduceData {
-    const VERSIONS: VersionRange = VersionRange { min: 0, max: 10 };
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 11 };
     const DEPRECATED_VERSIONS: Option<VersionRange> = Some(VersionRange { min: 0, max: 6 });
 }
 

--- a/src/messages/produce_response.rs
+++ b/src/messages/produce_response.rs
@@ -17,18 +17,18 @@ use crate::protocol::{
     Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
 };
 
-/// Valid versions: 0-10
+/// Valid versions: 0-11
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct BatchIndexAndErrorMessage {
     /// The batch index of the record that cause the batch to be dropped
     ///
-    /// Supported API versions: 8-10
+    /// Supported API versions: 8-11
     pub batch_index: i32,
 
     /// The error message of the record that caused the batch to be dropped
     ///
-    /// Supported API versions: 8-10
+    /// Supported API versions: 8-11
     pub batch_index_error_message: Option<StrBytes>,
 
     /// Other tagged fields
@@ -40,7 +40,7 @@ impl BatchIndexAndErrorMessage {
     ///
     /// The batch index of the record that cause the batch to be dropped
     ///
-    /// Supported API versions: 8-10
+    /// Supported API versions: 8-11
     pub fn with_batch_index(mut self, value: i32) -> Self {
         self.batch_index = value;
         self
@@ -49,7 +49,7 @@ impl BatchIndexAndErrorMessage {
     ///
     /// The error message of the record that caused the batch to be dropped
     ///
-    /// Supported API versions: 8-10
+    /// Supported API versions: 8-11
     pub fn with_batch_index_error_message(mut self, value: Option<StrBytes>) -> Self {
         self.batch_index_error_message = value;
         self
@@ -183,22 +183,22 @@ impl Default for BatchIndexAndErrorMessage {
 }
 
 impl Message for BatchIndexAndErrorMessage {
-    const VERSIONS: VersionRange = VersionRange { min: 0, max: 10 };
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 11 };
     const DEPRECATED_VERSIONS: Option<VersionRange> = None;
 }
 
-/// Valid versions: 0-10
+/// Valid versions: 0-11
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct LeaderIdAndEpoch {
     /// The ID of the current leader or -1 if the leader is unknown.
     ///
-    /// Supported API versions: 10
+    /// Supported API versions: 10-11
     pub leader_id: super::BrokerId,
 
     /// The latest known leader epoch
     ///
-    /// Supported API versions: 10
+    /// Supported API versions: 10-11
     pub leader_epoch: i32,
 
     /// Other tagged fields
@@ -210,7 +210,7 @@ impl LeaderIdAndEpoch {
     ///
     /// The ID of the current leader or -1 if the leader is unknown.
     ///
-    /// Supported API versions: 10
+    /// Supported API versions: 10-11
     pub fn with_leader_id(mut self, value: super::BrokerId) -> Self {
         self.leader_id = value;
         self
@@ -219,7 +219,7 @@ impl LeaderIdAndEpoch {
     ///
     /// The latest known leader epoch
     ///
-    /// Supported API versions: 10
+    /// Supported API versions: 10-11
     pub fn with_leader_epoch(mut self, value: i32) -> Self {
         self.leader_epoch = value;
         self
@@ -341,27 +341,27 @@ impl Default for LeaderIdAndEpoch {
 }
 
 impl Message for LeaderIdAndEpoch {
-    const VERSIONS: VersionRange = VersionRange { min: 0, max: 10 };
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 11 };
     const DEPRECATED_VERSIONS: Option<VersionRange> = None;
 }
 
-/// Valid versions: 0-10
+/// Valid versions: 0-11
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct NodeEndpoint {
     /// The node's hostname.
     ///
-    /// Supported API versions: 10
+    /// Supported API versions: 10-11
     pub host: StrBytes,
 
     /// The node's port.
     ///
-    /// Supported API versions: 10
+    /// Supported API versions: 10-11
     pub port: i32,
 
     /// The rack of the node, or null if it has not been assigned to a rack.
     ///
-    /// Supported API versions: 10
+    /// Supported API versions: 10-11
     pub rack: Option<StrBytes>,
 
     /// Other tagged fields
@@ -373,7 +373,7 @@ impl NodeEndpoint {
     ///
     /// The node's hostname.
     ///
-    /// Supported API versions: 10
+    /// Supported API versions: 10-11
     pub fn with_host(mut self, value: StrBytes) -> Self {
         self.host = value;
         self
@@ -382,7 +382,7 @@ impl NodeEndpoint {
     ///
     /// The node's port.
     ///
-    /// Supported API versions: 10
+    /// Supported API versions: 10-11
     pub fn with_port(mut self, value: i32) -> Self {
         self.port = value;
         self
@@ -391,7 +391,7 @@ impl NodeEndpoint {
     ///
     /// The rack of the node, or null if it has not been assigned to a rack.
     ///
-    /// Supported API versions: 10
+    /// Supported API versions: 10-11
     pub fn with_rack(mut self, value: Option<StrBytes>) -> Self {
         self.rack = value;
         self
@@ -558,52 +558,52 @@ impl Default for NodeEndpoint {
 }
 
 impl Message for NodeEndpoint {
-    const VERSIONS: VersionRange = VersionRange { min: 0, max: 10 };
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 11 };
     const DEPRECATED_VERSIONS: Option<VersionRange> = None;
 }
 
-/// Valid versions: 0-10
+/// Valid versions: 0-11
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct PartitionProduceResponse {
     /// The partition index.
     ///
-    /// Supported API versions: 0-10
+    /// Supported API versions: 0-11
     pub index: i32,
 
     /// The error code, or 0 if there was no error.
     ///
-    /// Supported API versions: 0-10
+    /// Supported API versions: 0-11
     pub error_code: i16,
 
     /// The base offset.
     ///
-    /// Supported API versions: 0-10
+    /// Supported API versions: 0-11
     pub base_offset: i64,
 
     /// The timestamp returned by broker after appending the messages. If CreateTime is used for the topic, the timestamp will be -1.  If LogAppendTime is used for the topic, the timestamp will be the broker local time when the messages are appended.
     ///
-    /// Supported API versions: 2-10
+    /// Supported API versions: 2-11
     pub log_append_time_ms: i64,
 
     /// The log start offset.
     ///
-    /// Supported API versions: 5-10
+    /// Supported API versions: 5-11
     pub log_start_offset: i64,
 
     /// The batch indices of records that caused the batch to be dropped
     ///
-    /// Supported API versions: 8-10
+    /// Supported API versions: 8-11
     pub record_errors: Vec<BatchIndexAndErrorMessage>,
 
     /// The global error message summarizing the common root cause of the records that caused the batch to be dropped
     ///
-    /// Supported API versions: 8-10
+    /// Supported API versions: 8-11
     pub error_message: Option<StrBytes>,
 
     ///
     ///
-    /// Supported API versions: 10
+    /// Supported API versions: 10-11
     pub current_leader: LeaderIdAndEpoch,
 
     /// Other tagged fields
@@ -615,7 +615,7 @@ impl PartitionProduceResponse {
     ///
     /// The partition index.
     ///
-    /// Supported API versions: 0-10
+    /// Supported API versions: 0-11
     pub fn with_index(mut self, value: i32) -> Self {
         self.index = value;
         self
@@ -624,7 +624,7 @@ impl PartitionProduceResponse {
     ///
     /// The error code, or 0 if there was no error.
     ///
-    /// Supported API versions: 0-10
+    /// Supported API versions: 0-11
     pub fn with_error_code(mut self, value: i16) -> Self {
         self.error_code = value;
         self
@@ -633,7 +633,7 @@ impl PartitionProduceResponse {
     ///
     /// The base offset.
     ///
-    /// Supported API versions: 0-10
+    /// Supported API versions: 0-11
     pub fn with_base_offset(mut self, value: i64) -> Self {
         self.base_offset = value;
         self
@@ -642,7 +642,7 @@ impl PartitionProduceResponse {
     ///
     /// The timestamp returned by broker after appending the messages. If CreateTime is used for the topic, the timestamp will be -1.  If LogAppendTime is used for the topic, the timestamp will be the broker local time when the messages are appended.
     ///
-    /// Supported API versions: 2-10
+    /// Supported API versions: 2-11
     pub fn with_log_append_time_ms(mut self, value: i64) -> Self {
         self.log_append_time_ms = value;
         self
@@ -651,7 +651,7 @@ impl PartitionProduceResponse {
     ///
     /// The log start offset.
     ///
-    /// Supported API versions: 5-10
+    /// Supported API versions: 5-11
     pub fn with_log_start_offset(mut self, value: i64) -> Self {
         self.log_start_offset = value;
         self
@@ -660,7 +660,7 @@ impl PartitionProduceResponse {
     ///
     /// The batch indices of records that caused the batch to be dropped
     ///
-    /// Supported API versions: 8-10
+    /// Supported API versions: 8-11
     pub fn with_record_errors(mut self, value: Vec<BatchIndexAndErrorMessage>) -> Self {
         self.record_errors = value;
         self
@@ -669,7 +669,7 @@ impl PartitionProduceResponse {
     ///
     /// The global error message summarizing the common root cause of the records that caused the batch to be dropped
     ///
-    /// Supported API versions: 8-10
+    /// Supported API versions: 8-11
     pub fn with_error_message(mut self, value: Option<StrBytes>) -> Self {
         self.error_message = value;
         self
@@ -678,7 +678,7 @@ impl PartitionProduceResponse {
     ///
     ///
     ///
-    /// Supported API versions: 10
+    /// Supported API versions: 10-11
     pub fn with_current_leader(mut self, value: LeaderIdAndEpoch) -> Self {
         self.current_leader = value;
         self
@@ -903,27 +903,27 @@ impl Default for PartitionProduceResponse {
 }
 
 impl Message for PartitionProduceResponse {
-    const VERSIONS: VersionRange = VersionRange { min: 0, max: 10 };
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 11 };
     const DEPRECATED_VERSIONS: Option<VersionRange> = None;
 }
 
-/// Valid versions: 0-10
+/// Valid versions: 0-11
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct ProduceResponse {
     /// Each produce response
     ///
-    /// Supported API versions: 0-10
+    /// Supported API versions: 0-11
     pub responses: indexmap::IndexMap<super::TopicName, TopicProduceResponse>,
 
     /// The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota.
     ///
-    /// Supported API versions: 1-10
+    /// Supported API versions: 1-11
     pub throttle_time_ms: i32,
 
     /// Endpoints for all current-leaders enumerated in PartitionProduceResponses, with errors NOT_LEADER_OR_FOLLOWER.
     ///
-    /// Supported API versions: 10
+    /// Supported API versions: 10-11
     pub node_endpoints: indexmap::IndexMap<super::BrokerId, NodeEndpoint>,
 
     /// Other tagged fields
@@ -935,7 +935,7 @@ impl ProduceResponse {
     ///
     /// Each produce response
     ///
-    /// Supported API versions: 0-10
+    /// Supported API versions: 0-11
     pub fn with_responses(
         mut self,
         value: indexmap::IndexMap<super::TopicName, TopicProduceResponse>,
@@ -947,7 +947,7 @@ impl ProduceResponse {
     ///
     /// The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota.
     ///
-    /// Supported API versions: 1-10
+    /// Supported API versions: 1-11
     pub fn with_throttle_time_ms(mut self, value: i32) -> Self {
         self.throttle_time_ms = value;
         self
@@ -956,7 +956,7 @@ impl ProduceResponse {
     ///
     /// Endpoints for all current-leaders enumerated in PartitionProduceResponses, with errors NOT_LEADER_OR_FOLLOWER.
     ///
-    /// Supported API versions: 10
+    /// Supported API versions: 10-11
     pub fn with_node_endpoints(
         mut self,
         value: indexmap::IndexMap<super::BrokerId, NodeEndpoint>,
@@ -1124,17 +1124,17 @@ impl Default for ProduceResponse {
 }
 
 impl Message for ProduceResponse {
-    const VERSIONS: VersionRange = VersionRange { min: 0, max: 10 };
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 11 };
     const DEPRECATED_VERSIONS: Option<VersionRange> = None;
 }
 
-/// Valid versions: 0-10
+/// Valid versions: 0-11
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct TopicProduceResponse {
     /// Each partition that we produced to within the topic.
     ///
-    /// Supported API versions: 0-10
+    /// Supported API versions: 0-11
     pub partition_responses: Vec<PartitionProduceResponse>,
 
     /// Other tagged fields
@@ -1146,7 +1146,7 @@ impl TopicProduceResponse {
     ///
     /// Each partition that we produced to within the topic.
     ///
-    /// Supported API versions: 0-10
+    /// Supported API versions: 0-11
     pub fn with_partition_responses(mut self, value: Vec<PartitionProduceResponse>) -> Self {
         self.partition_responses = value;
         self
@@ -1266,7 +1266,7 @@ impl Default for TopicProduceResponse {
 }
 
 impl Message for TopicProduceResponse {
-    const VERSIONS: VersionRange = VersionRange { min: 0, max: 10 };
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 11 };
     const DEPRECATED_VERSIONS: Option<VersionRange> = None;
 }
 

--- a/src/messages/txn_offset_commit_request.rs
+++ b/src/messages/txn_offset_commit_request.rs
@@ -17,48 +17,48 @@ use crate::protocol::{
     Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
 };
 
-/// Valid versions: 0-3
+/// Valid versions: 0-4
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct TxnOffsetCommitRequest {
     /// The ID of the transaction.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub transactional_id: super::TransactionalId,
 
     /// The ID of the group.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub group_id: super::GroupId,
 
     /// The current producer ID in use by the transactional ID.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub producer_id: super::ProducerId,
 
     /// The current epoch associated with the producer ID.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub producer_epoch: i16,
 
     /// The generation of the consumer.
     ///
-    /// Supported API versions: 3
+    /// Supported API versions: 3-4
     pub generation_id: i32,
 
     /// The member ID assigned by the group coordinator.
     ///
-    /// Supported API versions: 3
+    /// Supported API versions: 3-4
     pub member_id: StrBytes,
 
     /// The unique identifier of the consumer instance provided by end user.
     ///
-    /// Supported API versions: 3
+    /// Supported API versions: 3-4
     pub group_instance_id: Option<StrBytes>,
 
     /// Each topic that we want to commit offsets for.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub topics: Vec<TxnOffsetCommitRequestTopic>,
 
     /// Other tagged fields
@@ -70,7 +70,7 @@ impl TxnOffsetCommitRequest {
     ///
     /// The ID of the transaction.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub fn with_transactional_id(mut self, value: super::TransactionalId) -> Self {
         self.transactional_id = value;
         self
@@ -79,7 +79,7 @@ impl TxnOffsetCommitRequest {
     ///
     /// The ID of the group.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub fn with_group_id(mut self, value: super::GroupId) -> Self {
         self.group_id = value;
         self
@@ -88,7 +88,7 @@ impl TxnOffsetCommitRequest {
     ///
     /// The current producer ID in use by the transactional ID.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub fn with_producer_id(mut self, value: super::ProducerId) -> Self {
         self.producer_id = value;
         self
@@ -97,7 +97,7 @@ impl TxnOffsetCommitRequest {
     ///
     /// The current epoch associated with the producer ID.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub fn with_producer_epoch(mut self, value: i16) -> Self {
         self.producer_epoch = value;
         self
@@ -106,7 +106,7 @@ impl TxnOffsetCommitRequest {
     ///
     /// The generation of the consumer.
     ///
-    /// Supported API versions: 3
+    /// Supported API versions: 3-4
     pub fn with_generation_id(mut self, value: i32) -> Self {
         self.generation_id = value;
         self
@@ -115,7 +115,7 @@ impl TxnOffsetCommitRequest {
     ///
     /// The member ID assigned by the group coordinator.
     ///
-    /// Supported API versions: 3
+    /// Supported API versions: 3-4
     pub fn with_member_id(mut self, value: StrBytes) -> Self {
         self.member_id = value;
         self
@@ -124,7 +124,7 @@ impl TxnOffsetCommitRequest {
     ///
     /// The unique identifier of the consumer instance provided by end user.
     ///
-    /// Supported API versions: 3
+    /// Supported API versions: 3-4
     pub fn with_group_instance_id(mut self, value: Option<StrBytes>) -> Self {
         self.group_instance_id = value;
         self
@@ -133,7 +133,7 @@ impl TxnOffsetCommitRequest {
     ///
     /// Each topic that we want to commit offsets for.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub fn with_topics(mut self, value: Vec<TxnOffsetCommitRequestTopic>) -> Self {
         self.topics = value;
         self
@@ -338,32 +338,32 @@ impl Default for TxnOffsetCommitRequest {
 }
 
 impl Message for TxnOffsetCommitRequest {
-    const VERSIONS: VersionRange = VersionRange { min: 0, max: 3 };
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 4 };
     const DEPRECATED_VERSIONS: Option<VersionRange> = None;
 }
 
-/// Valid versions: 0-3
+/// Valid versions: 0-4
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct TxnOffsetCommitRequestPartition {
     /// The index of the partition within the topic.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub partition_index: i32,
 
     /// The message offset to be committed.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub committed_offset: i64,
 
     /// The leader epoch of the last consumed record.
     ///
-    /// Supported API versions: 2-3
+    /// Supported API versions: 2-4
     pub committed_leader_epoch: i32,
 
     /// Any associated metadata the client wants to keep.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub committed_metadata: Option<StrBytes>,
 
     /// Other tagged fields
@@ -375,7 +375,7 @@ impl TxnOffsetCommitRequestPartition {
     ///
     /// The index of the partition within the topic.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub fn with_partition_index(mut self, value: i32) -> Self {
         self.partition_index = value;
         self
@@ -384,7 +384,7 @@ impl TxnOffsetCommitRequestPartition {
     ///
     /// The message offset to be committed.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub fn with_committed_offset(mut self, value: i64) -> Self {
         self.committed_offset = value;
         self
@@ -393,7 +393,7 @@ impl TxnOffsetCommitRequestPartition {
     ///
     /// The leader epoch of the last consumed record.
     ///
-    /// Supported API versions: 2-3
+    /// Supported API versions: 2-4
     pub fn with_committed_leader_epoch(mut self, value: i32) -> Self {
         self.committed_leader_epoch = value;
         self
@@ -402,7 +402,7 @@ impl TxnOffsetCommitRequestPartition {
     ///
     /// Any associated metadata the client wants to keep.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub fn with_committed_metadata(mut self, value: Option<StrBytes>) -> Self {
         self.committed_metadata = value;
         self
@@ -522,22 +522,22 @@ impl Default for TxnOffsetCommitRequestPartition {
 }
 
 impl Message for TxnOffsetCommitRequestPartition {
-    const VERSIONS: VersionRange = VersionRange { min: 0, max: 3 };
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 4 };
     const DEPRECATED_VERSIONS: Option<VersionRange> = None;
 }
 
-/// Valid versions: 0-3
+/// Valid versions: 0-4
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct TxnOffsetCommitRequestTopic {
     /// The topic name.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub name: super::TopicName,
 
     /// The partitions inside the topic that we want to commit offsets for.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub partitions: Vec<TxnOffsetCommitRequestPartition>,
 
     /// Other tagged fields
@@ -549,7 +549,7 @@ impl TxnOffsetCommitRequestTopic {
     ///
     /// The topic name.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub fn with_name(mut self, value: super::TopicName) -> Self {
         self.name = value;
         self
@@ -558,7 +558,7 @@ impl TxnOffsetCommitRequestTopic {
     ///
     /// The partitions inside the topic that we want to commit offsets for.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub fn with_partitions(mut self, value: Vec<TxnOffsetCommitRequestPartition>) -> Self {
         self.partitions = value;
         self
@@ -673,7 +673,7 @@ impl Default for TxnOffsetCommitRequestTopic {
 }
 
 impl Message for TxnOffsetCommitRequestTopic {
-    const VERSIONS: VersionRange = VersionRange { min: 0, max: 3 };
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 4 };
     const DEPRECATED_VERSIONS: Option<VersionRange> = None;
 }
 

--- a/src/messages/txn_offset_commit_response.rs
+++ b/src/messages/txn_offset_commit_response.rs
@@ -17,18 +17,18 @@ use crate::protocol::{
     Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
 };
 
-/// Valid versions: 0-3
+/// Valid versions: 0-4
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct TxnOffsetCommitResponse {
     /// The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub throttle_time_ms: i32,
 
     /// The responses for each topic.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub topics: Vec<TxnOffsetCommitResponseTopic>,
 
     /// Other tagged fields
@@ -40,7 +40,7 @@ impl TxnOffsetCommitResponse {
     ///
     /// The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub fn with_throttle_time_ms(mut self, value: i32) -> Self {
         self.throttle_time_ms = value;
         self
@@ -49,7 +49,7 @@ impl TxnOffsetCommitResponse {
     ///
     /// The responses for each topic.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub fn with_topics(mut self, value: Vec<TxnOffsetCommitResponseTopic>) -> Self {
         self.topics = value;
         self
@@ -152,22 +152,22 @@ impl Default for TxnOffsetCommitResponse {
 }
 
 impl Message for TxnOffsetCommitResponse {
-    const VERSIONS: VersionRange = VersionRange { min: 0, max: 3 };
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 4 };
     const DEPRECATED_VERSIONS: Option<VersionRange> = None;
 }
 
-/// Valid versions: 0-3
+/// Valid versions: 0-4
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct TxnOffsetCommitResponsePartition {
     /// The partition index.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub partition_index: i32,
 
     /// The error code, or 0 if there was no error.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub error_code: i16,
 
     /// Other tagged fields
@@ -179,7 +179,7 @@ impl TxnOffsetCommitResponsePartition {
     ///
     /// The partition index.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub fn with_partition_index(mut self, value: i32) -> Self {
         self.partition_index = value;
         self
@@ -188,7 +188,7 @@ impl TxnOffsetCommitResponsePartition {
     ///
     /// The error code, or 0 if there was no error.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub fn with_error_code(mut self, value: i16) -> Self {
         self.error_code = value;
         self
@@ -278,22 +278,22 @@ impl Default for TxnOffsetCommitResponsePartition {
 }
 
 impl Message for TxnOffsetCommitResponsePartition {
-    const VERSIONS: VersionRange = VersionRange { min: 0, max: 3 };
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 4 };
     const DEPRECATED_VERSIONS: Option<VersionRange> = None;
 }
 
-/// Valid versions: 0-3
+/// Valid versions: 0-4
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct TxnOffsetCommitResponseTopic {
     /// The topic name.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub name: super::TopicName,
 
     /// The responses for each partition in the topic.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub partitions: Vec<TxnOffsetCommitResponsePartition>,
 
     /// Other tagged fields
@@ -305,7 +305,7 @@ impl TxnOffsetCommitResponseTopic {
     ///
     /// The topic name.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub fn with_name(mut self, value: super::TopicName) -> Self {
         self.name = value;
         self
@@ -314,7 +314,7 @@ impl TxnOffsetCommitResponseTopic {
     ///
     /// The responses for each partition in the topic.
     ///
-    /// Supported API versions: 0-3
+    /// Supported API versions: 0-4
     pub fn with_partitions(mut self, value: Vec<TxnOffsetCommitResponsePartition>) -> Self {
         self.partitions = value;
         self
@@ -429,7 +429,7 @@ impl Default for TxnOffsetCommitResponseTopic {
 }
 
 impl Message for TxnOffsetCommitResponseTopic {
-    const VERSIONS: VersionRange = VersionRange { min: 0, max: 3 };
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 4 };
     const DEPRECATED_VERSIONS: Option<VersionRange> = None;
 }
 

--- a/src/messages/voters_record.rs
+++ b/src/messages/voters_record.rs
@@ -1,0 +1,537 @@
+//! VotersRecord
+//!
+//! See the schema for this message [here](https://github.com/apache/kafka/blob/trunk/clients/src/main/resources/common/message/VotersRecord.json).
+// WARNING: the items of this module are generated and should not be edited directly
+#![allow(unused)]
+
+use std::borrow::Borrow;
+use std::collections::BTreeMap;
+
+use anyhow::{bail, Result};
+use bytes::Bytes;
+use uuid::Uuid;
+
+use crate::protocol::{
+    buf::{ByteBuf, ByteBufMut},
+    compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
+    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+};
+
+/// Valid versions: 0
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq)]
+pub struct Endpoint {
+    /// The hostname
+    ///
+    /// Supported API versions: 0
+    pub host: StrBytes,
+
+    /// The port
+    ///
+    /// Supported API versions: 0
+    pub port: u16,
+
+    /// Other tagged fields
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
+}
+
+impl Endpoint {
+    /// Sets `host` to the passed value.
+    ///
+    /// The hostname
+    ///
+    /// Supported API versions: 0
+    pub fn with_host(mut self, value: StrBytes) -> Self {
+        self.host = value;
+        self
+    }
+    /// Sets `port` to the passed value.
+    ///
+    /// The port
+    ///
+    /// Supported API versions: 0
+    pub fn with_port(mut self, value: u16) -> Self {
+        self.port = value;
+        self
+    }
+    /// Sets unknown_tagged_fields to the passed value.
+    pub fn with_unknown_tagged_fields(mut self, value: BTreeMap<i32, Bytes>) -> Self {
+        self.unknown_tagged_fields = value;
+        self
+    }
+    /// Inserts an entry into unknown_tagged_fields.
+    pub fn with_unknown_tagged_field(mut self, key: i32, value: Bytes) -> Self {
+        self.unknown_tagged_fields.insert(key, value);
+        self
+    }
+}
+
+impl MapEncodable for Endpoint {
+    type Key = StrBytes;
+    fn encode<B: ByteBufMut>(&self, key: &Self::Key, buf: &mut B, version: i16) -> Result<()> {
+        types::CompactString.encode(buf, key)?;
+        types::CompactString.encode(buf, &self.host)?;
+        types::UInt16.encode(buf, &self.port)?;
+        let num_tagged_fields = self.unknown_tagged_fields.len();
+        if num_tagged_fields > std::u32::MAX as usize {
+            bail!(
+                "Too many tagged fields to encode ({} fields)",
+                num_tagged_fields
+            );
+        }
+        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+
+        write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
+        Ok(())
+    }
+    fn compute_size(&self, key: &Self::Key, version: i16) -> Result<usize> {
+        let mut total_size = 0;
+        total_size += types::CompactString.compute_size(key)?;
+        total_size += types::CompactString.compute_size(&self.host)?;
+        total_size += types::UInt16.compute_size(&self.port)?;
+        let num_tagged_fields = self.unknown_tagged_fields.len();
+        if num_tagged_fields > std::u32::MAX as usize {
+            bail!(
+                "Too many tagged fields to encode ({} fields)",
+                num_tagged_fields
+            );
+        }
+        total_size += types::UnsignedVarInt.compute_size(num_tagged_fields as u32)?;
+
+        total_size += compute_unknown_tagged_fields_size(&self.unknown_tagged_fields)?;
+        Ok(total_size)
+    }
+}
+
+impl MapDecodable for Endpoint {
+    type Key = StrBytes;
+    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<(Self::Key, Self)> {
+        let key_field = types::CompactString.decode(buf)?;
+        let host = types::CompactString.decode(buf)?;
+        let port = types::UInt16.decode(buf)?;
+        let mut unknown_tagged_fields = BTreeMap::new();
+        let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
+        for _ in 0..num_tagged_fields {
+            let tag: u32 = types::UnsignedVarInt.decode(buf)?;
+            let size: u32 = types::UnsignedVarInt.decode(buf)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
+            unknown_tagged_fields.insert(tag as i32, unknown_value);
+        }
+        Ok((
+            key_field,
+            Self {
+                host,
+                port,
+                unknown_tagged_fields,
+            },
+        ))
+    }
+}
+
+impl Default for Endpoint {
+    fn default() -> Self {
+        Self {
+            host: Default::default(),
+            port: 0,
+            unknown_tagged_fields: BTreeMap::new(),
+        }
+    }
+}
+
+impl Message for Endpoint {
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 0 };
+    const DEPRECATED_VERSIONS: Option<VersionRange> = None;
+}
+
+/// Valid versions: 0
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq)]
+pub struct KRaftVersionFeature {
+    /// The minimum supported KRaft protocol version
+    ///
+    /// Supported API versions: 0
+    pub min_supported_version: i16,
+
+    /// The maximum supported KRaft protocol version
+    ///
+    /// Supported API versions: 0
+    pub max_supported_version: i16,
+
+    /// Other tagged fields
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
+}
+
+impl KRaftVersionFeature {
+    /// Sets `min_supported_version` to the passed value.
+    ///
+    /// The minimum supported KRaft protocol version
+    ///
+    /// Supported API versions: 0
+    pub fn with_min_supported_version(mut self, value: i16) -> Self {
+        self.min_supported_version = value;
+        self
+    }
+    /// Sets `max_supported_version` to the passed value.
+    ///
+    /// The maximum supported KRaft protocol version
+    ///
+    /// Supported API versions: 0
+    pub fn with_max_supported_version(mut self, value: i16) -> Self {
+        self.max_supported_version = value;
+        self
+    }
+    /// Sets unknown_tagged_fields to the passed value.
+    pub fn with_unknown_tagged_fields(mut self, value: BTreeMap<i32, Bytes>) -> Self {
+        self.unknown_tagged_fields = value;
+        self
+    }
+    /// Inserts an entry into unknown_tagged_fields.
+    pub fn with_unknown_tagged_field(mut self, key: i32, value: Bytes) -> Self {
+        self.unknown_tagged_fields.insert(key, value);
+        self
+    }
+}
+
+impl Encodable for KRaftVersionFeature {
+    fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        types::Int16.encode(buf, &self.min_supported_version)?;
+        types::Int16.encode(buf, &self.max_supported_version)?;
+        let num_tagged_fields = self.unknown_tagged_fields.len();
+        if num_tagged_fields > std::u32::MAX as usize {
+            bail!(
+                "Too many tagged fields to encode ({} fields)",
+                num_tagged_fields
+            );
+        }
+        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+
+        write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
+        Ok(())
+    }
+    fn compute_size(&self, version: i16) -> Result<usize> {
+        let mut total_size = 0;
+        total_size += types::Int16.compute_size(&self.min_supported_version)?;
+        total_size += types::Int16.compute_size(&self.max_supported_version)?;
+        let num_tagged_fields = self.unknown_tagged_fields.len();
+        if num_tagged_fields > std::u32::MAX as usize {
+            bail!(
+                "Too many tagged fields to encode ({} fields)",
+                num_tagged_fields
+            );
+        }
+        total_size += types::UnsignedVarInt.compute_size(num_tagged_fields as u32)?;
+
+        total_size += compute_unknown_tagged_fields_size(&self.unknown_tagged_fields)?;
+        Ok(total_size)
+    }
+}
+
+impl Decodable for KRaftVersionFeature {
+    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        let min_supported_version = types::Int16.decode(buf)?;
+        let max_supported_version = types::Int16.decode(buf)?;
+        let mut unknown_tagged_fields = BTreeMap::new();
+        let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
+        for _ in 0..num_tagged_fields {
+            let tag: u32 = types::UnsignedVarInt.decode(buf)?;
+            let size: u32 = types::UnsignedVarInt.decode(buf)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
+            unknown_tagged_fields.insert(tag as i32, unknown_value);
+        }
+        Ok(Self {
+            min_supported_version,
+            max_supported_version,
+            unknown_tagged_fields,
+        })
+    }
+}
+
+impl Default for KRaftVersionFeature {
+    fn default() -> Self {
+        Self {
+            min_supported_version: 0,
+            max_supported_version: 0,
+            unknown_tagged_fields: BTreeMap::new(),
+        }
+    }
+}
+
+impl Message for KRaftVersionFeature {
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 0 };
+    const DEPRECATED_VERSIONS: Option<VersionRange> = None;
+}
+
+/// Valid versions: 0
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq)]
+pub struct Voter {
+    /// The replica id of the voter in the topic partition
+    ///
+    /// Supported API versions: 0
+    pub voter_id: super::BrokerId,
+
+    /// The directory id of the voter in the topic partition
+    ///
+    /// Supported API versions: 0
+    pub voter_directory_id: Uuid,
+
+    /// The endpoint that can be used to communicate with the voter
+    ///
+    /// Supported API versions: 0
+    pub endpoints: indexmap::IndexMap<StrBytes, Endpoint>,
+
+    /// The range of versions of the protocol that the replica supports
+    ///
+    /// Supported API versions: 0
+    pub k_raft_version_feature: KRaftVersionFeature,
+
+    /// Other tagged fields
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
+}
+
+impl Voter {
+    /// Sets `voter_id` to the passed value.
+    ///
+    /// The replica id of the voter in the topic partition
+    ///
+    /// Supported API versions: 0
+    pub fn with_voter_id(mut self, value: super::BrokerId) -> Self {
+        self.voter_id = value;
+        self
+    }
+    /// Sets `voter_directory_id` to the passed value.
+    ///
+    /// The directory id of the voter in the topic partition
+    ///
+    /// Supported API versions: 0
+    pub fn with_voter_directory_id(mut self, value: Uuid) -> Self {
+        self.voter_directory_id = value;
+        self
+    }
+    /// Sets `endpoints` to the passed value.
+    ///
+    /// The endpoint that can be used to communicate with the voter
+    ///
+    /// Supported API versions: 0
+    pub fn with_endpoints(mut self, value: indexmap::IndexMap<StrBytes, Endpoint>) -> Self {
+        self.endpoints = value;
+        self
+    }
+    /// Sets `k_raft_version_feature` to the passed value.
+    ///
+    /// The range of versions of the protocol that the replica supports
+    ///
+    /// Supported API versions: 0
+    pub fn with_k_raft_version_feature(mut self, value: KRaftVersionFeature) -> Self {
+        self.k_raft_version_feature = value;
+        self
+    }
+    /// Sets unknown_tagged_fields to the passed value.
+    pub fn with_unknown_tagged_fields(mut self, value: BTreeMap<i32, Bytes>) -> Self {
+        self.unknown_tagged_fields = value;
+        self
+    }
+    /// Inserts an entry into unknown_tagged_fields.
+    pub fn with_unknown_tagged_field(mut self, key: i32, value: Bytes) -> Self {
+        self.unknown_tagged_fields.insert(key, value);
+        self
+    }
+}
+
+impl Encodable for Voter {
+    fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        types::Int32.encode(buf, &self.voter_id)?;
+        types::Uuid.encode(buf, &self.voter_directory_id)?;
+        types::CompactArray(types::Struct { version }).encode(buf, &self.endpoints)?;
+        types::Struct { version }.encode(buf, &self.k_raft_version_feature)?;
+        let num_tagged_fields = self.unknown_tagged_fields.len();
+        if num_tagged_fields > std::u32::MAX as usize {
+            bail!(
+                "Too many tagged fields to encode ({} fields)",
+                num_tagged_fields
+            );
+        }
+        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+
+        write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
+        Ok(())
+    }
+    fn compute_size(&self, version: i16) -> Result<usize> {
+        let mut total_size = 0;
+        total_size += types::Int32.compute_size(&self.voter_id)?;
+        total_size += types::Uuid.compute_size(&self.voter_directory_id)?;
+        total_size +=
+            types::CompactArray(types::Struct { version }).compute_size(&self.endpoints)?;
+        total_size += types::Struct { version }.compute_size(&self.k_raft_version_feature)?;
+        let num_tagged_fields = self.unknown_tagged_fields.len();
+        if num_tagged_fields > std::u32::MAX as usize {
+            bail!(
+                "Too many tagged fields to encode ({} fields)",
+                num_tagged_fields
+            );
+        }
+        total_size += types::UnsignedVarInt.compute_size(num_tagged_fields as u32)?;
+
+        total_size += compute_unknown_tagged_fields_size(&self.unknown_tagged_fields)?;
+        Ok(total_size)
+    }
+}
+
+impl Decodable for Voter {
+    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        let voter_id = types::Int32.decode(buf)?;
+        let voter_directory_id = types::Uuid.decode(buf)?;
+        let endpoints = types::CompactArray(types::Struct { version }).decode(buf)?;
+        let k_raft_version_feature = types::Struct { version }.decode(buf)?;
+        let mut unknown_tagged_fields = BTreeMap::new();
+        let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
+        for _ in 0..num_tagged_fields {
+            let tag: u32 = types::UnsignedVarInt.decode(buf)?;
+            let size: u32 = types::UnsignedVarInt.decode(buf)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
+            unknown_tagged_fields.insert(tag as i32, unknown_value);
+        }
+        Ok(Self {
+            voter_id,
+            voter_directory_id,
+            endpoints,
+            k_raft_version_feature,
+            unknown_tagged_fields,
+        })
+    }
+}
+
+impl Default for Voter {
+    fn default() -> Self {
+        Self {
+            voter_id: (0).into(),
+            voter_directory_id: Uuid::nil(),
+            endpoints: Default::default(),
+            k_raft_version_feature: Default::default(),
+            unknown_tagged_fields: BTreeMap::new(),
+        }
+    }
+}
+
+impl Message for Voter {
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 0 };
+    const DEPRECATED_VERSIONS: Option<VersionRange> = None;
+}
+
+/// Valid versions: 0
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq)]
+pub struct VotersRecord {
+    /// The version of the voters record
+    ///
+    /// Supported API versions: 0
+    pub version: i16,
+
+    ///
+    ///
+    /// Supported API versions: 0
+    pub voters: Vec<Voter>,
+
+    /// Other tagged fields
+    pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
+}
+
+impl VotersRecord {
+    /// Sets `version` to the passed value.
+    ///
+    /// The version of the voters record
+    ///
+    /// Supported API versions: 0
+    pub fn with_version(mut self, value: i16) -> Self {
+        self.version = value;
+        self
+    }
+    /// Sets `voters` to the passed value.
+    ///
+    ///
+    ///
+    /// Supported API versions: 0
+    pub fn with_voters(mut self, value: Vec<Voter>) -> Self {
+        self.voters = value;
+        self
+    }
+    /// Sets unknown_tagged_fields to the passed value.
+    pub fn with_unknown_tagged_fields(mut self, value: BTreeMap<i32, Bytes>) -> Self {
+        self.unknown_tagged_fields = value;
+        self
+    }
+    /// Inserts an entry into unknown_tagged_fields.
+    pub fn with_unknown_tagged_field(mut self, key: i32, value: Bytes) -> Self {
+        self.unknown_tagged_fields.insert(key, value);
+        self
+    }
+}
+
+impl Encodable for VotersRecord {
+    fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        types::Int16.encode(buf, &self.version)?;
+        types::CompactArray(types::Struct { version }).encode(buf, &self.voters)?;
+        let num_tagged_fields = self.unknown_tagged_fields.len();
+        if num_tagged_fields > std::u32::MAX as usize {
+            bail!(
+                "Too many tagged fields to encode ({} fields)",
+                num_tagged_fields
+            );
+        }
+        types::UnsignedVarInt.encode(buf, num_tagged_fields as u32)?;
+
+        write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
+        Ok(())
+    }
+    fn compute_size(&self, version: i16) -> Result<usize> {
+        let mut total_size = 0;
+        total_size += types::Int16.compute_size(&self.version)?;
+        total_size += types::CompactArray(types::Struct { version }).compute_size(&self.voters)?;
+        let num_tagged_fields = self.unknown_tagged_fields.len();
+        if num_tagged_fields > std::u32::MAX as usize {
+            bail!(
+                "Too many tagged fields to encode ({} fields)",
+                num_tagged_fields
+            );
+        }
+        total_size += types::UnsignedVarInt.compute_size(num_tagged_fields as u32)?;
+
+        total_size += compute_unknown_tagged_fields_size(&self.unknown_tagged_fields)?;
+        Ok(total_size)
+    }
+}
+
+impl Decodable for VotersRecord {
+    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        let version = types::Int16.decode(buf)?;
+        let voters = types::CompactArray(types::Struct { version }).decode(buf)?;
+        let mut unknown_tagged_fields = BTreeMap::new();
+        let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
+        for _ in 0..num_tagged_fields {
+            let tag: u32 = types::UnsignedVarInt.decode(buf)?;
+            let size: u32 = types::UnsignedVarInt.decode(buf)?;
+            let unknown_value = buf.try_get_bytes(size as usize)?;
+            unknown_tagged_fields.insert(tag as i32, unknown_value);
+        }
+        Ok(Self {
+            version,
+            voters,
+            unknown_tagged_fields,
+        })
+    }
+}
+
+impl Default for VotersRecord {
+    fn default() -> Self {
+        Self {
+            version: 0,
+            voters: Default::default(),
+            unknown_tagged_fields: BTreeMap::new(),
+        }
+    }
+}
+
+impl Message for VotersRecord {
+    const VERSIONS: VersionRange = VersionRange { min: 0, max: 0 };
+    const DEPRECATED_VERSIONS: Option<VersionRange> = None;
+}


### PR DESCRIPTION
closes https://github.com/tychedelia/kafka-protocol-rs/issues/74

This PR is a breaking change since `#[non-exhaustive]` is not used everywhere.