### PR TITLE
update pinned rust + fix clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,11 +34,11 @@ gzip = ["dep:flate2"]
 # Enable compression of records using zstd
 zstd = ["dep:zstd"]
 # Enable compression of records using snap
-snap = ["dep:snap"]
+snappy = ["dep:snap"]
 # Enable compression of records using lz4
 lz4 = ["dep:lz4"]
 
-default = ["client", "broker", "gzip", "zstd", "snap", "lz4"]
+default = ["client", "broker", "gzip", "zstd", "snappy", "lz4"]
 
 [dependencies]
 bytes = "1.0.1"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.76"
+channel = "1.81"
 components = [ "rustfmt", "clippy" ]
 targets = [ "aarch64-unknown-linux-gnu" ]

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -210,7 +210,7 @@ pub(crate) fn write_unknown_tagged_fields<B: ByteBufMut, R: RangeBounds<i32>>(
     unknown_tagged_fields: &BTreeMap<i32, Bytes>,
 ) -> Result<()> {
     for (&k, v) in unknown_tagged_fields.range(range) {
-        if v.len() > std::u32::MAX as usize {
+        if v.len() > u32::MAX as usize {
             bail!("Tagged field is too long to encode ({} bytes)", v.len());
         }
         types::UnsignedVarInt.encode(buf, k as u32)?;
@@ -225,7 +225,7 @@ pub(crate) fn compute_unknown_tagged_fields_size(
 ) -> Result<usize> {
     let mut total_size = 0;
     for (&k, v) in unknown_tagged_fields {
-        if v.len() > std::u32::MAX as usize {
+        if v.len() > u32::MAX as usize {
             bail!("Tagged field is too long to encode ({} bytes)", v.len());
         }
         total_size += types::UnsignedVarInt.compute_size(k as u32)?;

--- a/src/protocol/types.rs
+++ b/src/protocol/types.rs
@@ -270,7 +270,7 @@ pub struct String;
 impl Encoder<Option<&str>> for String {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, value: Option<&str>) -> Result<()> {
         if let Some(s) = value {
-            if s.len() > std::i16::MAX as usize {
+            if s.len() > i16::MAX as usize {
                 bail!("String is too long to encode ({} bytes)", s.len());
             } else {
                 Int16.encode(buf, s.len() as i16)?;
@@ -284,7 +284,7 @@ impl Encoder<Option<&str>> for String {
     }
     fn compute_size(&self, value: Option<&str>) -> Result<usize> {
         if let Some(s) = value {
-            if s.len() > std::i16::MAX as usize {
+            if s.len() > i16::MAX as usize {
                 bail!("String is too long to encode ({} bytes)", s.len());
             } else {
                 Ok(2 + s.len())
@@ -421,7 +421,7 @@ impl Encoder<Option<&str>> for CompactString {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, value: Option<&str>) -> Result<()> {
         if let Some(s) = value {
             // Use >= because we're going to add one to the length
-            if s.len() >= std::u32::MAX as usize {
+            if s.len() >= u32::MAX as usize {
                 bail!("CompactString is too long to encode ({} bytes)", s.len());
             } else {
                 UnsignedVarInt.encode(buf, (s.len() as u32) + 1)?;
@@ -436,7 +436,7 @@ impl Encoder<Option<&str>> for CompactString {
     fn compute_size(&self, value: Option<&str>) -> Result<usize> {
         if let Some(s) = value {
             // Use >= because we're going to add one to the length
-            if s.len() >= std::u32::MAX as usize {
+            if s.len() >= u32::MAX as usize {
                 bail!("CompactString is too long to encode ({} bytes)", s.len());
             } else {
                 Ok(UnsignedVarInt.compute_size((s.len() as u32) + 1)? + s.len())
@@ -714,7 +714,7 @@ impl Encoder<Option<&[u8]>> for CompactBytes {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, value: Option<&[u8]>) -> Result<()> {
         if let Some(s) = value {
             // Use >= because we're going to add one to the length
-            if s.len() >= std::u32::MAX as usize {
+            if s.len() >= u32::MAX as usize {
                 bail!("CompactBytes is too long to encode ({} bytes)", s.len());
             } else {
                 UnsignedVarInt.encode(buf, (s.len() as u32) + 1)?;
@@ -729,7 +729,7 @@ impl Encoder<Option<&[u8]>> for CompactBytes {
     fn compute_size(&self, value: Option<&[u8]>) -> Result<usize> {
         if let Some(s) = value {
             // Use >= because we're going to add one to the length
-            if s.len() >= std::u32::MAX as usize {
+            if s.len() >= u32::MAX as usize {
                 bail!("CompactBytes is too long to encode ({} bytes)", s.len());
             } else {
                 Ok(UnsignedVarInt.compute_size((s.len() as u32) + 1)? + s.len())
@@ -1126,7 +1126,7 @@ impl<T, E: for<'a> Encoder<&'a T>> Encoder<Option<&[T]>> for CompactArray<E> {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, value: Option<&[T]>) -> Result<()> {
         if let Some(a) = value {
             // Use >= because we're going to add one to the length
-            if a.len() >= std::u32::MAX as usize {
+            if a.len() >= u32::MAX as usize {
                 bail!("CompactArray is too long to encode ({} items)", a.len());
             } else {
                 UnsignedVarInt.encode(buf, (a.len() as u32) + 1)?;
@@ -1143,7 +1143,7 @@ impl<T, E: for<'a> Encoder<&'a T>> Encoder<Option<&[T]>> for CompactArray<E> {
     fn compute_size(&self, value: Option<&[T]>) -> Result<usize> {
         if let Some(a) = value {
             // Use >= because we're going to add one to the length
-            if a.len() >= std::u32::MAX as usize {
+            if a.len() >= u32::MAX as usize {
                 bail!("CompactArray is too long to encode ({} items)", a.len());
             } else if let Some(fixed_size) = self.0.fixed_size() {
                 Ok(UnsignedVarInt.compute_size((a.len() as u32) + 1)? + a.len() * fixed_size)
@@ -1202,7 +1202,7 @@ impl<K: Eq + Hash, V, E: for<'a> Encoder<(&'a K, &'a V)>> Encoder<Option<&IndexM
     fn encode<B: ByteBufMut>(&self, buf: &mut B, value: Option<&IndexMap<K, V>>) -> Result<()> {
         if let Some(a) = value {
             // Use >= because we're going to add one to the length
-            if a.len() >= std::u32::MAX as usize {
+            if a.len() >= u32::MAX as usize {
                 bail!("CompactArray is too long to encode ({} items)", a.len());
             } else {
                 UnsignedVarInt.encode(buf, (a.len() as u32) + 1)?;
@@ -1219,7 +1219,7 @@ impl<K: Eq + Hash, V, E: for<'a> Encoder<(&'a K, &'a V)>> Encoder<Option<&IndexM
     fn compute_size(&self, value: Option<&IndexMap<K, V>>) -> Result<usize> {
         if let Some(a) = value {
             // Use >= because we're going to add one to the length
-            if a.len() >= std::u32::MAX as usize {
+            if a.len() >= u32::MAX as usize {
                 bail!("CompactArray is too long to encode ({} items)", a.len());
             } else if let Some(fixed_size) = self.0.fixed_size() {
                 Ok(UnsignedVarInt.compute_size((a.len() as u32) + 1)? + a.len() * fixed_size)
@@ -1352,12 +1352,12 @@ mod tests {
         test_encoder_decoder(VarLong, 300, &[216, 4]);
         test_encoder_decoder(
             VarLong,
-            std::i64::MAX,
+            i64::MAX,
             &[254, 255, 255, 255, 255, 255, 255, 255, 255, 1],
         );
         test_encoder_decoder(
             VarLong,
-            std::i64::MIN,
+            i64::MIN,
             &[255, 255, 255, 255, 255, 255, 255, 255, 255, 1],
         );
     }

--- a/src/records.rs
+++ b/src/records.rs
@@ -160,6 +160,7 @@ impl RecordBatchEncoder {
     /// strategy based on version.
     /// # Arguments
     /// * `compressor` - A function that compresses the given batch of records.
+    ///
     /// If `None`, the right compression algorithm will automatically be selected and applied.
     pub fn encode<'a, B, I, CF>(
         buf: &mut B,
@@ -439,6 +440,7 @@ impl RecordBatchEncoder {
                 Compression::Zstd => cmpr::Zstd::compress(buf, |buf| {
                     Self::encode_new_records(buf, records, min_offset, min_timestamp, options)
                 })?,
+                #[allow(unreachable_patterns)]
                 c => {
                     return Err(anyhow!(
                         "Support for {c:?} is not enabled as a cargo feature"
@@ -486,6 +488,7 @@ impl RecordBatchDecoder {
     /// Decode the provided buffer into a vec of records.
     /// # Arguments
     /// * `decompressor` - A function that decompresses the given batch of records.
+    ///
     /// If `None`, the right decompression algorithm will automatically be selected and applied.
     pub fn decode<B: ByteBuf, F>(buf: &mut B, decompressor: Option<F>) -> Result<Vec<Record>>
     where
@@ -651,6 +654,7 @@ impl RecordBatchDecoder {
                 Compression::Lz4 => cmpr::Lz4::decompress(buf, |buf| {
                     Self::decode_new_records(buf, &batch_decode_info, version, records)
                 })?,
+                #[allow(unreachable_patterns)]
                 c => {
                     return Err(anyhow!(
                         "Support for {c:?} is not enabled as a cargo feature"


### PR DESCRIPTION
Update the pinned rust version and fix clippy lints.
Turns out the feature for snappy compression was broken, the name of the feature was different to the name used in the `cfg`s and rust 1.76 didnt pick this up yet.

I set the feature name to ["snappy"](https://google.github.io/snappy/) to match the name of the compression format rather than the name ["snap"](https://github.com/BurntSushi/rust-snappy) which is the rust crate that implements snappy, since the choice of crate is an implementation detail.

AFAIK this project has no MSRV requirements, so the toolchain is not set to an old version to ensure an MSRV, if desired I can leave it a few versions behind though.