### PR TITLE
Make Debug impl for newtypes passthrough to inner type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 - Update protocol to kafka 3.8.0
+- The Debug impl for new type wrappers now passes directly to the inner type.
+  The full list of new type wrappers is BrokerId, GroupId, ProducerId, TopicName and TransactionalId.
+  For example GroupId was previously `GroupId("some group")` but is now `"some group"`.
 
 ## v0.12.0
 

--- a/protocol_codegen/src/generate_messages.rs
+++ b/protocol_codegen/src/generate_messages.rs
@@ -479,7 +479,6 @@ fn encode<T: Encodable>(encodable: &T, bytes: &mut bytes::BytesMut, version: i16
 
     for entity_type in entity_types {
         let mut derives = vec![
-            "Debug",
             "Clone",
             "Eq",
             "PartialEq",
@@ -567,6 +566,18 @@ fn encode<T: Encodable>(encodable: &T, bytes: &mut bytes::BytesMut, version: i16
             entity_type.name
         )?;
         writeln!(module_file, "}}")?;
+
+        writeln!(
+            module_file,
+            "impl std::fmt::Debug for {} {{",
+            entity_type.name
+        )?;
+        writeln!(
+            module_file,
+            "    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {{ self.0.fmt(f) }}",
+        )?;
+        writeln!(module_file, "}}")?;
+
         writeln!(
             module_file,
             "impl NewType<{}> for {} {{}}",

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -962,7 +962,6 @@ impl Request for DescribeTopicPartitionsRequest {
 
 /// Valid API keys in the Kafka protocol.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum ApiKey {
     /// API key for request ProduceRequest
     ProduceKey = 0,
@@ -3485,7 +3484,7 @@ impl From<DescribeTopicPartitionsResponse> for ResponseKind {
 }
 
 /// The ID of the leader broker.
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default, Copy)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default, Copy)]
 pub struct BrokerId(pub i32);
 
 impl From<i32> for BrokerId {
@@ -3519,10 +3518,15 @@ impl std::cmp::PartialEq<BrokerId> for i32 {
         self == &other.0
     }
 }
+impl std::fmt::Debug for BrokerId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
 impl NewType<i32> for BrokerId {}
 
 /// The group ID string.
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
 pub struct GroupId(pub StrBytes);
 
 impl From<StrBytes> for GroupId {
@@ -3556,10 +3560,15 @@ impl std::cmp::PartialEq<GroupId> for StrBytes {
         self == &other.0
     }
 }
+impl std::fmt::Debug for GroupId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
 impl NewType<StrBytes> for GroupId {}
 
 /// The first producer ID in this range, inclusive
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default, Copy)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default, Copy)]
 pub struct ProducerId(pub i64);
 
 impl From<i64> for ProducerId {
@@ -3593,10 +3602,15 @@ impl std::cmp::PartialEq<ProducerId> for i64 {
         self == &other.0
     }
 }
+impl std::fmt::Debug for ProducerId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
 impl NewType<i64> for ProducerId {}
 
 /// The topic name.
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
 pub struct TopicName(pub StrBytes);
 
 impl From<StrBytes> for TopicName {
@@ -3630,10 +3644,15 @@ impl std::cmp::PartialEq<TopicName> for StrBytes {
         self == &other.0
     }
 }
+impl std::fmt::Debug for TopicName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
 impl NewType<StrBytes> for TopicName {}
 
 ///
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
 pub struct TransactionalId(pub StrBytes);
 
 impl From<StrBytes> for TransactionalId {
@@ -3665,6 +3684,11 @@ impl std::cmp::PartialEq<StrBytes> for TransactionalId {
 impl std::cmp::PartialEq<TransactionalId> for StrBytes {
     fn eq(&self, other: &TransactionalId) -> bool {
         self == &other.0
+    }
+}
+impl std::fmt::Debug for TransactionalId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
     }
 }
 impl NewType<StrBytes> for TransactionalId {}


### PR DESCRIPTION
kafka-protocol has generated newtypes, which wrap integers and strings to give some extra type safety.
For example:

* BrokerId wraps i32
* GroupId wraps StrBytes

Currently the Debug impl for these types is derived by `#[derive(Debug)]`.
This results in debug output like:

* BrokerId(2)
* GroupId("some group")

This PR changes the debug output to instead directly display the type:

* 2
* "some group"

This should result in more concise logs.
Here are some example usages:

```rust
tracing::info!("Received request for group {group_id:?}");
// before
// Received request for group GroupId("foo")
// after
// Received request for group "foo"
//
// assuming the user specifies that its a group the log is easier to read

tracing::info!("{fetch_request:?}");
// before
//Fetch(FetchRequest { cluster_id: None, replica_id: BrokerId(-1), replica_state: ReplicaState { replica_id: BrokerId(-1), replica_epoch: -1, unknown_tagged_fields: {} }, max_wait_ms: 500, min_bytes: 1, max_bytes: 52428800, isolation_level: 0, session_id: 0, session_epoch: 0, topics: [FetchTopic { topic: TopicName(""), topic_id: 4033c2f1-9daf-4473-85f6-a786bf0dd5da, partitions: [FetchPartition { partition: 0, current_leader_epoch: 0, fetch_offset: 0, last_fetched_epoch: -1, log_start_offset: -1, partition_max_bytes: 1048576, unknown_tagged_fields: {} }], unknown_tagged_fields: {} }], forgotten_topics_data: [], rack_id: "", unknown_tagged_fields: {} })
// after
//Fetch(FetchRequest { cluster_id: None, replica_id: -1, replica_state: ReplicaState { replica_id: -1, replica_epoch: -1, unknown_tagged_fields: {} }, max_wait_ms: 500, min_bytes: 1, max_bytes: 52428800, isolation_level: 0, session_id: 0, session_epoch: 0, topics: [FetchTopic { topic: "", topic_id: 4033c2f1-9daf-4473-85f6-a786bf0dd5da, partitions: [FetchPartition { partition: 0, current_leader_epoch: 0, fetch_offset: 0, last_fetched_epoch: -1, log_start_offset: -1, partition_max_bytes: 1048576, unknown_tagged_fields: {} }], unknown_tagged_fields: {} }], forgotten_topics_data: [], rack_id: "", unknown_tagged_fields: {} })
//
// A downside is that its slightly less clear that `replica_id` refers to a broker and that `topic` refers to the name of the topic
// However I think that in order to make sense of the log you need to be familiar with the protocol or refer to protocol documentation anyway, so I think its worth it for making the log easier to scan.
```

## Alternatives
As an alternative we could implement `Display` to skip the newtype name.
But in the case of a string type Display should not have quotes and Debug should be wrapped in quotes.
So I don't think this is appropriate for logs where we need to clearly show where a name begins and ends.
e.g.
`tracing::log("the group {group} hit an issue")`
could output: `the group did not hit an issue`

For this reason I dont think the string newtypes should implement Display at all, if the user really wants to they can get the inner type and display that.