### PR TITLE
Replace indexmap with vec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- All "map" types in the protocol that were previously of type `IndexMap<K, V>` are now of type `Vec<V>`, the value of `K` is stored as a field within `V`.
+  - This was done to resolve <https://github.com/tychedelia/kafka-protocol-rs/issues/84> and improve decoding speed.
+  - If you were previously calling `.get()` on the map, the best way to migrate is to refactor your code to avoid the need to lookup by iterating over the items in the response instead.
+  - Alternatively, you could replace `responses.get(name)` with something like `responses.iter().find(|x| x.name == name)` to achieve the same result. But note that this access is now O(N) instead of O(1).
+  - Alternatively, you could use an intermediate hashmap before converting to a Vec to retain the O(1) lookup.
 - Update protocol to kafka 3.8.0
 - The Debug impl for new type wrappers now passes directly to the inner type.
   The full list of new type wrappers is BrokerId, GroupId, ProducerId, TopicName and TransactionalId.
@@ -22,11 +27,11 @@
 - Use `IntoIterator` instead of `Iterator` for `RecordBatchEncoder::encode`
 - Use CRC-32 ISO/HDLC instead of CRC-32 CKSUM.
 - Add `Display` and more `From<T>` implementations for `StrBytes`.
-- Avoid redunand variant names in RequestKind/ResponseKind.
+- Avoid redundant variant names in RequestKind/ResponseKind.
 
 ## v0.10.2
 
-- Implement From<T> for RequestKind and ResponseKind.
+- Implement `From<T>` for RequestKind and ResponseKind.
 
 ## v0.10.1
 
@@ -60,7 +65,7 @@ and other misc improvements.
 
 ## v0.7.0
 
