### PR TITLE
allow easily using multiple versions of ListOffsets api

### DIFF
--- a/src/messages/list_offsets_response.rs
+++ b/src/messages/list_offsets_response.rs
@@ -196,10 +196,6 @@ impl Encodable for ListOffsetsPartitionResponse {
         }
         if version >= 4 {
             total_size += types::Int32.compute_size(&self.leader_epoch)?;
-        } else {
-            if self.leader_epoch != -1 {
-                bail!("failed to encode");
-            }
         }
         if version >= 6 {
             let num_tagged_fields = self.unknown_tagged_fields.len();


### PR DESCRIPTION
this code actually prevents writing user code that works across multiple versions.

for example, if i want to support both new and latest version of ListOffsets api, i would just set the `leader_epoch` field in the respective Builder class and if the api version during encoding is <4, the encoder will simply ignore that field. 

currently due to this `bail`, i have to add `if` checks everywhere in my code to ensure the right fields are set
