### PR TITLE
Allow 'None' error type

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -185,7 +185,7 @@ macro_rules! define_errors {
 
 define_errors! { ResponseError,
     (UNKNOWN_SERVER_ERROR,                  -1, false, "The server experienced an unexpected error when processing the request."),
-    // (NONE,                                  0, false, "No error"),
+    (NONE,                                  0, false, "No error"),
     (OFFSET_OUT_OF_RANGE,                   1, false, "The requested offset is not within the range of offsets maintained by the server."),
     (CORRUPT_MESSAGE,                       2, true, "This message has failed its CRC checksum, exceeds the valid size, has a null key for a compacted topic, or is otherwise corrupt."),
     (UNKNOWN_TOPIC_OR_PARTITION,            3, true, "This server does not host this topic-partition."),

--- a/src/error.rs
+++ b/src/error.rs
@@ -137,8 +137,7 @@ macro_rules! define_errors {
                 #[doc = "Returns `None` if the error `code` is `0`."]
                 #[doc = concat!("Otherwise, the `Some(", stringify!($name), ")` is returned.")]
                 pub fn try_from_code(code: i16) -> Option<Self> {
-                    match code {
-                        0 => None,
+                    match code {                        
                         $(
                             $code => Some($name::[<$kind:camel>]),
                         )*


### PR DESCRIPTION
this allows for code paths that are like:

```rs
let error = if auth_succeeded()  { 
 ResponseError::None 
} else  {
  ResponseError::InvalidMsg
};


ResponseBuilder::default().with_error_code(error.code());
```