-- Switch to [crc32c](https://crates.io/crates/crc32c) crate, providing hardware accelration for crc operations
+- Switch to [crc32c](https://crates.io/crates/crc32c) crate, providing hardware acceleration for crc operations
 on supported platforms.
 - Formatting fixes.
 - Miscellaneous dependency updates.

--- a/src/messages/add_offsets_to_txn_request.rs
+++ b/src/messages/add_offsets_to_txn_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-4

--- a/src/messages/add_offsets_to_txn_response.rs
+++ b/src/messages/add_offsets_to_txn_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-4

--- a/src/messages/add_partitions_to_txn_response.rs
+++ b/src/messages/add_partitions_to_txn_response.rs
@@ -14,13 +14,18 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-5
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct AddPartitionsToTxnPartitionResult {
+    /// The partition indexes.
+    ///
+    /// Supported API versions: 0-5
+    pub partition_index: i32,
+
     /// The response error code.
     ///
     /// Supported API versions: 0-5
@@ -31,6 +36,15 @@ pub struct AddPartitionsToTxnPartitionResult {
 }
 
 impl AddPartitionsToTxnPartitionResult {
+    /// Sets `partition_index` to the passed value.
+    ///
+    /// The partition indexes.
+    ///
+    /// Supported API versions: 0-5
+    pub fn with_partition_index(mut self, value: i32) -> Self {
+        self.partition_index = value;
+        self
+    }
     /// Sets `partition_error_code` to the passed value.
     ///
     /// The response error code.
@@ -53,10 +67,9 @@ impl AddPartitionsToTxnPartitionResult {
 }
 
 #[cfg(feature = "broker")]
-impl MapEncodable for AddPartitionsToTxnPartitionResult {
-    type Key = i32;
-    fn encode<B: ByteBufMut>(&self, key: &Self::Key, buf: &mut B, version: i16) -> Result<()> {
-        types::Int32.encode(buf, key)?;
+impl Encodable for AddPartitionsToTxnPartitionResult {
+    fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        types::Int32.encode(buf, &self.partition_index)?;
         types::Int16.encode(buf, &self.partition_error_code)?;
         if version >= 3 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -72,9 +85,9 @@ impl MapEncodable for AddPartitionsToTxnPartitionResult {
         }
         Ok(())
     }
-    fn compute_size(&self, key: &Self::Key, version: i16) -> Result<usize> {
+    fn compute_size(&self, version: i16) -> Result<usize> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(key)?;
+        total_size += types::Int32.compute_size(&self.partition_index)?;
         total_size += types::Int16.compute_size(&self.partition_error_code)?;
         if version >= 3 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -93,10 +106,9 @@ impl MapEncodable for AddPartitionsToTxnPartitionResult {
 }
 
 #[cfg(feature = "client")]
-impl MapDecodable for AddPartitionsToTxnPartitionResult {
-    type Key = i32;
-    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<(Self::Key, Self)> {
-        let key_field = types::Int32.decode(buf)?;
+impl Decodable for AddPartitionsToTxnPartitionResult {
+    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        let partition_index = types::Int32.decode(buf)?;
         let partition_error_code = types::Int16.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
         if version >= 3 {
@@ -108,19 +120,18 @@ impl MapDecodable for AddPartitionsToTxnPartitionResult {
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
-        Ok((
-            key_field,
-            Self {
-                partition_error_code,
-                unknown_tagged_fields,
-            },
-        ))
+        Ok(Self {
+            partition_index,
+            partition_error_code,
+            unknown_tagged_fields,
+        })
     }
 }
 
 impl Default for AddPartitionsToTxnPartitionResult {
     fn default() -> Self {
         Self {
+            partition_index: 0,
             partition_error_code: 0,
             unknown_tagged_fields: BTreeMap::new(),
         }
@@ -149,14 +160,12 @@ pub struct AddPartitionsToTxnResponse {
     /// Results categorized by transactional ID.
     ///
     /// Supported API versions: 4-5
-    pub results_by_transaction:
-        indexmap::IndexMap<super::TransactionalId, AddPartitionsToTxnResult>,
+    pub results_by_transaction: Vec<AddPartitionsToTxnResult>,
 
     /// The results for each topic.
     ///
     /// Supported API versions: 0-3
-    pub results_by_topic_v3_and_below:
-        indexmap::IndexMap<super::TopicName, AddPartitionsToTxnTopicResult>,
+    pub results_by_topic_v3_and_below: Vec<AddPartitionsToTxnTopicResult>,
 
     /// Other tagged fields
     pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
@@ -186,10 +195,7 @@ impl AddPartitionsToTxnResponse {
     /// Results categorized by transactional ID.
     ///
     /// Supported API versions: 4-5
-    pub fn with_results_by_transaction(
-        mut self,
-        value: indexmap::IndexMap<super::TransactionalId, AddPartitionsToTxnResult>,
-    ) -> Self {
+    pub fn with_results_by_transaction(mut self, value: Vec<AddPartitionsToTxnResult>) -> Self {
         self.results_by_transaction = value;
         self
     }
@@ -200,7 +206,7 @@ impl AddPartitionsToTxnResponse {
     /// Supported API versions: 0-3
     pub fn with_results_by_topic_v3_and_below(
         mut self,
-        value: indexmap::IndexMap<super::TopicName, AddPartitionsToTxnTopicResult>,
+        value: Vec<AddPartitionsToTxnTopicResult>,
     ) -> Self {
         self.results_by_topic_v3_and_below = value;
         self
@@ -366,25 +372,36 @@ impl Message for AddPartitionsToTxnResponse {
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct AddPartitionsToTxnResult {
+    /// The transactional id corresponding to the transaction.
+    ///
+    /// Supported API versions: 4-5
+    pub transactional_id: super::TransactionalId,
+
     /// The results for each topic.
     ///
     /// Supported API versions: 4-5
-    pub topic_results: indexmap::IndexMap<super::TopicName, AddPartitionsToTxnTopicResult>,
+    pub topic_results: Vec<AddPartitionsToTxnTopicResult>,
 
     /// Other tagged fields
     pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl AddPartitionsToTxnResult {
+    /// Sets `transactional_id` to the passed value.
+    ///
+    /// The transactional id corresponding to the transaction.
+    ///
+    /// Supported API versions: 4-5
+    pub fn with_transactional_id(mut self, value: super::TransactionalId) -> Self {
+        self.transactional_id = value;
+        self
+    }
     /// Sets `topic_results` to the passed value.
     ///
     /// The results for each topic.
     ///
     /// Supported API versions: 4-5
-    pub fn with_topic_results(
-        mut self,
-        value: indexmap::IndexMap<super::TopicName, AddPartitionsToTxnTopicResult>,
-    ) -> Self {
+    pub fn with_topic_results(mut self, value: Vec<AddPartitionsToTxnTopicResult>) -> Self {
         self.topic_results = value;
         self
     }
@@ -401,13 +418,12 @@ impl AddPartitionsToTxnResult {
 }
 
 #[cfg(feature = "broker")]
-impl MapEncodable for AddPartitionsToTxnResult {
-    type Key = super::TransactionalId;
-    fn encode<B: ByteBufMut>(&self, key: &Self::Key, buf: &mut B, version: i16) -> Result<()> {
+impl Encodable for AddPartitionsToTxnResult {
+    fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version >= 4 {
-            types::CompactString.encode(buf, key)?;
+            types::CompactString.encode(buf, &self.transactional_id)?;
         } else {
-            if !key.is_empty() {
+            if !self.transactional_id.is_empty() {
                 bail!("failed to encode");
             }
         }
@@ -432,12 +448,12 @@ impl MapEncodable for AddPartitionsToTxnResult {
         }
         Ok(())
     }
-    fn compute_size(&self, key: &Self::Key, version: i16) -> Result<usize> {
+    fn compute_size(&self, version: i16) -> Result<usize> {
         let mut total_size = 0;
         if version >= 4 {
-            total_size += types::CompactString.compute_size(key)?;
+            total_size += types::CompactString.compute_size(&self.transactional_id)?;
         } else {
-            if !key.is_empty() {
+            if !self.transactional_id.is_empty() {
                 bail!("failed to encode");
             }
         }
@@ -466,10 +482,9 @@ impl MapEncodable for AddPartitionsToTxnResult {
 }
 
 #[cfg(feature = "client")]
-impl MapDecodable for AddPartitionsToTxnResult {
-    type Key = super::TransactionalId;
-    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<(Self::Key, Self)> {
-        let key_field = if version >= 4 {
+impl Decodable for AddPartitionsToTxnResult {
+    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        let transactional_id = if version >= 4 {
             types::CompactString.decode(buf)?
         } else {
             Default::default()
@@ -489,19 +504,18 @@ impl MapDecodable for AddPartitionsToTxnResult {
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
-        Ok((
-            key_field,
-            Self {
-                topic_results,
-                unknown_tagged_fields,
-            },
-        ))
+        Ok(Self {
+            transactional_id,
+            topic_results,
+            unknown_tagged_fields,
+        })
     }
 }
 
 impl Default for AddPartitionsToTxnResult {
     fn default() -> Self {
         Self {
+            transactional_id: Default::default(),
             topic_results: Default::default(),
             unknown_tagged_fields: BTreeMap::new(),
         }
@@ -517,16 +531,30 @@ impl Message for AddPartitionsToTxnResult {
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct AddPartitionsToTxnTopicResult {
+    /// The topic name.
+    ///
+    /// Supported API versions: 0-5
+    pub name: super::TopicName,
+
     /// The results for each partition
     ///
     /// Supported API versions: 0-5
-    pub results_by_partition: indexmap::IndexMap<i32, AddPartitionsToTxnPartitionResult>,
+    pub results_by_partition: Vec<AddPartitionsToTxnPartitionResult>,
 
     /// Other tagged fields
     pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl AddPartitionsToTxnTopicResult {
+    /// Sets `name` to the passed value.
+    ///
+    /// The topic name.
+    ///
+    /// Supported API versions: 0-5
+    pub fn with_name(mut self, value: super::TopicName) -> Self {
+        self.name = value;
+        self
+    }
     /// Sets `results_by_partition` to the passed value.
     ///
     /// The results for each partition
@@ -534,7 +562,7 @@ impl AddPartitionsToTxnTopicResult {
     /// Supported API versions: 0-5
     pub fn with_results_by_partition(
         mut self,
-        value: indexmap::IndexMap<i32, AddPartitionsToTxnPartitionResult>,
+        value: Vec<AddPartitionsToTxnPartitionResult>,
     ) -> Self {
         self.results_by_partition = value;
         self
@@ -552,13 +580,12 @@ impl AddPartitionsToTxnTopicResult {
 }
 
 #[cfg(feature = "broker")]
-impl MapEncodable for AddPartitionsToTxnTopicResult {
-    type Key = super::TopicName;
-    fn encode<B: ByteBufMut>(&self, key: &Self::Key, buf: &mut B, version: i16) -> Result<()> {
+impl Encodable for AddPartitionsToTxnTopicResult {
+    fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version >= 3 {
-            types::CompactString.encode(buf, key)?;
+            types::CompactString.encode(buf, &self.name)?;
         } else {
-            types::String.encode(buf, key)?;
+            types::String.encode(buf, &self.name)?;
         }
         if version >= 3 {
             types::CompactArray(types::Struct { version })
@@ -580,12 +607,12 @@ impl MapEncodable for AddPartitionsToTxnTopicResult {
         }
         Ok(())
     }
-    fn compute_size(&self, key: &Self::Key, version: i16) -> Result<usize> {
+    fn compute_size(&self, version: i16) -> Result<usize> {
         let mut total_size = 0;
         if version >= 3 {
-            total_size += types::CompactString.compute_size(key)?;
+            total_size += types::CompactString.compute_size(&self.name)?;
         } else {
-            total_size += types::String.compute_size(key)?;
+            total_size += types::String.compute_size(&self.name)?;
         }
         if version >= 3 {
             total_size += types::CompactArray(types::Struct { version })
@@ -611,10 +638,9 @@ impl MapEncodable for AddPartitionsToTxnTopicResult {
 }
 
 #[cfg(feature = "client")]
-impl MapDecodable for AddPartitionsToTxnTopicResult {
-    type Key = super::TopicName;
-    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<(Self::Key, Self)> {
-        let key_field = if version >= 3 {
+impl Decodable for AddPartitionsToTxnTopicResult {
+    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        let name = if version >= 3 {
             types::CompactString.decode(buf)?
         } else {
             types::String.decode(buf)?
@@ -634,19 +660,18 @@ impl MapDecodable for AddPartitionsToTxnTopicResult {
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
-        Ok((
-            key_field,
-            Self {
-                results_by_partition,
-                unknown_tagged_fields,
-            },
-        ))
+        Ok(Self {
+            name,
+            results_by_partition,
+            unknown_tagged_fields,
+        })
     }
 }
 
 impl Default for AddPartitionsToTxnTopicResult {
     fn default() -> Self {
         Self {
+            name: Default::default(),
             results_by_partition: Default::default(),
             unknown_tagged_fields: BTreeMap::new(),
         }

--- a/src/messages/allocate_producer_ids_request.rs
+++ b/src/messages/allocate_producer_ids_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0

--- a/src/messages/allocate_producer_ids_response.rs
+++ b/src/messages/allocate_producer_ids_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0

--- a/src/messages/alter_client_quotas_request.rs
+++ b/src/messages/alter_client_quotas_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-1

--- a/src/messages/alter_client_quotas_response.rs
+++ b/src/messages/alter_client_quotas_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-1

--- a/src/messages/alter_configs_response.rs
+++ b/src/messages/alter_configs_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-2

--- a/src/messages/alter_partition_reassignments_request.rs
+++ b/src/messages/alter_partition_reassignments_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0

--- a/src/messages/alter_partition_reassignments_response.rs
+++ b/src/messages/alter_partition_reassignments_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0

--- a/src/messages/alter_partition_request.rs
+++ b/src/messages/alter_partition_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-3

--- a/src/messages/alter_partition_response.rs
+++ b/src/messages/alter_partition_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-3

--- a/src/messages/alter_replica_log_dirs_response.rs
+++ b/src/messages/alter_replica_log_dirs_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-2

--- a/src/messages/alter_user_scram_credentials_request.rs
+++ b/src/messages/alter_user_scram_credentials_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0

--- a/src/messages/alter_user_scram_credentials_response.rs
+++ b/src/messages/alter_user_scram_credentials_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0

--- a/src/messages/api_versions_request.rs
+++ b/src/messages/api_versions_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-3

--- a/src/messages/assign_replicas_to_dirs_request.rs
+++ b/src/messages/assign_replicas_to_dirs_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0

--- a/src/messages/assign_replicas_to_dirs_response.rs
+++ b/src/messages/assign_replicas_to_dirs_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0

--- a/src/messages/begin_quorum_epoch_request.rs
+++ b/src/messages/begin_quorum_epoch_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0

--- a/src/messages/begin_quorum_epoch_response.rs
+++ b/src/messages/begin_quorum_epoch_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0

--- a/src/messages/broker_heartbeat_request.rs
+++ b/src/messages/broker_heartbeat_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-1

--- a/src/messages/broker_heartbeat_response.rs
+++ b/src/messages/broker_heartbeat_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-1

--- a/src/messages/broker_registration_request.rs
+++ b/src/messages/broker_registration_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-3
@@ -39,12 +39,12 @@ pub struct BrokerRegistrationRequest {
     /// The listeners of this broker
     ///
     /// Supported API versions: 0-3
-    pub listeners: indexmap::IndexMap<StrBytes, Listener>,
+    pub listeners: Vec<Listener>,
 
     /// The features on this broker
     ///
     /// Supported API versions: 0-3
-    pub features: indexmap::IndexMap<StrBytes, Feature>,
+    pub features: Vec<Feature>,
 
     /// The rack which this broker is in.
     ///
@@ -103,7 +103,7 @@ impl BrokerRegistrationRequest {
     /// The listeners of this broker
     ///
     /// Supported API versions: 0-3
-    pub fn with_listeners(mut self, value: indexmap::IndexMap<StrBytes, Listener>) -> Self {
+    pub fn with_listeners(mut self, value: Vec<Listener>) -> Self {
         self.listeners = value;
         self
     }
@@ -112,7 +112,7 @@ impl BrokerRegistrationRequest {
     /// The features on this broker
     ///
     /// Supported API versions: 0-3
-    pub fn with_features(mut self, value: indexmap::IndexMap<StrBytes, Feature>) -> Self {
+    pub fn with_features(mut self, value: Vec<Feature>) -> Self {
         self.features = value;
         self
     }
@@ -308,6 +308,11 @@ impl Message for BrokerRegistrationRequest {
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct Feature {
+    /// The feature name.
+    ///
+    /// Supported API versions: 0-3
+    pub name: StrBytes,
+
     /// The minimum supported feature level.
     ///
     /// Supported API versions: 0-3
@@ -323,6 +328,15 @@ pub struct Feature {
 }
 
 impl Feature {
+    /// Sets `name` to the passed value.
+    ///
+    /// The feature name.
+    ///
+    /// Supported API versions: 0-3
+    pub fn with_name(mut self, value: StrBytes) -> Self {
+        self.name = value;
+        self
+    }
     /// Sets `min_supported_version` to the passed value.
     ///
     /// The minimum supported feature level.
@@ -354,10 +368,9 @@ impl Feature {
 }
 
 #[cfg(feature = "client")]
-impl MapEncodable for Feature {
-    type Key = StrBytes;
-    fn encode<B: ByteBufMut>(&self, key: &Self::Key, buf: &mut B, version: i16) -> Result<()> {
-        types::CompactString.encode(buf, key)?;
+impl Encodable for Feature {
+    fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        types::CompactString.encode(buf, &self.name)?;
         types::Int16.encode(buf, &self.min_supported_version)?;
         types::Int16.encode(buf, &self.max_supported_version)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -372,9 +385,9 @@ impl MapEncodable for Feature {
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
     }
-    fn compute_size(&self, key: &Self::Key, version: i16) -> Result<usize> {
+    fn compute_size(&self, version: i16) -> Result<usize> {
         let mut total_size = 0;
-        total_size += types::CompactString.compute_size(key)?;
+        total_size += types::CompactString.compute_size(&self.name)?;
         total_size += types::Int16.compute_size(&self.min_supported_version)?;
         total_size += types::Int16.compute_size(&self.max_supported_version)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -392,10 +405,9 @@ impl MapEncodable for Feature {
 }
 
 #[cfg(feature = "broker")]
-impl MapDecodable for Feature {
-    type Key = StrBytes;
-    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<(Self::Key, Self)> {
-        let key_field = types::CompactString.decode(buf)?;
+impl Decodable for Feature {
+    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        let name = types::CompactString.decode(buf)?;
         let min_supported_version = types::Int16.decode(buf)?;
         let max_supported_version = types::Int16.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
@@ -406,20 +418,19 @@ impl MapDecodable for Feature {
             let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
-        Ok((
-            key_field,
-            Self {
-                min_supported_version,
-                max_supported_version,
-                unknown_tagged_fields,
-            },
-        ))
+        Ok(Self {
+            name,
+            min_supported_version,
+            max_supported_version,
+            unknown_tagged_fields,
+        })
     }
 }
 
 impl Default for Feature {
     fn default() -> Self {
         Self {
+            name: Default::default(),
             min_supported_version: 0,
             max_supported_version: 0,
             unknown_tagged_fields: BTreeMap::new(),
@@ -436,6 +447,11 @@ impl Message for Feature {
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct Listener {
+    /// The name of the endpoint.
+    ///
+    /// Supported API versions: 0-3
+    pub name: StrBytes,
+
     /// The hostname.
     ///
     /// Supported API versions: 0-3
@@ -456,6 +472,15 @@ pub struct Listener {
 }
 
 impl Listener {
+    /// Sets `name` to the passed value.
+    ///
+    /// The name of the endpoint.
+    ///
+    /// Supported API versions: 0-3
+    pub fn with_name(mut self, value: StrBytes) -> Self {
+        self.name = value;
+        self
+    }
     /// Sets `host` to the passed value.
     ///
     /// The hostname.
@@ -496,10 +521,9 @@ impl Listener {
 }
 
 #[cfg(feature = "client")]
-impl MapEncodable for Listener {
-    type Key = StrBytes;
-    fn encode<B: ByteBufMut>(&self, key: &Self::Key, buf: &mut B, version: i16) -> Result<()> {
-        types::CompactString.encode(buf, key)?;
+impl Encodable for Listener {
+    fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        types::CompactString.encode(buf, &self.name)?;
         types::CompactString.encode(buf, &self.host)?;
         types::UInt16.encode(buf, &self.port)?;
         types::Int16.encode(buf, &self.security_protocol)?;
@@ -515,9 +539,9 @@ impl MapEncodable for Listener {
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
     }
-    fn compute_size(&self, key: &Self::Key, version: i16) -> Result<usize> {
+    fn compute_size(&self, version: i16) -> Result<usize> {
         let mut total_size = 0;
-        total_size += types::CompactString.compute_size(key)?;
+        total_size += types::CompactString.compute_size(&self.name)?;
         total_size += types::CompactString.compute_size(&self.host)?;
         total_size += types::UInt16.compute_size(&self.port)?;
         total_size += types::Int16.compute_size(&self.security_protocol)?;
@@ -536,10 +560,9 @@ impl MapEncodable for Listener {
 }
 
 #[cfg(feature = "broker")]
-impl MapDecodable for Listener {
-    type Key = StrBytes;
-    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<(Self::Key, Self)> {
-        let key_field = types::CompactString.decode(buf)?;
+impl Decodable for Listener {
+    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        let name = types::CompactString.decode(buf)?;
         let host = types::CompactString.decode(buf)?;
         let port = types::UInt16.decode(buf)?;
         let security_protocol = types::Int16.decode(buf)?;
@@ -551,21 +574,20 @@ impl MapDecodable for Listener {
             let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
-        Ok((
-            key_field,
-            Self {
-                host,
-                port,
-                security_protocol,
-                unknown_tagged_fields,
-            },
-        ))
+        Ok(Self {
+            name,
+            host,
+            port,
+            security_protocol,
+            unknown_tagged_fields,
+        })
     }
 }
 
 impl Default for Listener {
     fn default() -> Self {
         Self {
+            name: Default::default(),
             host: Default::default(),
             port: 0,
             security_protocol: 0,

--- a/src/messages/broker_registration_response.rs
+++ b/src/messages/broker_registration_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-3

--- a/src/messages/consumer_group_describe_request.rs
+++ b/src/messages/consumer_group_describe_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0

--- a/src/messages/consumer_group_describe_response.rs
+++ b/src/messages/consumer_group_describe_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0

--- a/src/messages/consumer_group_heartbeat_request.rs
+++ b/src/messages/consumer_group_heartbeat_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0

--- a/src/messages/consumer_group_heartbeat_response.rs
+++ b/src/messages/consumer_group_heartbeat_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0

--- a/src/messages/controlled_shutdown_request.rs
+++ b/src/messages/controlled_shutdown_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-3

--- a/src/messages/controlled_shutdown_response.rs
+++ b/src/messages/controlled_shutdown_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-3

--- a/src/messages/controller_registration_request.rs
+++ b/src/messages/controller_registration_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0
@@ -39,12 +39,12 @@ pub struct ControllerRegistrationRequest {
     /// The listeners of this controller
     ///
     /// Supported API versions: 0
-    pub listeners: indexmap::IndexMap<StrBytes, Listener>,
+    pub listeners: Vec<Listener>,
 
     /// The features on this controller
     ///
     /// Supported API versions: 0
-    pub features: indexmap::IndexMap<StrBytes, Feature>,
+    pub features: Vec<Feature>,
 
     /// Other tagged fields
     pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
@@ -83,7 +83,7 @@ impl ControllerRegistrationRequest {
     /// The listeners of this controller
     ///
     /// Supported API versions: 0
-    pub fn with_listeners(mut self, value: indexmap::IndexMap<StrBytes, Listener>) -> Self {
+    pub fn with_listeners(mut self, value: Vec<Listener>) -> Self {
         self.listeners = value;
         self
     }
@@ -92,7 +92,7 @@ impl ControllerRegistrationRequest {
     /// The features on this controller
     ///
     /// Supported API versions: 0
-    pub fn with_features(mut self, value: indexmap::IndexMap<StrBytes, Feature>) -> Self {
+    pub fn with_features(mut self, value: Vec<Feature>) -> Self {
         self.features = value;
         self
     }
@@ -200,6 +200,11 @@ impl Message for ControllerRegistrationRequest {
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct Feature {
+    /// The feature name.
+    ///
+    /// Supported API versions: 0
+    pub name: StrBytes,
+
     /// The minimum supported feature level.
     ///
     /// Supported API versions: 0
@@ -215,6 +220,15 @@ pub struct Feature {
 }
 
 impl Feature {
+    /// Sets `name` to the passed value.
+    ///
+    /// The feature name.
+    ///
+    /// Supported API versions: 0
+    pub fn with_name(mut self, value: StrBytes) -> Self {
+        self.name = value;
+        self
+    }
     /// Sets `min_supported_version` to the passed value.
     ///
     /// The minimum supported feature level.
@@ -246,10 +260,9 @@ impl Feature {
 }
 
 #[cfg(feature = "client")]
-impl MapEncodable for Feature {
-    type Key = StrBytes;
-    fn encode<B: ByteBufMut>(&self, key: &Self::Key, buf: &mut B, version: i16) -> Result<()> {
-        types::CompactString.encode(buf, key)?;
+impl Encodable for Feature {
+    fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        types::CompactString.encode(buf, &self.name)?;
         types::Int16.encode(buf, &self.min_supported_version)?;
         types::Int16.encode(buf, &self.max_supported_version)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -264,9 +277,9 @@ impl MapEncodable for Feature {
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
     }
-    fn compute_size(&self, key: &Self::Key, version: i16) -> Result<usize> {
+    fn compute_size(&self, version: i16) -> Result<usize> {
         let mut total_size = 0;
-        total_size += types::CompactString.compute_size(key)?;
+        total_size += types::CompactString.compute_size(&self.name)?;
         total_size += types::Int16.compute_size(&self.min_supported_version)?;
         total_size += types::Int16.compute_size(&self.max_supported_version)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -284,10 +297,9 @@ impl MapEncodable for Feature {
 }
 
 #[cfg(feature = "broker")]
-impl MapDecodable for Feature {
-    type Key = StrBytes;
-    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<(Self::Key, Self)> {
-        let key_field = types::CompactString.decode(buf)?;
+impl Decodable for Feature {
+    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        let name = types::CompactString.decode(buf)?;
         let min_supported_version = types::Int16.decode(buf)?;
         let max_supported_version = types::Int16.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
@@ -298,20 +310,19 @@ impl MapDecodable for Feature {
             let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
-        Ok((
-            key_field,
-            Self {
-                min_supported_version,
-                max_supported_version,
-                unknown_tagged_fields,
-            },
-        ))
+        Ok(Self {
+            name,
+            min_supported_version,
+            max_supported_version,
+            unknown_tagged_fields,
+        })
     }
 }
 
 impl Default for Feature {
     fn default() -> Self {
         Self {
+            name: Default::default(),
             min_supported_version: 0,
             max_supported_version: 0,
             unknown_tagged_fields: BTreeMap::new(),
@@ -328,6 +339,11 @@ impl Message for Feature {
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct Listener {
+    /// The name of the endpoint.
+    ///
+    /// Supported API versions: 0
+    pub name: StrBytes,
+
     /// The hostname.
     ///
     /// Supported API versions: 0
@@ -348,6 +364,15 @@ pub struct Listener {
 }
 
 impl Listener {
+    /// Sets `name` to the passed value.
+    ///
+    /// The name of the endpoint.
+    ///
+    /// Supported API versions: 0
+    pub fn with_name(mut self, value: StrBytes) -> Self {
+        self.name = value;
+        self
+    }
     /// Sets `host` to the passed value.
     ///
     /// The hostname.
@@ -388,10 +413,9 @@ impl Listener {
 }
 
 #[cfg(feature = "client")]
-impl MapEncodable for Listener {
-    type Key = StrBytes;
-    fn encode<B: ByteBufMut>(&self, key: &Self::Key, buf: &mut B, version: i16) -> Result<()> {
-        types::CompactString.encode(buf, key)?;
+impl Encodable for Listener {
+    fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        types::CompactString.encode(buf, &self.name)?;
         types::CompactString.encode(buf, &self.host)?;
         types::UInt16.encode(buf, &self.port)?;
         types::Int16.encode(buf, &self.security_protocol)?;
@@ -407,9 +431,9 @@ impl MapEncodable for Listener {
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
     }
-    fn compute_size(&self, key: &Self::Key, version: i16) -> Result<usize> {
+    fn compute_size(&self, version: i16) -> Result<usize> {
         let mut total_size = 0;
-        total_size += types::CompactString.compute_size(key)?;
+        total_size += types::CompactString.compute_size(&self.name)?;
         total_size += types::CompactString.compute_size(&self.host)?;
         total_size += types::UInt16.compute_size(&self.port)?;
         total_size += types::Int16.compute_size(&self.security_protocol)?;
@@ -428,10 +452,9 @@ impl MapEncodable for Listener {
 }
 
 #[cfg(feature = "broker")]
-impl MapDecodable for Listener {
-    type Key = StrBytes;
-    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<(Self::Key, Self)> {
-        let key_field = types::CompactString.decode(buf)?;
+impl Decodable for Listener {
+    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        let name = types::CompactString.decode(buf)?;
         let host = types::CompactString.decode(buf)?;
         let port = types::UInt16.decode(buf)?;
         let security_protocol = types::Int16.decode(buf)?;
@@ -443,21 +466,20 @@ impl MapDecodable for Listener {
             let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
-        Ok((
-            key_field,
-            Self {
-                host,
-                port,
-                security_protocol,
-                unknown_tagged_fields,
-            },
-        ))
+        Ok(Self {
+            name,
+            host,
+            port,
+            security_protocol,
+            unknown_tagged_fields,
+        })
     }
 }
 
 impl Default for Listener {
     fn default() -> Self {
         Self {
+            name: Default::default(),
             host: Default::default(),
             port: 0,
             security_protocol: 0,

--- a/src/messages/controller_registration_response.rs
+++ b/src/messages/controller_registration_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0

--- a/src/messages/create_acls_request.rs
+++ b/src/messages/create_acls_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-3

--- a/src/messages/create_acls_response.rs
+++ b/src/messages/create_acls_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-3

--- a/src/messages/create_delegation_token_request.rs
+++ b/src/messages/create_delegation_token_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-3

--- a/src/messages/create_delegation_token_response.rs
+++ b/src/messages/create_delegation_token_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-3

--- a/src/messages/create_partitions_response.rs
+++ b/src/messages/create_partitions_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-3

--- a/src/messages/create_topics_response.rs
+++ b/src/messages/create_topics_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-7
@@ -286,6 +286,11 @@ impl Message for CreatableTopicConfigs {
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct CreatableTopicResult {
+    /// The topic name.
+    ///
+    /// Supported API versions: 0-7
+    pub name: super::TopicName,
+
     /// The unique topic ID
     ///
     /// Supported API versions: 7
@@ -326,6 +331,15 @@ pub struct CreatableTopicResult {
 }
 
 impl CreatableTopicResult {
+    /// Sets `name` to the passed value.
+    ///
+    /// The topic name.
+    ///
+    /// Supported API versions: 0-7
+    pub fn with_name(mut self, value: super::TopicName) -> Self {
+        self.name = value;
+        self
+    }
     /// Sets `topic_id` to the passed value.
     ///
     /// The unique topic ID
@@ -402,13 +416,12 @@ impl CreatableTopicResult {
 }
 
 #[cfg(feature = "broker")]
-impl MapEncodable for CreatableTopicResult {
-    type Key = super::TopicName;
-    fn encode<B: ByteBufMut>(&self, key: &Self::Key, buf: &mut B, version: i16) -> Result<()> {
+impl Encodable for CreatableTopicResult {
+    fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version >= 5 {
-            types::CompactString.encode(buf, key)?;
+            types::CompactString.encode(buf, &self.name)?;
         } else {
-            types::String.encode(buf, key)?;
+            types::String.encode(buf, &self.name)?;
         }
         if version >= 7 {
             types::Uuid.encode(buf, &self.topic_id)?;
@@ -459,12 +472,12 @@ impl MapEncodable for CreatableTopicResult {
         }
         Ok(())
     }
-    fn compute_size(&self, key: &Self::Key, version: i16) -> Result<usize> {
+    fn compute_size(&self, version: i16) -> Result<usize> {
         let mut total_size = 0;
         if version >= 5 {
-            total_size += types::CompactString.compute_size(key)?;
+            total_size += types::CompactString.compute_size(&self.name)?;
         } else {
-            total_size += types::String.compute_size(key)?;
+            total_size += types::String.compute_size(&self.name)?;
         }
         if version >= 7 {
             total_size += types::Uuid.compute_size(&self.topic_id)?;
@@ -519,10 +532,9 @@ impl MapEncodable for CreatableTopicResult {
 }
 
 #[cfg(feature = "client")]
-impl MapDecodable for CreatableTopicResult {
-    type Key = super::TopicName;
-    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<(Self::Key, Self)> {
-        let key_field = if version >= 5 {
+impl Decodable for CreatableTopicResult {
+    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        let name = if version >= 5 {
             types::CompactString.decode(buf)?
         } else {
             types::String.decode(buf)?
@@ -575,25 +587,24 @@ impl MapDecodable for CreatableTopicResult {
                 }
             }
         }
-        Ok((
-            key_field,
-            Self {
-                topic_id,
-                error_code,
-                error_message,
-                topic_config_error_code,
-                num_partitions,
-                replication_factor,
-                configs,
-                unknown_tagged_fields,
-            },
-        ))
+        Ok(Self {
+            name,
+            topic_id,
+            error_code,
+            error_message,
+            topic_config_error_code,
+            num_partitions,
+            replication_factor,
+            configs,
+            unknown_tagged_fields,
+        })
     }
 }
 
 impl Default for CreatableTopicResult {
     fn default() -> Self {
         Self {
+            name: Default::default(),
             topic_id: Uuid::nil(),
             error_code: 0,
             error_message: Some(Default::default()),
@@ -623,7 +634,7 @@ pub struct CreateTopicsResponse {
     /// Results for each topic we tried to create.
     ///
     /// Supported API versions: 0-7
-    pub topics: indexmap::IndexMap<super::TopicName, CreatableTopicResult>,
+    pub topics: Vec<CreatableTopicResult>,
 
     /// Other tagged fields
     pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
@@ -644,10 +655,7 @@ impl CreateTopicsResponse {
     /// Results for each topic we tried to create.
     ///
     /// Supported API versions: 0-7
-    pub fn with_topics(
-        mut self,
-        value: indexmap::IndexMap<super::TopicName, CreatableTopicResult>,
-    ) -> Self {
+    pub fn with_topics(mut self, value: Vec<CreatableTopicResult>) -> Self {
         self.topics = value;
         self
     }

--- a/src/messages/default_principal_data.rs
+++ b/src/messages/default_principal_data.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0

--- a/src/messages/delete_acls_request.rs
+++ b/src/messages/delete_acls_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-3

--- a/src/messages/delete_acls_response.rs
+++ b/src/messages/delete_acls_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-3

--- a/src/messages/delete_groups_request.rs
+++ b/src/messages/delete_groups_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-2

--- a/src/messages/delete_records_request.rs
+++ b/src/messages/delete_records_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-2

--- a/src/messages/delete_records_response.rs
+++ b/src/messages/delete_records_response.rs
@@ -14,13 +14,18 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-2
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct DeleteRecordsPartitionResult {
+    /// The partition index.
+    ///
+    /// Supported API versions: 0-2
+    pub partition_index: i32,
+
     /// The partition low water mark.
     ///
     /// Supported API versions: 0-2
@@ -36,6 +41,15 @@ pub struct DeleteRecordsPartitionResult {
 }
 
 impl DeleteRecordsPartitionResult {
+    /// Sets `partition_index` to the passed value.
+    ///
+    /// The partition index.
+    ///
+    /// Supported API versions: 0-2
+    pub fn with_partition_index(mut self, value: i32) -> Self {
+        self.partition_index = value;
+        self
+    }
     /// Sets `low_watermark` to the passed value.
     ///
     /// The partition low water mark.
@@ -67,10 +81,9 @@ impl DeleteRecordsPartitionResult {
 }
 
 #[cfg(feature = "broker")]
-impl MapEncodable for DeleteRecordsPartitionResult {
-    type Key = i32;
-    fn encode<B: ByteBufMut>(&self, key: &Self::Key, buf: &mut B, version: i16) -> Result<()> {
-        types::Int32.encode(buf, key)?;
+impl Encodable for DeleteRecordsPartitionResult {
+    fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        types::Int32.encode(buf, &self.partition_index)?;
         types::Int64.encode(buf, &self.low_watermark)?;
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 2 {
@@ -87,9 +100,9 @@ impl MapEncodable for DeleteRecordsPartitionResult {
         }
         Ok(())
     }
-    fn compute_size(&self, key: &Self::Key, version: i16) -> Result<usize> {
+    fn compute_size(&self, version: i16) -> Result<usize> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(key)?;
+        total_size += types::Int32.compute_size(&self.partition_index)?;
         total_size += types::Int64.compute_size(&self.low_watermark)?;
         total_size += types::Int16.compute_size(&self.error_code)?;
         if version >= 2 {
@@ -109,10 +122,9 @@ impl MapEncodable for DeleteRecordsPartitionResult {
 }
 
 #[cfg(feature = "client")]
-impl MapDecodable for DeleteRecordsPartitionResult {
-    type Key = i32;
-    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<(Self::Key, Self)> {
-        let key_field = types::Int32.decode(buf)?;
+impl Decodable for DeleteRecordsPartitionResult {
+    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        let partition_index = types::Int32.decode(buf)?;
         let low_watermark = types::Int64.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
@@ -125,20 +137,19 @@ impl MapDecodable for DeleteRecordsPartitionResult {
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
-        Ok((
-            key_field,
-            Self {
-                low_watermark,
-                error_code,
-                unknown_tagged_fields,
-            },
-        ))
+        Ok(Self {
+            partition_index,
+            low_watermark,
+            error_code,
+            unknown_tagged_fields,
+        })
     }
 }
 
 impl Default for DeleteRecordsPartitionResult {
     fn default() -> Self {
         Self {
+            partition_index: 0,
             low_watermark: 0,
             error_code: 0,
             unknown_tagged_fields: BTreeMap::new(),
@@ -163,7 +174,7 @@ pub struct DeleteRecordsResponse {
     /// Each topic that we wanted to delete records from.
     ///
     /// Supported API versions: 0-2
-    pub topics: indexmap::IndexMap<super::TopicName, DeleteRecordsTopicResult>,
+    pub topics: Vec<DeleteRecordsTopicResult>,
 
     /// Other tagged fields
     pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
@@ -184,10 +195,7 @@ impl DeleteRecordsResponse {
     /// Each topic that we wanted to delete records from.
     ///
     /// Supported API versions: 0-2
-    pub fn with_topics(
-        mut self,
-        value: indexmap::IndexMap<super::TopicName, DeleteRecordsTopicResult>,
-    ) -> Self {
+    pub fn with_topics(mut self, value: Vec<DeleteRecordsTopicResult>) -> Self {
         self.topics = value;
         self
     }
@@ -297,25 +305,36 @@ impl Message for DeleteRecordsResponse {
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct DeleteRecordsTopicResult {
+    /// The topic name.
+    ///
+    /// Supported API versions: 0-2
+    pub name: super::TopicName,
+
     /// Each partition that we wanted to delete records from.
     ///
     /// Supported API versions: 0-2
-    pub partitions: indexmap::IndexMap<i32, DeleteRecordsPartitionResult>,
+    pub partitions: Vec<DeleteRecordsPartitionResult>,
 
     /// Other tagged fields
     pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
 
 impl DeleteRecordsTopicResult {
+    /// Sets `name` to the passed value.
+    ///
+    /// The topic name.
+    ///
+    /// Supported API versions: 0-2
+    pub fn with_name(mut self, value: super::TopicName) -> Self {
+        self.name = value;
+        self
+    }
     /// Sets `partitions` to the passed value.
     ///
     /// Each partition that we wanted to delete records from.
     ///
     /// Supported API versions: 0-2
-    pub fn with_partitions(
-        mut self,
-        value: indexmap::IndexMap<i32, DeleteRecordsPartitionResult>,
-    ) -> Self {
+    pub fn with_partitions(mut self, value: Vec<DeleteRecordsPartitionResult>) -> Self {
         self.partitions = value;
         self
     }
@@ -332,13 +351,12 @@ impl DeleteRecordsTopicResult {
 }
 
 #[cfg(feature = "broker")]
-impl MapEncodable for DeleteRecordsTopicResult {
-    type Key = super::TopicName;
-    fn encode<B: ByteBufMut>(&self, key: &Self::Key, buf: &mut B, version: i16) -> Result<()> {
+impl Encodable for DeleteRecordsTopicResult {
+    fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version >= 2 {
-            types::CompactString.encode(buf, key)?;
+            types::CompactString.encode(buf, &self.name)?;
         } else {
-            types::String.encode(buf, key)?;
+            types::String.encode(buf, &self.name)?;
         }
         if version >= 2 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.partitions)?;
@@ -359,12 +377,12 @@ impl MapEncodable for DeleteRecordsTopicResult {
         }
         Ok(())
     }
-    fn compute_size(&self, key: &Self::Key, version: i16) -> Result<usize> {
+    fn compute_size(&self, version: i16) -> Result<usize> {
         let mut total_size = 0;
         if version >= 2 {
-            total_size += types::CompactString.compute_size(key)?;
+            total_size += types::CompactString.compute_size(&self.name)?;
         } else {
-            total_size += types::String.compute_size(key)?;
+            total_size += types::String.compute_size(&self.name)?;
         }
         if version >= 2 {
             total_size +=
@@ -389,10 +407,9 @@ impl MapEncodable for DeleteRecordsTopicResult {
 }
 
 #[cfg(feature = "client")]
-impl MapDecodable for DeleteRecordsTopicResult {
-    type Key = super::TopicName;
-    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<(Self::Key, Self)> {
-        let key_field = if version >= 2 {
+impl Decodable for DeleteRecordsTopicResult {
+    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        let name = if version >= 2 {
             types::CompactString.decode(buf)?
         } else {
             types::String.decode(buf)?
@@ -412,19 +429,18 @@ impl MapDecodable for DeleteRecordsTopicResult {
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
-        Ok((
-            key_field,
-            Self {
-                partitions,
-                unknown_tagged_fields,
-            },
-        ))
+        Ok(Self {
+            name,
+            partitions,
+            unknown_tagged_fields,
+        })
     }
 }
 
 impl Default for DeleteRecordsTopicResult {
     fn default() -> Self {
         Self {
+            name: Default::default(),
             partitions: Default::default(),
             unknown_tagged_fields: BTreeMap::new(),
         }

--- a/src/messages/delete_topics_request.rs
+++ b/src/messages/delete_topics_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-6

--- a/src/messages/describe_acls_request.rs
+++ b/src/messages/describe_acls_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-3

--- a/src/messages/describe_acls_response.rs
+++ b/src/messages/describe_acls_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-3

--- a/src/messages/describe_client_quotas_request.rs
+++ b/src/messages/describe_client_quotas_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-1

--- a/src/messages/describe_client_quotas_response.rs
+++ b/src/messages/describe_client_quotas_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-1

--- a/src/messages/describe_cluster_request.rs
+++ b/src/messages/describe_cluster_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-1

--- a/src/messages/describe_cluster_response.rs
+++ b/src/messages/describe_cluster_response.rs
@@ -14,13 +14,18 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-1
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct DescribeClusterBroker {
+    /// The broker ID.
+    ///
+    /// Supported API versions: 0-1
+    pub broker_id: super::BrokerId,
+
     /// The broker hostname.
     ///
     /// Supported API versions: 0-1
@@ -41,6 +46,15 @@ pub struct DescribeClusterBroker {
 }
 
 impl DescribeClusterBroker {
+    /// Sets `broker_id` to the passed value.
+    ///
+    /// The broker ID.
+    ///
+    /// Supported API versions: 0-1
+    pub fn with_broker_id(mut self, value: super::BrokerId) -> Self {
+        self.broker_id = value;
+        self
+    }
     /// Sets `host` to the passed value.
     ///
     /// The broker hostname.
@@ -81,10 +95,9 @@ impl DescribeClusterBroker {
 }
 
 #[cfg(feature = "broker")]
-impl MapEncodable for DescribeClusterBroker {
-    type Key = super::BrokerId;
-    fn encode<B: ByteBufMut>(&self, key: &Self::Key, buf: &mut B, version: i16) -> Result<()> {
-        types::Int32.encode(buf, key)?;
+impl Encodable for DescribeClusterBroker {
+    fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        types::Int32.encode(buf, &self.broker_id)?;
         types::CompactString.encode(buf, &self.host)?;
         types::Int32.encode(buf, &self.port)?;
         types::CompactString.encode(buf, &self.rack)?;
@@ -100,9 +113,9 @@ impl MapEncodable for DescribeClusterBroker {
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
     }
-    fn compute_size(&self, key: &Self::Key, version: i16) -> Result<usize> {
+    fn compute_size(&self, version: i16) -> Result<usize> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(key)?;
+        total_size += types::Int32.compute_size(&self.broker_id)?;
         total_size += types::CompactString.compute_size(&self.host)?;
         total_size += types::Int32.compute_size(&self.port)?;
         total_size += types::CompactString.compute_size(&self.rack)?;
@@ -121,10 +134,9 @@ impl MapEncodable for DescribeClusterBroker {
 }
 
 #[cfg(feature = "client")]
-impl MapDecodable for DescribeClusterBroker {
-    type Key = super::BrokerId;
-    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<(Self::Key, Self)> {
-        let key_field = types::Int32.decode(buf)?;
+impl Decodable for DescribeClusterBroker {
+    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        let broker_id = types::Int32.decode(buf)?;
         let host = types::CompactString.decode(buf)?;
         let port = types::Int32.decode(buf)?;
         let rack = types::CompactString.decode(buf)?;
@@ -136,21 +148,20 @@ impl MapDecodable for DescribeClusterBroker {
             let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
-        Ok((
-            key_field,
-            Self {
-                host,
-                port,
-                rack,
-                unknown_tagged_fields,
-            },
-        ))
+        Ok(Self {
+            broker_id,
+            host,
+            port,
+            rack,
+            unknown_tagged_fields,
+        })
     }
 }
 
 impl Default for DescribeClusterBroker {
     fn default() -> Self {
         Self {
+            broker_id: (0).into(),
             host: Default::default(),
             port: 0,
             rack: None,
@@ -201,7 +212,7 @@ pub struct DescribeClusterResponse {
     /// Each broker in the response.
     ///
     /// Supported API versions: 0-1
-    pub brokers: indexmap::IndexMap<super::BrokerId, DescribeClusterBroker>,
+    pub brokers: Vec<DescribeClusterBroker>,
 
     /// 32-bit bitfield to represent authorized operations for this cluster.
     ///
@@ -272,10 +283,7 @@ impl DescribeClusterResponse {
     /// Each broker in the response.
     ///
     /// Supported API versions: 0-1
-    pub fn with_brokers(
-        mut self,
-        value: indexmap::IndexMap<super::BrokerId, DescribeClusterBroker>,
-    ) -> Self {
+    pub fn with_brokers(mut self, value: Vec<DescribeClusterBroker>) -> Self {
         self.brokers = value;
         self
     }

--- a/src/messages/describe_configs_request.rs
+++ b/src/messages/describe_configs_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-4

--- a/src/messages/describe_configs_response.rs
+++ b/src/messages/describe_configs_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-4

--- a/src/messages/describe_delegation_token_request.rs
+++ b/src/messages/describe_delegation_token_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-3

--- a/src/messages/describe_delegation_token_response.rs
+++ b/src/messages/describe_delegation_token_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-3

--- a/src/messages/describe_groups_request.rs
+++ b/src/messages/describe_groups_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-5

--- a/src/messages/describe_groups_response.rs
+++ b/src/messages/describe_groups_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-5

--- a/src/messages/describe_log_dirs_response.rs
+++ b/src/messages/describe_log_dirs_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-4

--- a/src/messages/describe_producers_request.rs
+++ b/src/messages/describe_producers_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0

--- a/src/messages/describe_producers_response.rs
+++ b/src/messages/describe_producers_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0

--- a/src/messages/describe_quorum_request.rs
+++ b/src/messages/describe_quorum_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-1

--- a/src/messages/describe_quorum_response.rs
+++ b/src/messages/describe_quorum_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-1

--- a/src/messages/describe_topic_partitions_request.rs
+++ b/src/messages/describe_topic_partitions_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0

--- a/src/messages/describe_transactions_request.rs
+++ b/src/messages/describe_transactions_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0

--- a/src/messages/describe_user_scram_credentials_request.rs
+++ b/src/messages/describe_user_scram_credentials_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0

--- a/src/messages/describe_user_scram_credentials_response.rs
+++ b/src/messages/describe_user_scram_credentials_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0

--- a/src/messages/elect_leaders_response.rs
+++ b/src/messages/elect_leaders_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-2

--- a/src/messages/end_quorum_epoch_request.rs
+++ b/src/messages/end_quorum_epoch_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0

--- a/src/messages/end_quorum_epoch_response.rs
+++ b/src/messages/end_quorum_epoch_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0

--- a/src/messages/end_txn_request.rs
+++ b/src/messages/end_txn_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-4

--- a/src/messages/end_txn_response.rs
+++ b/src/messages/end_txn_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-4

--- a/src/messages/envelope_request.rs
+++ b/src/messages/envelope_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0

--- a/src/messages/envelope_response.rs
+++ b/src/messages/envelope_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0

--- a/src/messages/expire_delegation_token_request.rs
+++ b/src/messages/expire_delegation_token_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-2

--- a/src/messages/expire_delegation_token_response.rs
+++ b/src/messages/expire_delegation_token_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-2

--- a/src/messages/fetch_request.rs
+++ b/src/messages/fetch_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-16

--- a/src/messages/fetch_snapshot_request.rs
+++ b/src/messages/fetch_snapshot_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0

--- a/src/messages/fetch_snapshot_response.rs
+++ b/src/messages/fetch_snapshot_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0

--- a/src/messages/find_coordinator_request.rs
+++ b/src/messages/find_coordinator_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-5

--- a/src/messages/find_coordinator_response.rs
+++ b/src/messages/find_coordinator_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-5

--- a/src/messages/get_telemetry_subscriptions_request.rs
+++ b/src/messages/get_telemetry_subscriptions_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0

--- a/src/messages/get_telemetry_subscriptions_response.rs
+++ b/src/messages/get_telemetry_subscriptions_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0

--- a/src/messages/heartbeat_request.rs
+++ b/src/messages/heartbeat_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-4

--- a/src/messages/heartbeat_response.rs
+++ b/src/messages/heartbeat_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-4

--- a/src/messages/incremental_alter_configs_request.rs
+++ b/src/messages/incremental_alter_configs_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-1

--- a/src/messages/incremental_alter_configs_response.rs
+++ b/src/messages/incremental_alter_configs_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-1

--- a/src/messages/init_producer_id_request.rs
+++ b/src/messages/init_producer_id_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-5

--- a/src/messages/init_producer_id_response.rs
+++ b/src/messages/init_producer_id_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-5

--- a/src/messages/join_group_request.rs
+++ b/src/messages/join_group_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-9
@@ -54,7 +54,7 @@ pub struct JoinGroupRequest {
     /// The list of protocols that the member supports.
     ///
     /// Supported API versions: 0-9
-    pub protocols: indexmap::IndexMap<StrBytes, JoinGroupRequestProtocol>,
+    pub protocols: Vec<JoinGroupRequestProtocol>,
 
     /// The reason why the member (re-)joins the group.
     ///
@@ -125,10 +125,7 @@ impl JoinGroupRequest {
     /// The list of protocols that the member supports.
     ///
     /// Supported API versions: 0-9
-    pub fn with_protocols(
-        mut self,
-        value: indexmap::IndexMap<StrBytes, JoinGroupRequestProtocol>,
-    ) -> Self {
+    pub fn with_protocols(mut self, value: Vec<JoinGroupRequestProtocol>) -> Self {
         self.protocols = value;
         self
     }
@@ -357,6 +354,11 @@ impl Message for JoinGroupRequest {
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct JoinGroupRequestProtocol {
+    /// The protocol name.
+    ///
+    /// Supported API versions: 0-9
+    pub name: StrBytes,
+
     /// The protocol metadata.
     ///
     /// Supported API versions: 0-9
@@ -367,6 +369,15 @@ pub struct JoinGroupRequestProtocol {
 }
 
 impl JoinGroupRequestProtocol {
+    /// Sets `name` to the passed value.
+    ///
+    /// The protocol name.
+    ///
+    /// Supported API versions: 0-9
+    pub fn with_name(mut self, value: StrBytes) -> Self {
+        self.name = value;
+        self
+    }
     /// Sets `metadata` to the passed value.
     ///
     /// The protocol metadata.
@@ -389,13 +400,12 @@ impl JoinGroupRequestProtocol {
 }
 
 #[cfg(feature = "client")]
-impl MapEncodable for JoinGroupRequestProtocol {
-    type Key = StrBytes;
-    fn encode<B: ByteBufMut>(&self, key: &Self::Key, buf: &mut B, version: i16) -> Result<()> {
+impl Encodable for JoinGroupRequestProtocol {
+    fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version >= 6 {
-            types::CompactString.encode(buf, key)?;
+            types::CompactString.encode(buf, &self.name)?;
         } else {
-            types::String.encode(buf, key)?;
+            types::String.encode(buf, &self.name)?;
         }
         if version >= 6 {
             types::CompactBytes.encode(buf, &self.metadata)?;
@@ -416,12 +426,12 @@ impl MapEncodable for JoinGroupRequestProtocol {
         }
         Ok(())
     }
-    fn compute_size(&self, key: &Self::Key, version: i16) -> Result<usize> {
+    fn compute_size(&self, version: i16) -> Result<usize> {
         let mut total_size = 0;
         if version >= 6 {
-            total_size += types::CompactString.compute_size(key)?;
+            total_size += types::CompactString.compute_size(&self.name)?;
         } else {
-            total_size += types::String.compute_size(key)?;
+            total_size += types::String.compute_size(&self.name)?;
         }
         if version >= 6 {
             total_size += types::CompactBytes.compute_size(&self.metadata)?;
@@ -445,10 +455,9 @@ impl MapEncodable for JoinGroupRequestProtocol {
 }
 
 #[cfg(feature = "broker")]
-impl MapDecodable for JoinGroupRequestProtocol {
-    type Key = StrBytes;
-    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<(Self::Key, Self)> {
-        let key_field = if version >= 6 {
+impl Decodable for JoinGroupRequestProtocol {
+    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        let name = if version >= 6 {
             types::CompactString.decode(buf)?
         } else {
             types::String.decode(buf)?
@@ -468,19 +477,18 @@ impl MapDecodable for JoinGroupRequestProtocol {
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
-        Ok((
-            key_field,
-            Self {
-                metadata,
-                unknown_tagged_fields,
-            },
-        ))
+        Ok(Self {
+            name,
+            metadata,
+            unknown_tagged_fields,
+        })
     }
 }
 
 impl Default for JoinGroupRequestProtocol {
     fn default() -> Self {
         Self {
+            name: Default::default(),
             metadata: Default::default(),
             unknown_tagged_fields: BTreeMap::new(),
         }

--- a/src/messages/join_group_response.rs
+++ b/src/messages/join_group_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-9

--- a/src/messages/k_raft_version_record.rs
+++ b/src/messages/k_raft_version_record.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0

--- a/src/messages/leader_and_isr_request.rs
+++ b/src/messages/leader_and_isr_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-7

--- a/src/messages/leader_and_isr_response.rs
+++ b/src/messages/leader_and_isr_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-7
@@ -199,7 +199,7 @@ pub struct LeaderAndIsrResponse {
     /// Each topic
     ///
     /// Supported API versions: 5-7
-    pub topics: indexmap::IndexMap<Uuid, LeaderAndIsrTopicError>,
+    pub topics: Vec<LeaderAndIsrTopicError>,
 
     /// Other tagged fields
     pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
@@ -229,7 +229,7 @@ impl LeaderAndIsrResponse {
     /// Each topic
     ///
     /// Supported API versions: 5-7
-    pub fn with_topics(mut self, value: indexmap::IndexMap<Uuid, LeaderAndIsrTopicError>) -> Self {
+    pub fn with_topics(mut self, value: Vec<LeaderAndIsrTopicError>) -> Self {
         self.topics = value;
         self
     }
@@ -379,6 +379,11 @@ impl Message for LeaderAndIsrResponse {
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct LeaderAndIsrTopicError {
+    /// The unique topic ID
+    ///
+    /// Supported API versions: 5-7
+    pub topic_id: Uuid,
+
     /// Each partition.
     ///
     /// Supported API versions: 5-7
@@ -389,6 +394,15 @@ pub struct LeaderAndIsrTopicError {
 }
 
 impl LeaderAndIsrTopicError {
+    /// Sets `topic_id` to the passed value.
+    ///
+    /// The unique topic ID
+    ///
+    /// Supported API versions: 5-7
+    pub fn with_topic_id(mut self, value: Uuid) -> Self {
+        self.topic_id = value;
+        self
+    }
     /// Sets `partition_errors` to the passed value.
     ///
     /// Each partition.
@@ -411,13 +425,12 @@ impl LeaderAndIsrTopicError {
 }
 
 #[cfg(feature = "broker")]
-impl MapEncodable for LeaderAndIsrTopicError {
-    type Key = Uuid;
-    fn encode<B: ByteBufMut>(&self, key: &Self::Key, buf: &mut B, version: i16) -> Result<()> {
+impl Encodable for LeaderAndIsrTopicError {
+    fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version >= 5 {
-            types::Uuid.encode(buf, key)?;
+            types::Uuid.encode(buf, &self.topic_id)?;
         } else {
-            if key != &Uuid::nil() {
+            if &self.topic_id != &Uuid::nil() {
                 bail!("failed to encode");
             }
         }
@@ -442,12 +455,12 @@ impl MapEncodable for LeaderAndIsrTopicError {
         }
         Ok(())
     }
-    fn compute_size(&self, key: &Self::Key, version: i16) -> Result<usize> {
+    fn compute_size(&self, version: i16) -> Result<usize> {
         let mut total_size = 0;
         if version >= 5 {
-            total_size += types::Uuid.compute_size(key)?;
+            total_size += types::Uuid.compute_size(&self.topic_id)?;
         } else {
-            if key != &Uuid::nil() {
+            if &self.topic_id != &Uuid::nil() {
                 bail!("failed to encode");
             }
         }
@@ -476,10 +489,9 @@ impl MapEncodable for LeaderAndIsrTopicError {
 }
 
 #[cfg(feature = "client")]
-impl MapDecodable for LeaderAndIsrTopicError {
-    type Key = Uuid;
-    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<(Self::Key, Self)> {
-        let key_field = if version >= 5 {
+impl Decodable for LeaderAndIsrTopicError {
+    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        let topic_id = if version >= 5 {
             types::Uuid.decode(buf)?
         } else {
             Uuid::nil()
@@ -499,19 +511,18 @@ impl MapDecodable for LeaderAndIsrTopicError {
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
-        Ok((
-            key_field,
-            Self {
-                partition_errors,
-                unknown_tagged_fields,
-            },
-        ))
+        Ok(Self {
+            topic_id,
+            partition_errors,
+            unknown_tagged_fields,
+        })
     }
 }
 
 impl Default for LeaderAndIsrTopicError {
     fn default() -> Self {
         Self {
+            topic_id: Uuid::nil(),
             partition_errors: Default::default(),
             unknown_tagged_fields: BTreeMap::new(),
         }

--- a/src/messages/leader_change_message.rs
+++ b/src/messages/leader_change_message.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0

--- a/src/messages/leave_group_request.rs
+++ b/src/messages/leave_group_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-5

--- a/src/messages/leave_group_response.rs
+++ b/src/messages/leave_group_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-5

--- a/src/messages/list_client_metrics_resources_request.rs
+++ b/src/messages/list_client_metrics_resources_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0

--- a/src/messages/list_client_metrics_resources_response.rs
+++ b/src/messages/list_client_metrics_resources_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0

--- a/src/messages/list_groups_request.rs
+++ b/src/messages/list_groups_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-5

--- a/src/messages/list_groups_response.rs
+++ b/src/messages/list_groups_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-5

--- a/src/messages/list_offsets_request.rs
+++ b/src/messages/list_offsets_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-8

--- a/src/messages/list_offsets_response.rs
+++ b/src/messages/list_offsets_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-8

--- a/src/messages/list_partition_reassignments_request.rs
+++ b/src/messages/list_partition_reassignments_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0

--- a/src/messages/list_partition_reassignments_response.rs
+++ b/src/messages/list_partition_reassignments_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0

--- a/src/messages/list_transactions_request.rs
+++ b/src/messages/list_transactions_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-1

--- a/src/messages/list_transactions_response.rs
+++ b/src/messages/list_transactions_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-1

--- a/src/messages/metadata_request.rs
+++ b/src/messages/metadata_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-12

--- a/src/messages/metadata_response.rs
+++ b/src/messages/metadata_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-12
@@ -29,7 +29,7 @@ pub struct MetadataResponse {
     /// A list of brokers present in the cluster.
     ///
     /// Supported API versions: 0-12
-    pub brokers: indexmap::IndexMap<super::BrokerId, MetadataResponseBroker>,
+    pub brokers: Vec<MetadataResponseBroker>,
 
     /// The cluster ID that responding broker belongs to.
     ///
@@ -44,7 +44,7 @@ pub struct MetadataResponse {
     /// Each topic in the response.
     ///
     /// Supported API versions: 0-12
-    pub topics: indexmap::IndexMap<super::TopicName, MetadataResponseTopic>,
+    pub topics: Vec<MetadataResponseTopic>,
 
     /// 32-bit bitfield to represent authorized operations for this cluster.
     ///
@@ -70,10 +70,7 @@ impl MetadataResponse {
     /// A list of brokers present in the cluster.
     ///
     /// Supported API versions: 0-12
-    pub fn with_brokers(
-        mut self,
-        value: indexmap::IndexMap<super::BrokerId, MetadataResponseBroker>,
-    ) -> Self {
+    pub fn with_brokers(mut self, value: Vec<MetadataResponseBroker>) -> Self {
         self.brokers = value;
         self
     }
@@ -100,10 +97,7 @@ impl MetadataResponse {
     /// Each topic in the response.
     ///
     /// Supported API versions: 0-12
-    pub fn with_topics(
-        mut self,
-        value: indexmap::IndexMap<super::TopicName, MetadataResponseTopic>,
-    ) -> Self {
+    pub fn with_topics(mut self, value: Vec<MetadataResponseTopic>) -> Self {
         self.topics = value;
         self
     }
@@ -307,6 +301,11 @@ impl Message for MetadataResponse {
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct MetadataResponseBroker {
+    /// The broker ID.
+    ///
+    /// Supported API versions: 0-12
+    pub node_id: super::BrokerId,
+
     /// The broker hostname.
     ///
     /// Supported API versions: 0-12
@@ -327,6 +326,15 @@ pub struct MetadataResponseBroker {
 }
 
 impl MetadataResponseBroker {
+    /// Sets `node_id` to the passed value.
+    ///
+    /// The broker ID.
+    ///
+    /// Supported API versions: 0-12
+    pub fn with_node_id(mut self, value: super::BrokerId) -> Self {
+        self.node_id = value;
+        self
+    }
     /// Sets `host` to the passed value.
     ///
     /// The broker hostname.
@@ -367,10 +375,9 @@ impl MetadataResponseBroker {
 }
 
 #[cfg(feature = "broker")]
-impl MapEncodable for MetadataResponseBroker {
-    type Key = super::BrokerId;
-    fn encode<B: ByteBufMut>(&self, key: &Self::Key, buf: &mut B, version: i16) -> Result<()> {
-        types::Int32.encode(buf, key)?;
+impl Encodable for MetadataResponseBroker {
+    fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        types::Int32.encode(buf, &self.node_id)?;
         if version >= 9 {
             types::CompactString.encode(buf, &self.host)?;
         } else {
@@ -398,9 +405,9 @@ impl MapEncodable for MetadataResponseBroker {
         }
         Ok(())
     }
-    fn compute_size(&self, key: &Self::Key, version: i16) -> Result<usize> {
+    fn compute_size(&self, version: i16) -> Result<usize> {
         let mut total_size = 0;
-        total_size += types::Int32.compute_size(key)?;
+        total_size += types::Int32.compute_size(&self.node_id)?;
         if version >= 9 {
             total_size += types::CompactString.compute_size(&self.host)?;
         } else {
@@ -431,10 +438,9 @@ impl MapEncodable for MetadataResponseBroker {
 }
 
 #[cfg(feature = "client")]
-impl MapDecodable for MetadataResponseBroker {
-    type Key = super::BrokerId;
-    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<(Self::Key, Self)> {
-        let key_field = types::Int32.decode(buf)?;
+impl Decodable for MetadataResponseBroker {
+    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        let node_id = types::Int32.decode(buf)?;
         let host = if version >= 9 {
             types::CompactString.decode(buf)?
         } else {
@@ -460,21 +466,20 @@ impl MapDecodable for MetadataResponseBroker {
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
-        Ok((
-            key_field,
-            Self {
-                host,
-                port,
-                rack,
-                unknown_tagged_fields,
-            },
-        ))
+        Ok(Self {
+            node_id,
+            host,
+            port,
+            rack,
+            unknown_tagged_fields,
+        })
     }
 }
 
 impl Default for MetadataResponseBroker {
     fn default() -> Self {
         Self {
+            node_id: (0).into(),
             host: Default::default(),
             port: 0,
             rack: None,
@@ -771,6 +776,11 @@ pub struct MetadataResponseTopic {
     /// Supported API versions: 0-12
     pub error_code: i16,
 
+    /// The topic name. Null for non-existing topics queried by ID. This is never null when ErrorCode is zero. One of Name and TopicId is always populated.
+    ///
+    /// Supported API versions: 0-12
+    pub name: Option<super::TopicName>,
+
     /// The topic id. Zero for non-existing topics queried by name. This is never zero when ErrorCode is zero. One of Name and TopicId is always populated.
     ///
     /// Supported API versions: 10-12
@@ -803,6 +813,15 @@ impl MetadataResponseTopic {
     /// Supported API versions: 0-12
     pub fn with_error_code(mut self, value: i16) -> Self {
         self.error_code = value;
+        self
+    }
+    /// Sets `name` to the passed value.
+    ///
+    /// The topic name. Null for non-existing topics queried by ID. This is never null when ErrorCode is zero. One of Name and TopicId is always populated.
+    ///
+    /// Supported API versions: 0-12
+    pub fn with_name(mut self, value: Option<super::TopicName>) -> Self {
+        self.name = value;
         self
     }
     /// Sets `topic_id` to the passed value.
@@ -854,14 +873,13 @@ impl MetadataResponseTopic {
 }
 
 #[cfg(feature = "broker")]
-impl MapEncodable for MetadataResponseTopic {
-    type Key = super::TopicName;
-    fn encode<B: ByteBufMut>(&self, key: &Self::Key, buf: &mut B, version: i16) -> Result<()> {
+impl Encodable for MetadataResponseTopic {
+    fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 9 {
-            types::CompactString.encode(buf, key)?;
+            types::CompactString.encode(buf, &self.name)?;
         } else {
-            types::String.encode(buf, key)?;
+            types::String.encode(buf, &self.name)?;
         }
         if version >= 10 {
             types::Uuid.encode(buf, &self.topic_id)?;
@@ -895,13 +913,13 @@ impl MapEncodable for MetadataResponseTopic {
         }
         Ok(())
     }
-    fn compute_size(&self, key: &Self::Key, version: i16) -> Result<usize> {
+    fn compute_size(&self, version: i16) -> Result<usize> {
         let mut total_size = 0;
         total_size += types::Int16.compute_size(&self.error_code)?;
         if version >= 9 {
-            total_size += types::CompactString.compute_size(key)?;
+            total_size += types::CompactString.compute_size(&self.name)?;
         } else {
-            total_size += types::String.compute_size(key)?;
+            total_size += types::String.compute_size(&self.name)?;
         }
         if version >= 10 {
             total_size += types::Uuid.compute_size(&self.topic_id)?;
@@ -939,11 +957,10 @@ impl MapEncodable for MetadataResponseTopic {
 }
 
 #[cfg(feature = "client")]
-impl MapDecodable for MetadataResponseTopic {
-    type Key = super::TopicName;
-    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<(Self::Key, Self)> {
+impl Decodable for MetadataResponseTopic {
+    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         let error_code = types::Int16.decode(buf)?;
-        let key_field = if version >= 9 {
+        let name = if version >= 9 {
             types::CompactString.decode(buf)?
         } else {
             types::String.decode(buf)?
@@ -978,17 +995,15 @@ impl MapDecodable for MetadataResponseTopic {
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
-        Ok((
-            key_field,
-            Self {
-                error_code,
-                topic_id,
-                is_internal,
-                partitions,
-                topic_authorized_operations,
-                unknown_tagged_fields,
-            },
-        ))
+        Ok(Self {
+            error_code,
+            name,
+            topic_id,
+            is_internal,
+            partitions,
+            topic_authorized_operations,
+            unknown_tagged_fields,
+        })
     }
 }
 
@@ -996,6 +1011,7 @@ impl Default for MetadataResponseTopic {
     fn default() -> Self {
         Self {
             error_code: 0,
+            name: Some(Default::default()),
             topic_id: Uuid::nil(),
             is_internal: false,
             partitions: Default::default(),

--- a/src/messages/offset_commit_request.rs
+++ b/src/messages/offset_commit_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-9

--- a/src/messages/offset_commit_response.rs
+++ b/src/messages/offset_commit_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-9

--- a/src/messages/offset_fetch_request.rs
+++ b/src/messages/offset_fetch_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-9

--- a/src/messages/offset_fetch_response.rs
+++ b/src/messages/offset_fetch_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-9

--- a/src/messages/produce_request.rs
+++ b/src/messages/produce_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-11
@@ -177,7 +177,7 @@ pub struct ProduceRequest {
     /// Each topic to produce to.
     ///
     /// Supported API versions: 0-11
-    pub topic_data: indexmap::IndexMap<super::TopicName, TopicProduceData>,
+    pub topic_data: Vec<TopicProduceData>,
 
     /// Other tagged fields
     pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
@@ -216,10 +216,7 @@ impl ProduceRequest {
     /// Each topic to produce to.
     ///
     /// Supported API versions: 0-11
-    pub fn with_topic_data(
-        mut self,
-        value: indexmap::IndexMap<super::TopicName, TopicProduceData>,
-    ) -> Self {
+    pub fn with_topic_data(mut self, value: Vec<TopicProduceData>) -> Self {
         self.topic_data = value;
         self
     }
@@ -367,6 +364,11 @@ impl Message for ProduceRequest {
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct TopicProduceData {
+    /// The topic name.
+    ///
+    /// Supported API versions: 0-11
+    pub name: super::TopicName,
+
     /// Each partition to produce to.
     ///
     /// Supported API versions: 0-11
@@ -377,6 +379,15 @@ pub struct TopicProduceData {
 }
 
 impl TopicProduceData {
+    /// Sets `name` to the passed value.
+    ///
+    /// The topic name.
+    ///
+    /// Supported API versions: 0-11
+    pub fn with_name(mut self, value: super::TopicName) -> Self {
+        self.name = value;
+        self
+    }
     /// Sets `partition_data` to the passed value.
     ///
     /// Each partition to produce to.
@@ -399,13 +410,12 @@ impl TopicProduceData {
 }
 
 #[cfg(feature = "client")]
-impl MapEncodable for TopicProduceData {
-    type Key = super::TopicName;
-    fn encode<B: ByteBufMut>(&self, key: &Self::Key, buf: &mut B, version: i16) -> Result<()> {
+impl Encodable for TopicProduceData {
+    fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version >= 9 {
-            types::CompactString.encode(buf, key)?;
+            types::CompactString.encode(buf, &self.name)?;
         } else {
-            types::String.encode(buf, key)?;
+            types::String.encode(buf, &self.name)?;
         }
         if version >= 9 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.partition_data)?;
@@ -426,12 +436,12 @@ impl MapEncodable for TopicProduceData {
         }
         Ok(())
     }
-    fn compute_size(&self, key: &Self::Key, version: i16) -> Result<usize> {
+    fn compute_size(&self, version: i16) -> Result<usize> {
         let mut total_size = 0;
         if version >= 9 {
-            total_size += types::CompactString.compute_size(key)?;
+            total_size += types::CompactString.compute_size(&self.name)?;
         } else {
-            total_size += types::String.compute_size(key)?;
+            total_size += types::String.compute_size(&self.name)?;
         }
         if version >= 9 {
             total_size += types::CompactArray(types::Struct { version })
@@ -457,10 +467,9 @@ impl MapEncodable for TopicProduceData {
 }
 
 #[cfg(feature = "broker")]
-impl MapDecodable for TopicProduceData {
-    type Key = super::TopicName;
-    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<(Self::Key, Self)> {
-        let key_field = if version >= 9 {
+impl Decodable for TopicProduceData {
+    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        let name = if version >= 9 {
             types::CompactString.decode(buf)?
         } else {
             types::String.decode(buf)?
@@ -480,19 +489,18 @@ impl MapDecodable for TopicProduceData {
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
-        Ok((
-            key_field,
-            Self {
-                partition_data,
-                unknown_tagged_fields,
-            },
-        ))
+        Ok(Self {
+            name,
+            partition_data,
+            unknown_tagged_fields,
+        })
     }
 }
 
 impl Default for TopicProduceData {
     fn default() -> Self {
         Self {
+            name: Default::default(),
             partition_data: Default::default(),
             unknown_tagged_fields: BTreeMap::new(),
         }

--- a/src/messages/produce_response.rs
+++ b/src/messages/produce_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-11
@@ -349,6 +349,11 @@ impl Message for LeaderIdAndEpoch {
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct NodeEndpoint {
+    /// The ID of the associated node.
+    ///
+    /// Supported API versions: 10-11
+    pub node_id: super::BrokerId,
+
     /// The node's hostname.
     ///
     /// Supported API versions: 10-11
@@ -369,6 +374,15 @@ pub struct NodeEndpoint {
 }
 
 impl NodeEndpoint {
+    /// Sets `node_id` to the passed value.
+    ///
+    /// The ID of the associated node.
+    ///
+    /// Supported API versions: 10-11
+    pub fn with_node_id(mut self, value: super::BrokerId) -> Self {
+        self.node_id = value;
+        self
+    }
     /// Sets `host` to the passed value.
     ///
     /// The node's hostname.
@@ -409,13 +423,12 @@ impl NodeEndpoint {
 }
 
 #[cfg(feature = "broker")]
-impl MapEncodable for NodeEndpoint {
-    type Key = super::BrokerId;
-    fn encode<B: ByteBufMut>(&self, key: &Self::Key, buf: &mut B, version: i16) -> Result<()> {
+impl Encodable for NodeEndpoint {
+    fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version >= 10 {
-            types::Int32.encode(buf, key)?;
+            types::Int32.encode(buf, &self.node_id)?;
         } else {
-            if *key != 0 {
+            if self.node_id != 0 {
                 bail!("failed to encode");
             }
         }
@@ -454,12 +467,12 @@ impl MapEncodable for NodeEndpoint {
         }
         Ok(())
     }
-    fn compute_size(&self, key: &Self::Key, version: i16) -> Result<usize> {
+    fn compute_size(&self, version: i16) -> Result<usize> {
         let mut total_size = 0;
         if version >= 10 {
-            total_size += types::Int32.compute_size(key)?;
+            total_size += types::Int32.compute_size(&self.node_id)?;
         } else {
-            if *key != 0 {
+            if self.node_id != 0 {
                 bail!("failed to encode");
             }
         }
@@ -501,10 +514,9 @@ impl MapEncodable for NodeEndpoint {
 }
 
 #[cfg(feature = "client")]
-impl MapDecodable for NodeEndpoint {
-    type Key = super::BrokerId;
-    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<(Self::Key, Self)> {
-        let key_field = if version >= 10 {
+impl Decodable for NodeEndpoint {
+    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        let node_id = if version >= 10 {
             types::Int32.decode(buf)?
         } else {
             (0).into()
@@ -534,21 +546,20 @@ impl MapDecodable for NodeEndpoint {
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
-        Ok((
-            key_field,
-            Self {
-                host,
-                port,
-                rack,
-                unknown_tagged_fields,
-            },
-        ))
+        Ok(Self {
+            node_id,
+            host,
+            port,
+            rack,
+            unknown_tagged_fields,
+        })
     }
 }
 
 impl Default for NodeEndpoint {
     fn default() -> Self {
         Self {
+            node_id: (0).into(),
             host: Default::default(),
             port: 0,
             rack: None,
@@ -914,7 +925,7 @@ pub struct ProduceResponse {
     /// Each produce response
     ///
     /// Supported API versions: 0-11
-    pub responses: indexmap::IndexMap<super::TopicName, TopicProduceResponse>,
+    pub responses: Vec<TopicProduceResponse>,
 
     /// The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota.
     ///
@@ -924,7 +935,7 @@ pub struct ProduceResponse {
     /// Endpoints for all current-leaders enumerated in PartitionProduceResponses, with errors NOT_LEADER_OR_FOLLOWER.
     ///
     /// Supported API versions: 10-11
-    pub node_endpoints: indexmap::IndexMap<super::BrokerId, NodeEndpoint>,
+    pub node_endpoints: Vec<NodeEndpoint>,
 
     /// Other tagged fields
     pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
@@ -936,10 +947,7 @@ impl ProduceResponse {
     /// Each produce response
     ///
     /// Supported API versions: 0-11
-    pub fn with_responses(
-        mut self,
-        value: indexmap::IndexMap<super::TopicName, TopicProduceResponse>,
-    ) -> Self {
+    pub fn with_responses(mut self, value: Vec<TopicProduceResponse>) -> Self {
         self.responses = value;
         self
     }
@@ -957,10 +965,7 @@ impl ProduceResponse {
     /// Endpoints for all current-leaders enumerated in PartitionProduceResponses, with errors NOT_LEADER_OR_FOLLOWER.
     ///
     /// Supported API versions: 10-11
-    pub fn with_node_endpoints(
-        mut self,
-        value: indexmap::IndexMap<super::BrokerId, NodeEndpoint>,
-    ) -> Self {
+    pub fn with_node_endpoints(mut self, value: Vec<NodeEndpoint>) -> Self {
         self.node_endpoints = value;
         self
     }
@@ -1132,6 +1137,11 @@ impl Message for ProduceResponse {
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct TopicProduceResponse {
+    /// The topic name
+    ///
+    /// Supported API versions: 0-11
+    pub name: super::TopicName,
+
     /// Each partition that we produced to within the topic.
     ///
     /// Supported API versions: 0-11
@@ -1142,6 +1152,15 @@ pub struct TopicProduceResponse {
 }
 
 impl TopicProduceResponse {
+    /// Sets `name` to the passed value.
+    ///
+    /// The topic name
+    ///
+    /// Supported API versions: 0-11
+    pub fn with_name(mut self, value: super::TopicName) -> Self {
+        self.name = value;
+        self
+    }
     /// Sets `partition_responses` to the passed value.
     ///
     /// Each partition that we produced to within the topic.
@@ -1164,13 +1183,12 @@ impl TopicProduceResponse {
 }
 
 #[cfg(feature = "broker")]
-impl MapEncodable for TopicProduceResponse {
-    type Key = super::TopicName;
-    fn encode<B: ByteBufMut>(&self, key: &Self::Key, buf: &mut B, version: i16) -> Result<()> {
+impl Encodable for TopicProduceResponse {
+    fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version >= 9 {
-            types::CompactString.encode(buf, key)?;
+            types::CompactString.encode(buf, &self.name)?;
         } else {
-            types::String.encode(buf, key)?;
+            types::String.encode(buf, &self.name)?;
         }
         if version >= 9 {
             types::CompactArray(types::Struct { version })
@@ -1192,12 +1210,12 @@ impl MapEncodable for TopicProduceResponse {
         }
         Ok(())
     }
-    fn compute_size(&self, key: &Self::Key, version: i16) -> Result<usize> {
+    fn compute_size(&self, version: i16) -> Result<usize> {
         let mut total_size = 0;
         if version >= 9 {
-            total_size += types::CompactString.compute_size(key)?;
+            total_size += types::CompactString.compute_size(&self.name)?;
         } else {
-            total_size += types::String.compute_size(key)?;
+            total_size += types::String.compute_size(&self.name)?;
         }
         if version >= 9 {
             total_size += types::CompactArray(types::Struct { version })
@@ -1223,10 +1241,9 @@ impl MapEncodable for TopicProduceResponse {
 }
 
 #[cfg(feature = "client")]
-impl MapDecodable for TopicProduceResponse {
-    type Key = super::TopicName;
-    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<(Self::Key, Self)> {
-        let key_field = if version >= 9 {
+impl Decodable for TopicProduceResponse {
+    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        let name = if version >= 9 {
             types::CompactString.decode(buf)?
         } else {
             types::String.decode(buf)?
@@ -1246,19 +1263,18 @@ impl MapDecodable for TopicProduceResponse {
                 unknown_tagged_fields.insert(tag as i32, unknown_value);
             }
         }
-        Ok((
-            key_field,
-            Self {
-                partition_responses,
-                unknown_tagged_fields,
-            },
-        ))
+        Ok(Self {
+            name,
+            partition_responses,
+            unknown_tagged_fields,
+        })
     }
 }
 
 impl Default for TopicProduceResponse {
     fn default() -> Self {
         Self {
+            name: Default::default(),
             partition_responses: Default::default(),
             unknown_tagged_fields: BTreeMap::new(),
         }

--- a/src/messages/push_telemetry_request.rs
+++ b/src/messages/push_telemetry_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0

--- a/src/messages/push_telemetry_response.rs
+++ b/src/messages/push_telemetry_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0

--- a/src/messages/renew_delegation_token_request.rs
+++ b/src/messages/renew_delegation_token_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-2

--- a/src/messages/renew_delegation_token_response.rs
+++ b/src/messages/renew_delegation_token_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-2

--- a/src/messages/request_header.rs
+++ b/src/messages/request_header.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-2

--- a/src/messages/response_header.rs
+++ b/src/messages/response_header.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-1

--- a/src/messages/sasl_authenticate_request.rs
+++ b/src/messages/sasl_authenticate_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-2

--- a/src/messages/sasl_authenticate_response.rs
+++ b/src/messages/sasl_authenticate_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-2

--- a/src/messages/sasl_handshake_request.rs
+++ b/src/messages/sasl_handshake_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-1

--- a/src/messages/sasl_handshake_response.rs
+++ b/src/messages/sasl_handshake_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-1

--- a/src/messages/snapshot_footer_record.rs
+++ b/src/messages/snapshot_footer_record.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0

--- a/src/messages/snapshot_header_record.rs
+++ b/src/messages/snapshot_header_record.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0

--- a/src/messages/stop_replica_request.rs
+++ b/src/messages/stop_replica_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-4

--- a/src/messages/stop_replica_response.rs
+++ b/src/messages/stop_replica_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-4

--- a/src/messages/sync_group_request.rs
+++ b/src/messages/sync_group_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-5

--- a/src/messages/sync_group_response.rs
+++ b/src/messages/sync_group_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-5

--- a/src/messages/txn_offset_commit_request.rs
+++ b/src/messages/txn_offset_commit_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-4

--- a/src/messages/txn_offset_commit_response.rs
+++ b/src/messages/txn_offset_commit_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-4

--- a/src/messages/unregister_broker_request.rs
+++ b/src/messages/unregister_broker_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0

--- a/src/messages/unregister_broker_response.rs
+++ b/src/messages/unregister_broker_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0

--- a/src/messages/update_features_request.rs
+++ b/src/messages/update_features_request.rs
@@ -14,13 +14,18 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-1
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct FeatureUpdateKey {
+    /// The name of the finalized feature to be updated.
+    ///
+    /// Supported API versions: 0-1
+    pub feature: StrBytes,
+
     /// The new maximum version level for the finalized feature. A value >= 1 is valid. A value < 1, is special, and can be used to request the deletion of the finalized feature.
     ///
     /// Supported API versions: 0-1
@@ -41,6 +46,15 @@ pub struct FeatureUpdateKey {
 }
 
 impl FeatureUpdateKey {
+    /// Sets `feature` to the passed value.
+    ///
+    /// The name of the finalized feature to be updated.
+    ///
+    /// Supported API versions: 0-1
+    pub fn with_feature(mut self, value: StrBytes) -> Self {
+        self.feature = value;
+        self
+    }
     /// Sets `max_version_level` to the passed value.
     ///
     /// The new maximum version level for the finalized feature. A value >= 1 is valid. A value < 1, is special, and can be used to request the deletion of the finalized feature.
@@ -81,10 +95,9 @@ impl FeatureUpdateKey {
 }
 
 #[cfg(feature = "client")]
-impl MapEncodable for FeatureUpdateKey {
-    type Key = StrBytes;
-    fn encode<B: ByteBufMut>(&self, key: &Self::Key, buf: &mut B, version: i16) -> Result<()> {
-        types::CompactString.encode(buf, key)?;
+impl Encodable for FeatureUpdateKey {
+    fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        types::CompactString.encode(buf, &self.feature)?;
         types::Int16.encode(buf, &self.max_version_level)?;
         if version == 0 {
             types::Boolean.encode(buf, &self.allow_downgrade)?;
@@ -112,9 +125,9 @@ impl MapEncodable for FeatureUpdateKey {
         write_unknown_tagged_fields(buf, 0.., &self.unknown_tagged_fields)?;
         Ok(())
     }
-    fn compute_size(&self, key: &Self::Key, version: i16) -> Result<usize> {
+    fn compute_size(&self, version: i16) -> Result<usize> {
         let mut total_size = 0;
-        total_size += types::CompactString.compute_size(key)?;
+        total_size += types::CompactString.compute_size(&self.feature)?;
         total_size += types::Int16.compute_size(&self.max_version_level)?;
         if version == 0 {
             total_size += types::Boolean.compute_size(&self.allow_downgrade)?;
@@ -145,10 +158,9 @@ impl MapEncodable for FeatureUpdateKey {
 }
 
 #[cfg(feature = "broker")]
-impl MapDecodable for FeatureUpdateKey {
-    type Key = StrBytes;
-    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<(Self::Key, Self)> {
-        let key_field = types::CompactString.decode(buf)?;
+impl Decodable for FeatureUpdateKey {
+    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        let feature = types::CompactString.decode(buf)?;
         let max_version_level = types::Int16.decode(buf)?;
         let allow_downgrade = if version == 0 {
             types::Boolean.decode(buf)?
@@ -168,21 +180,20 @@ impl MapDecodable for FeatureUpdateKey {
             let unknown_value = buf.try_get_bytes(size as usize)?;
             unknown_tagged_fields.insert(tag as i32, unknown_value);
         }
-        Ok((
-            key_field,
-            Self {
-                max_version_level,
-                allow_downgrade,
-                upgrade_type,
-                unknown_tagged_fields,
-            },
-        ))
+        Ok(Self {
+            feature,
+            max_version_level,
+            allow_downgrade,
+            upgrade_type,
+            unknown_tagged_fields,
+        })
     }
 }
 
 impl Default for FeatureUpdateKey {
     fn default() -> Self {
         Self {
+            feature: Default::default(),
             max_version_level: 0,
             allow_downgrade: false,
             upgrade_type: 1,
@@ -208,7 +219,7 @@ pub struct UpdateFeaturesRequest {
     /// The list of updates to finalized features.
     ///
     /// Supported API versions: 0-1
-    pub feature_updates: indexmap::IndexMap<StrBytes, FeatureUpdateKey>,
+    pub feature_updates: Vec<FeatureUpdateKey>,
 
     /// True if we should validate the request, but not perform the upgrade or downgrade.
     ///
@@ -234,10 +245,7 @@ impl UpdateFeaturesRequest {
     /// The list of updates to finalized features.
     ///
     /// Supported API versions: 0-1
-    pub fn with_feature_updates(
-        mut self,
-        value: indexmap::IndexMap<StrBytes, FeatureUpdateKey>,
-    ) -> Self {
+    pub fn with_feature_updates(mut self, value: Vec<FeatureUpdateKey>) -> Self {
         self.feature_updates = value;
         self
     }

--- a/src/messages/update_metadata_request.rs
+++ b/src/messages/update_metadata_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-8

--- a/src/messages/update_metadata_response.rs
+++ b/src/messages/update_metadata_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-8

--- a/src/messages/vote_request.rs
+++ b/src/messages/vote_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0

--- a/src/messages/vote_response.rs
+++ b/src/messages/vote_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0

--- a/src/messages/write_txn_markers_request.rs
+++ b/src/messages/write_txn_markers_request.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-1

--- a/src/messages/write_txn_markers_response.rs
+++ b/src/messages/write_txn_markers_response.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::protocol::{
     buf::{ByteBuf, ByteBufMut},
     compute_unknown_tagged_fields_size, types, write_unknown_tagged_fields, Decodable, Decoder,
-    Encodable, Encoder, HeaderVersion, MapDecodable, MapEncodable, Message, StrBytes, VersionRange,
+    Encodable, Encoder, HeaderVersion, Message, StrBytes, VersionRange,
 };
 
 /// Valid versions: 0-1

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -175,17 +175,6 @@ pub trait Decodable: Sized {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self>;
 }
 
-pub(crate) trait MapEncodable: Sized {
-    type Key;
-    fn encode<B: ByteBufMut>(&self, key: &Self::Key, buf: &mut B, version: i16) -> Result<()>;
-    fn compute_size(&self, key: &Self::Key, version: i16) -> Result<usize>;
-}
-
-pub(crate) trait MapDecodable: Sized {
-    type Key;
-    fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<(Self::Key, Self)>;
-}
-
 /// Every message has a set of versions valid for a given header version.
 pub trait HeaderVersion {
     /// Maps a header version to a given version for a particular API message.

--- a/src/protocol/types.rs
+++ b/src/protocol/types.rs
@@ -4,9 +4,7 @@
 //! types that use zigzag encoded to represent length as a "compact" representation.
 //!
 //! It is unnecessary to interact directly with these types for most use cases.
-use super::{
-    Decodable, Decoder, Encodable, Encoder, MapDecodable, MapEncodable, NewType, StrBytes,
-};
+use super::{Decodable, Decoder, Encodable, Encoder, NewType, StrBytes};
 use crate::protocol::buf::{ByteBuf, ByteBufMut};
 use anyhow::{bail, Result};
 use indexmap::IndexMap;
@@ -905,21 +903,6 @@ impl<T: Decodable> Decoder<Option<T>> for OptionStruct {
         } else {
             Ok(None)
         }
-    }
-}
-
-impl<T: MapEncodable> Encoder<(&T::Key, &T)> for Struct {
-    fn encode<B: ByteBufMut>(&self, buf: &mut B, (key, value): (&T::Key, &T)) -> Result<()> {
-        value.encode(key, buf, self.version)
-    }
-    fn compute_size(&self, (key, value): (&T::Key, &T)) -> Result<usize> {
-        value.compute_size(key, self.version)
-    }
-}
-
-impl<T: MapDecodable> Decoder<(T::Key, T)> for Struct {
-    fn decode<B: ByteBuf>(&self, buf: &mut B) -> Result<(T::Key, T)> {
-        T::decode(buf, self.version)
     }
 }
 


### PR DESCRIPTION
If we are to make a fix for https://github.com/tychedelia/kafka-protocol-rs/issues/84 before we release v0.13.0 then this is our best option. I believe that along with resolving #84 it should also improve performance, so I recommend landing it, but it is also a bit controversial so maybe we want to release v0.13.0 first to give users time to give feedback.

This PR replaces all usages of `IndexMap<K, V>` with `Vec<V>` instead storing the `K` in the `V`.

I think its important that we make it clear that there is no longer an O(1) get operation, as such I think its most appropriate to just use a `Vec<T>`.
We can of course still change back to a custom collection type in the future, but since there is no plan or development capacity for it we would be just kidding ourselves to add a type now with the intention of it magically gaining O(1) in the future.

In order for existing implementations to convert from the old O(1) lookup to an O(N) lookup, they just need to swap:
```rust
if let Some(response) = responses.get(name) {
}
```
to:
```rust
if let Some(response) = responses.iter().find(|x| x.name == name) {
}
```

This is not that hard, and makes it clear this is O(N)

## Example porting:

Since this is such a large change to our API its important to test it out in some actual applications.
I've ported the proxy I work on to the new API: https://github.com/shotover/shotover-proxy/pull/1759

Largely the transition was very smooth, in one case I jumped through hoops to retain the O(1) lookup since it looked important in that case. (combine_produce_responses in sink_cluster/mod.rs) In all other cases the O(1) lookup was not needed.

And notably our automated CI benchmarks measured that time to decode produce requests was reduced by 20% !
This is a microbenchmark around decoding and does not take into account usage of the decoded request.

## Usages in other applications.

Kafka broker implementations would benefit the most from the swap to `Vec`.
They want to take a list of entries in the request, process them one by one and then produce a response for each of them. This does not involve lookups into the request or response.

However for kafka client implementations the swap to `Vec` seems worse off.
They need to construct batch request which involves performing lookups into the partially built request.
The fetch request does not use a map type but the produce request does.
So this would be a regression for clients creating a ProduceRequest to be encoded...
But on closer inspection, with the current implementation of kafka-protocol, this isnt true!
Since the actual record is stored as a `Bytes`, there is no way to append extra records to an existing `PartitionProduceData`.
Therefore the only way to efficiently batch records is with an intermediate representation, looking something like:
1. Application submits many records to the driver to be produced.
2. Driver stores each of these records in a `HashMap<TopicName, (i32, Vec<Record>)>` or similar.
3. Driver hits timeout or record limit and flushes pending produced records.
4. Driver iterates through the hashmap converting each element into a `TopicProduceData` and storing them in a `Vec<TopicProduceData>`. (previously an IndexMap)

So the swap to vec should be an improvement here as well!

## Interesting perf observation

Fun fact I realized about IndexMap is its actually backed by 2 allocations.
So if we create a HashMap (1 allocation) to construct a request to be batch encoded, and then convert that to a Vec (1 allocation) to be compatible with kafka-protocol, that is actually the same number of allocations as just using IndexMap.

## Possible future solutions

With vast changes to kafka-protocol we could truly resolve some of these issues along with other issues.
There are conflicting needs between the users of client drivers, kafka brokers and proxies.
The only way to truly give everyone what they want is to generate different versions of kafka-protocol for each use case.
I think the best way to implement this would be to have one generator that generates 3 different crates that we publish as 3 different crates.

The needs are:
* client
  + Efficient encode of requests and decode of responses (no need to go the other way)
* broker
  + Efficient encode of responses and decode of requests (no need to go the other way)
* proxy
   + requests and responses must be able to be easily rewritten and both encoded and decoded
   
If a type needs to be decoded but we know it will never be encoded, there are lots of zero-copy tricks we can employ to optimize this.

With this approach we can also better integrate records into kafka-protocol to avoid the issue described earlier for clients producing records.
Consider that:
* clients want to be able to append to in progress records (need access to internal state, not just a Bytes)
* brokers just want to read the record. (preparsed is probably faster)
* proxies might not want to parse the record as its an extra cost that isnt needed to route the request.



However:
I cannot justify implementing this myself, since the status quo is already perfect for a proxy, and this is a huge undertaking but I would happily review PRs to implement this.