### PR TITLE
Reduce allocations when decoding maps

### DIFF
--- a/src/protocol/types.rs
+++ b/src/protocol/types.rs
@@ -1092,12 +1092,8 @@ impl<K: Eq + Hash, V, E: Decoder<(K, V)>> Decoder<Option<IndexMap<K, V>>> for Ar
         match Int32.decode(buf)? {
             -1 => Ok(None),
             n if n >= 0 => {
-                let mut result = IndexMap::new();
-                for _ in 0..n {
-                    let (k, v) = self.0.decode(buf)?;
-                    result.insert(k, v);
-                }
-                Ok(Some(result))
+                let result: Result<IndexMap<K, V>> = (0..n).map(|_| self.0.decode(buf)).collect();
+                Ok(Some(result?))
             }
             n => {
                 bail!("Array length is negative ({})", n);
@@ -1290,12 +1286,8 @@ impl<K: Eq + Hash, V, E: Decoder<(K, V)>> Decoder<Option<IndexMap<K, V>>> for Co
         match UnsignedVarInt.decode(buf)? {
             0 => Ok(None),
             n => {
-                let mut result = IndexMap::new();
-                for _ in 1..n {
-                    let (k, v) = self.0.decode(buf)?;
-                    result.insert(k, v);
-                }
-                Ok(Some(result))
+                let result: Result<IndexMap<K, V>> = (1..n).map(|_| self.0.decode(buf)).collect();
+                Ok(Some(result?))
             }
         }
     }


### PR DESCRIPTION
This PR alters the decode logic for maps to avoid reallocations due to map growth from insertions.
By using iterators + collect the size of the allocation required for the IndexMap is known up front, avoiding the need for reallocations as decoded items are inserted to the map.

This should give a small speed up to decoding of produce messages since they use maps.