### PR TITLE
Release 0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.13.0
+
 - All "map" types in the protocol that were previously of type `IndexMap<K, V>` are now of type `Vec<V>`, the value of `K` is stored as a field within `V`.
   - This was done to resolve <https://github.com/tychedelia/kafka-protocol-rs/issues/84> and improve decoding speed.
   - If you were previously calling `.get()` on the map, the best way to migrate is to refactor your code to avoid the need to lookup by iterating over the items in the response instead.
@@ -11,6 +13,8 @@
 - The Debug impl for new type wrappers now passes directly to the inner type.
   The full list of new type wrappers is BrokerId, GroupId, ProducerId, TopicName and TransactionalId.
   For example GroupId was previously `GroupId("some group")` but is now `"some group"`.
+- ApiKey is now non_exhaustive.
+- Added `gzip`, `zstd`, `snappy` and `lz4` features to enable the different compression algorithms for records (All enabled by default)
 
 ## v0.12.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,7 +947,7 @@ checksum = "9dbbfed4e59ba9750e15ba154fdfd9329cee16ff3df539c2666b70f58cc32105"
 
 [[package]]
 name = "kafka-protocol"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["protocol_codegen"]
 
 [package]
 name = "kafka-protocol"
-version = "0.12.0"
+version = "0.13.0"
 authors = [
     "Diggory Blake <diggsey@googlemail.com>",
     "Charlotte McElwain <charlotte.c.mcelwain@gmail.com>",


### PR DESCRIPTION
Releases kafka-protocol 0.13

@tychedelia up to you if you want to include https://github.com/tychedelia/kafka-protocol-rs/pull/90 in this release, I've done a full writeup on my thoughts in the PR.