### PR TITLE
Improve error handling on encode version violation

### DIFF
--- a/src/messages/add_partitions_to_txn_request.rs
+++ b/src/messages/add_partitions_to_txn_request.rs
@@ -115,7 +115,7 @@ impl Encodable for AddPartitionsToTxnRequest {
             types::CompactArray(types::Struct { version }).encode(buf, &self.transactions)?;
         } else {
             if !self.transactions.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version <= 3 {
@@ -126,21 +126,21 @@ impl Encodable for AddPartitionsToTxnRequest {
             }
         } else {
             if !self.v3_and_below_transactional_id.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version <= 3 {
             types::Int64.encode(buf, &self.v3_and_below_producer_id)?;
         } else {
             if self.v3_and_below_producer_id != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version <= 3 {
             types::Int16.encode(buf, &self.v3_and_below_producer_epoch)?;
         } else {
             if self.v3_and_below_producer_epoch != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version <= 3 {
@@ -152,7 +152,7 @@ impl Encodable for AddPartitionsToTxnRequest {
             }
         } else {
             if !self.v3_and_below_topics.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
@@ -176,7 +176,7 @@ impl Encodable for AddPartitionsToTxnRequest {
                 types::CompactArray(types::Struct { version }).compute_size(&self.transactions)?;
         } else {
             if !self.transactions.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version <= 3 {
@@ -188,21 +188,21 @@ impl Encodable for AddPartitionsToTxnRequest {
             }
         } else {
             if !self.v3_and_below_transactional_id.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version <= 3 {
             total_size += types::Int64.compute_size(&self.v3_and_below_producer_id)?;
         } else {
             if self.v3_and_below_producer_id != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version <= 3 {
             total_size += types::Int16.compute_size(&self.v3_and_below_producer_epoch)?;
         } else {
             if self.v3_and_below_producer_epoch != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version <= 3 {
@@ -215,7 +215,7 @@ impl Encodable for AddPartitionsToTxnRequest {
             }
         } else {
             if !self.v3_and_below_topics.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
@@ -557,35 +557,35 @@ impl Encodable for AddPartitionsToTxnTransaction {
             types::CompactString.encode(buf, &self.transactional_id)?;
         } else {
             if !self.transactional_id.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {
             types::Int64.encode(buf, &self.producer_id)?;
         } else {
             if self.producer_id != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {
             types::Int16.encode(buf, &self.producer_epoch)?;
         } else {
             if self.producer_epoch != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {
             types::Boolean.encode(buf, &self.verify_only)?;
         } else {
             if self.verify_only {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
         } else {
             if !self.topics.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
@@ -608,28 +608,28 @@ impl Encodable for AddPartitionsToTxnTransaction {
             total_size += types::CompactString.compute_size(&self.transactional_id)?;
         } else {
             if !self.transactional_id.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {
             total_size += types::Int64.compute_size(&self.producer_id)?;
         } else {
             if self.producer_id != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {
             total_size += types::Int16.compute_size(&self.producer_epoch)?;
         } else {
             if self.producer_epoch != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {
             total_size += types::Boolean.compute_size(&self.verify_only)?;
         } else {
             if self.verify_only {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {
@@ -637,7 +637,7 @@ impl Encodable for AddPartitionsToTxnTransaction {
                 types::CompactArray(types::Struct { version }).compute_size(&self.topics)?;
         } else {
             if !self.topics.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {

--- a/src/messages/add_partitions_to_txn_response.rs
+++ b/src/messages/add_partitions_to_txn_response.rs
@@ -235,7 +235,7 @@ impl Encodable for AddPartitionsToTxnResponse {
                 .encode(buf, &self.results_by_transaction)?;
         } else {
             if !self.results_by_transaction.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version <= 3 {
@@ -248,7 +248,7 @@ impl Encodable for AddPartitionsToTxnResponse {
             }
         } else {
             if !self.results_by_topic_v3_and_below.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
@@ -276,7 +276,7 @@ impl Encodable for AddPartitionsToTxnResponse {
                 .compute_size(&self.results_by_transaction)?;
         } else {
             if !self.results_by_transaction.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version <= 3 {
@@ -289,7 +289,7 @@ impl Encodable for AddPartitionsToTxnResponse {
             }
         } else {
             if !self.results_by_topic_v3_and_below.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
@@ -424,14 +424,14 @@ impl Encodable for AddPartitionsToTxnResult {
             types::CompactString.encode(buf, &self.transactional_id)?;
         } else {
             if !self.transactional_id.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.topic_results)?;
         } else {
             if !self.topic_results.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
@@ -454,7 +454,7 @@ impl Encodable for AddPartitionsToTxnResult {
             total_size += types::CompactString.compute_size(&self.transactional_id)?;
         } else {
             if !self.transactional_id.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {
@@ -462,7 +462,7 @@ impl Encodable for AddPartitionsToTxnResult {
                 types::CompactArray(types::Struct { version }).compute_size(&self.topic_results)?;
         } else {
             if !self.topic_results.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {

--- a/src/messages/alter_partition_request.rs
+++ b/src/messages/alter_partition_request.rs
@@ -212,14 +212,14 @@ impl Encodable for BrokerState {
             types::Int32.encode(buf, &self.broker_id)?;
         } else {
             if self.broker_id != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
             types::Int64.encode(buf, &self.broker_epoch)?;
         } else {
             if self.broker_epoch != -1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -240,14 +240,14 @@ impl Encodable for BrokerState {
             total_size += types::Int32.compute_size(&self.broker_id)?;
         } else {
             if self.broker_id != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
             total_size += types::Int64.compute_size(&self.broker_epoch)?;
         } else {
             if self.broker_epoch != -1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -422,7 +422,7 @@ impl Encodable for PartitionData {
             types::CompactArray(types::Int32).encode(buf, &self.new_isr)?;
         } else {
             if !self.new_isr.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
@@ -430,14 +430,14 @@ impl Encodable for PartitionData {
                 .encode(buf, &self.new_isr_with_epochs)?;
         } else {
             if !self.new_isr_with_epochs.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 1 {
             types::Int8.encode(buf, &self.leader_recovery_state)?;
         } else {
             if self.leader_recovery_state != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         types::Int32.encode(buf, &self.partition_epoch)?;
@@ -461,7 +461,7 @@ impl Encodable for PartitionData {
             total_size += types::CompactArray(types::Int32).compute_size(&self.new_isr)?;
         } else {
             if !self.new_isr.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
@@ -469,14 +469,14 @@ impl Encodable for PartitionData {
                 .compute_size(&self.new_isr_with_epochs)?;
         } else {
             if !self.new_isr_with_epochs.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 1 {
             total_size += types::Int8.compute_size(&self.leader_recovery_state)?;
         } else {
             if self.leader_recovery_state != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         total_size += types::Int32.compute_size(&self.partition_epoch)?;

--- a/src/messages/api_versions_response.rs
+++ b/src/messages/api_versions_response.rs
@@ -610,21 +610,21 @@ impl Encodable for FinalizedFeatureKey {
             types::CompactString.encode(buf, &self.name)?;
         } else {
             if !self.name.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
             types::Int16.encode(buf, &self.max_version_level)?;
         } else {
             if self.max_version_level != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
             types::Int16.encode(buf, &self.min_version_level)?;
         } else {
             if self.min_version_level != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
@@ -647,21 +647,21 @@ impl Encodable for FinalizedFeatureKey {
             total_size += types::CompactString.compute_size(&self.name)?;
         } else {
             if !self.name.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
             total_size += types::Int16.compute_size(&self.max_version_level)?;
         } else {
             if self.max_version_level != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
             total_size += types::Int16.compute_size(&self.min_version_level)?;
         } else {
             if self.min_version_level != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
@@ -803,21 +803,21 @@ impl Encodable for SupportedFeatureKey {
             types::CompactString.encode(buf, &self.name)?;
         } else {
             if !self.name.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
             types::Int16.encode(buf, &self.min_version)?;
         } else {
             if self.min_version != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
             types::Int16.encode(buf, &self.max_version)?;
         } else {
             if self.max_version != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
@@ -840,21 +840,21 @@ impl Encodable for SupportedFeatureKey {
             total_size += types::CompactString.compute_size(&self.name)?;
         } else {
             if !self.name.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
             total_size += types::Int16.compute_size(&self.min_version)?;
         } else {
             if self.min_version != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
             total_size += types::Int16.compute_size(&self.max_version)?;
         } else {
             if self.max_version != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {

--- a/src/messages/broker_registration_request.rs
+++ b/src/messages/broker_registration_request.rs
@@ -177,7 +177,7 @@ impl Encodable for BrokerRegistrationRequest {
             types::Boolean.encode(buf, &self.is_migrating_zk_broker)?;
         } else {
             if self.is_migrating_zk_broker {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 2 {
@@ -212,7 +212,7 @@ impl Encodable for BrokerRegistrationRequest {
             total_size += types::Boolean.compute_size(&self.is_migrating_zk_broker)?;
         } else {
             if self.is_migrating_zk_broker {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 2 {

--- a/src/messages/consumer_protocol_subscription.rs
+++ b/src/messages/consumer_protocol_subscription.rs
@@ -218,14 +218,14 @@ impl Encodable for TopicPartition {
             types::String.encode(buf, &self.topic)?;
         } else {
             if !self.topic.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 1 {
             types::Array(types::Int32).encode(buf, &self.partitions)?;
         } else {
             if !self.partitions.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
 
@@ -237,14 +237,14 @@ impl Encodable for TopicPartition {
             total_size += types::String.compute_size(&self.topic)?;
         } else {
             if !self.topic.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 1 {
             total_size += types::Array(types::Int32).compute_size(&self.partitions)?;
         } else {
             if !self.partitions.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
 

--- a/src/messages/create_acls_request.rs
+++ b/src/messages/create_acls_request.rs
@@ -149,7 +149,7 @@ impl Encodable for AclCreation {
             types::Int8.encode(buf, &self.resource_pattern_type)?;
         } else {
             if self.resource_pattern_type != 3 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 2 {
@@ -190,7 +190,7 @@ impl Encodable for AclCreation {
             total_size += types::Int8.compute_size(&self.resource_pattern_type)?;
         } else {
             if self.resource_pattern_type != 3 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 2 {

--- a/src/messages/create_delegation_token_request.rs
+++ b/src/messages/create_delegation_token_request.rs
@@ -256,7 +256,7 @@ impl Encodable for CreateDelegationTokenRequest {
                 .map(|x| x.is_empty())
                 .unwrap_or_default()
             {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
@@ -268,7 +268,7 @@ impl Encodable for CreateDelegationTokenRequest {
                 .map(|x| x.is_empty())
                 .unwrap_or_default()
             {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 2 {
@@ -302,7 +302,7 @@ impl Encodable for CreateDelegationTokenRequest {
                 .map(|x| x.is_empty())
                 .unwrap_or_default()
             {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
@@ -314,7 +314,7 @@ impl Encodable for CreateDelegationTokenRequest {
                 .map(|x| x.is_empty())
                 .unwrap_or_default()
             {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 2 {

--- a/src/messages/create_delegation_token_response.rs
+++ b/src/messages/create_delegation_token_response.rs
@@ -210,14 +210,14 @@ impl Encodable for CreateDelegationTokenResponse {
             types::CompactString.encode(buf, &self.token_requester_principal_type)?;
         } else {
             if !self.token_requester_principal_type.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
             types::CompactString.encode(buf, &self.token_requester_principal_name)?;
         } else {
             if !self.token_requester_principal_name.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         types::Int64.encode(buf, &self.issue_timestamp_ms)?;
@@ -266,7 +266,7 @@ impl Encodable for CreateDelegationTokenResponse {
                 types::CompactString.compute_size(&self.token_requester_principal_type)?;
         } else {
             if !self.token_requester_principal_type.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
@@ -274,7 +274,7 @@ impl Encodable for CreateDelegationTokenResponse {
                 types::CompactString.compute_size(&self.token_requester_principal_name)?;
         } else {
             if !self.token_requester_principal_name.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         total_size += types::Int64.compute_size(&self.issue_timestamp_ms)?;

--- a/src/messages/create_topics_request.rs
+++ b/src/messages/create_topics_request.rs
@@ -453,7 +453,7 @@ impl Encodable for CreateTopicsRequest {
             types::Boolean.encode(buf, &self.validate_only)?;
         } else {
             if self.validate_only {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 5 {
@@ -483,7 +483,7 @@ impl Encodable for CreateTopicsRequest {
             total_size += types::Boolean.compute_size(&self.validate_only)?;
         } else {
             if self.validate_only {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 5 {

--- a/src/messages/create_topics_response.rs
+++ b/src/messages/create_topics_response.rs
@@ -115,7 +115,7 @@ impl Encodable for CreatableTopicConfigs {
             types::CompactString.encode(buf, &self.name)?;
         } else {
             if !self.name.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 5 {
@@ -127,14 +127,14 @@ impl Encodable for CreatableTopicConfigs {
                 .map(|x| x.is_empty())
                 .unwrap_or_default()
             {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 5 {
             types::Boolean.encode(buf, &self.read_only)?;
         } else {
             if self.read_only {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 5 {
@@ -144,7 +144,7 @@ impl Encodable for CreatableTopicConfigs {
             types::Boolean.encode(buf, &self.is_sensitive)?;
         } else {
             if self.is_sensitive {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 5 {
@@ -167,7 +167,7 @@ impl Encodable for CreatableTopicConfigs {
             total_size += types::CompactString.compute_size(&self.name)?;
         } else {
             if !self.name.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 5 {
@@ -179,14 +179,14 @@ impl Encodable for CreatableTopicConfigs {
                 .map(|x| x.is_empty())
                 .unwrap_or_default()
             {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 5 {
             total_size += types::Boolean.compute_size(&self.read_only)?;
         } else {
             if self.read_only {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 5 {
@@ -196,7 +196,7 @@ impl Encodable for CreatableTopicConfigs {
             total_size += types::Boolean.compute_size(&self.is_sensitive)?;
         } else {
             if self.is_sensitive {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 5 {

--- a/src/messages/delete_acls_request.rs
+++ b/src/messages/delete_acls_request.rs
@@ -149,7 +149,7 @@ impl Encodable for DeleteAclsFilter {
             types::Int8.encode(buf, &self.pattern_type_filter)?;
         } else {
             if self.pattern_type_filter != 3 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 2 {
@@ -190,7 +190,7 @@ impl Encodable for DeleteAclsFilter {
             total_size += types::Int8.compute_size(&self.pattern_type_filter)?;
         } else {
             if self.pattern_type_filter != 3 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 2 {

--- a/src/messages/delete_acls_response.rs
+++ b/src/messages/delete_acls_response.rs
@@ -354,7 +354,7 @@ impl Encodable for DeleteAclsMatchingAcl {
             types::Int8.encode(buf, &self.pattern_type)?;
         } else {
             if self.pattern_type != 3 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 2 {
@@ -401,7 +401,7 @@ impl Encodable for DeleteAclsMatchingAcl {
             total_size += types::Int8.compute_size(&self.pattern_type)?;
         } else {
             if self.pattern_type != 3 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 2 {

--- a/src/messages/delete_topics_request.rs
+++ b/src/messages/delete_topics_request.rs
@@ -73,14 +73,14 @@ impl Encodable for DeleteTopicState {
             types::CompactString.encode(buf, &self.name)?;
         } else {
             if !self.name.is_none() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 6 {
             types::Uuid.encode(buf, &self.topic_id)?;
         } else {
             if &self.topic_id != &Uuid::nil() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {
@@ -103,14 +103,14 @@ impl Encodable for DeleteTopicState {
             total_size += types::CompactString.compute_size(&self.name)?;
         } else {
             if !self.name.is_none() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 6 {
             total_size += types::Uuid.compute_size(&self.topic_id)?;
         } else {
             if &self.topic_id != &Uuid::nil() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {
@@ -245,7 +245,7 @@ impl Encodable for DeleteTopicsRequest {
             types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
         } else {
             if !self.topics.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version <= 5 {
@@ -277,7 +277,7 @@ impl Encodable for DeleteTopicsRequest {
                 types::CompactArray(types::Struct { version }).compute_size(&self.topics)?;
         } else {
             if !self.topics.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version <= 5 {

--- a/src/messages/describe_acls_request.rs
+++ b/src/messages/describe_acls_request.rs
@@ -149,7 +149,7 @@ impl Encodable for DescribeAclsRequest {
             types::Int8.encode(buf, &self.pattern_type_filter)?;
         } else {
             if self.pattern_type_filter != 3 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 2 {
@@ -190,7 +190,7 @@ impl Encodable for DescribeAclsRequest {
             total_size += types::Int8.compute_size(&self.pattern_type_filter)?;
         } else {
             if self.pattern_type_filter != 3 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 2 {

--- a/src/messages/describe_acls_response.rs
+++ b/src/messages/describe_acls_response.rs
@@ -295,7 +295,7 @@ impl Encodable for DescribeAclsResource {
             types::Int8.encode(buf, &self.pattern_type)?;
         } else {
             if self.pattern_type != 3 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 2 {
@@ -329,7 +329,7 @@ impl Encodable for DescribeAclsResource {
             total_size += types::Int8.compute_size(&self.pattern_type)?;
         } else {
             if self.pattern_type != 3 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 2 {

--- a/src/messages/describe_cluster_request.rs
+++ b/src/messages/describe_cluster_request.rs
@@ -74,7 +74,7 @@ impl Encodable for DescribeClusterRequest {
             types::Int8.encode(buf, &self.endpoint_type)?;
         } else {
             if self.endpoint_type != 1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -96,7 +96,7 @@ impl Encodable for DescribeClusterRequest {
             total_size += types::Int8.compute_size(&self.endpoint_type)?;
         } else {
             if self.endpoint_type != 1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         let num_tagged_fields = self.unknown_tagged_fields.len();

--- a/src/messages/describe_cluster_response.rs
+++ b/src/messages/describe_cluster_response.rs
@@ -318,7 +318,7 @@ impl Encodable for DescribeClusterResponse {
             types::Int8.encode(buf, &self.endpoint_type)?;
         } else {
             if self.endpoint_type != 1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         types::CompactString.encode(buf, &self.cluster_id)?;
@@ -346,7 +346,7 @@ impl Encodable for DescribeClusterResponse {
             total_size += types::Int8.compute_size(&self.endpoint_type)?;
         } else {
             if self.endpoint_type != 1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         total_size += types::CompactString.compute_size(&self.cluster_id)?;

--- a/src/messages/describe_configs_request.rs
+++ b/src/messages/describe_configs_request.rs
@@ -92,14 +92,14 @@ impl Encodable for DescribeConfigsRequest {
             types::Boolean.encode(buf, &self.include_synonyms)?;
         } else {
             if self.include_synonyms {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
             types::Boolean.encode(buf, &self.include_documentation)?;
         } else {
             if self.include_documentation {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {
@@ -128,14 +128,14 @@ impl Encodable for DescribeConfigsRequest {
             total_size += types::Boolean.compute_size(&self.include_synonyms)?;
         } else {
             if self.include_synonyms {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
             total_size += types::Boolean.compute_size(&self.include_documentation)?;
         } else {
             if self.include_documentation {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {

--- a/src/messages/describe_configs_response.rs
+++ b/src/messages/describe_configs_response.rs
@@ -182,7 +182,7 @@ impl Encodable for DescribeConfigsResourceResult {
             types::Boolean.encode(buf, &self.is_default)?;
         } else {
             if self.is_default {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 1 {
@@ -237,7 +237,7 @@ impl Encodable for DescribeConfigsResourceResult {
             total_size += types::Boolean.compute_size(&self.is_default)?;
         } else {
             if self.is_default {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 1 {
@@ -807,7 +807,7 @@ impl Encodable for DescribeConfigsSynonym {
             }
         } else {
             if !self.name.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 1 {
@@ -823,14 +823,14 @@ impl Encodable for DescribeConfigsSynonym {
                 .map(|x| x.is_empty())
                 .unwrap_or_default()
             {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 1 {
             types::Int8.encode(buf, &self.source)?;
         } else {
             if self.source != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {
@@ -857,7 +857,7 @@ impl Encodable for DescribeConfigsSynonym {
             }
         } else {
             if !self.name.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 1 {
@@ -873,14 +873,14 @@ impl Encodable for DescribeConfigsSynonym {
                 .map(|x| x.is_empty())
                 .unwrap_or_default()
             {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 1 {
             total_size += types::Int8.compute_size(&self.source)?;
         } else {
             if self.source != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {

--- a/src/messages/describe_delegation_token_response.rs
+++ b/src/messages/describe_delegation_token_response.rs
@@ -353,14 +353,14 @@ impl Encodable for DescribedDelegationToken {
             types::CompactString.encode(buf, &self.token_requester_principal_type)?;
         } else {
             if !self.token_requester_principal_type.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
             types::CompactString.encode(buf, &self.token_requester_principal_name)?;
         } else {
             if !self.token_requester_principal_name.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         types::Int64.encode(buf, &self.issue_timestamp)?;
@@ -412,7 +412,7 @@ impl Encodable for DescribedDelegationToken {
                 types::CompactString.compute_size(&self.token_requester_principal_type)?;
         } else {
             if !self.token_requester_principal_type.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
@@ -420,7 +420,7 @@ impl Encodable for DescribedDelegationToken {
                 types::CompactString.compute_size(&self.token_requester_principal_name)?;
         } else {
             if !self.token_requester_principal_name.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         total_size += types::Int64.compute_size(&self.issue_timestamp)?;

--- a/src/messages/describe_groups_request.rs
+++ b/src/messages/describe_groups_request.rs
@@ -78,7 +78,7 @@ impl Encodable for DescribeGroupsRequest {
             types::Boolean.encode(buf, &self.include_authorized_operations)?;
         } else {
             if self.include_authorized_operations {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 5 {
@@ -106,7 +106,7 @@ impl Encodable for DescribeGroupsRequest {
             total_size += types::Boolean.compute_size(&self.include_authorized_operations)?;
         } else {
             if self.include_authorized_operations {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 5 {

--- a/src/messages/describe_groups_response.rs
+++ b/src/messages/describe_groups_response.rs
@@ -316,7 +316,7 @@ impl Encodable for DescribedGroup {
             types::Int32.encode(buf, &self.authorized_operations)?;
         } else {
             if self.authorized_operations != -2147483648 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 5 {
@@ -366,7 +366,7 @@ impl Encodable for DescribedGroup {
             total_size += types::Int32.compute_size(&self.authorized_operations)?;
         } else {
             if self.authorized_operations != -2147483648 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 5 {

--- a/src/messages/elect_leaders_request.rs
+++ b/src/messages/elect_leaders_request.rs
@@ -87,7 +87,7 @@ impl Encodable for ElectLeadersRequest {
             types::Int8.encode(buf, &self.election_type)?;
         } else {
             if self.election_type != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 2 {
@@ -116,7 +116,7 @@ impl Encodable for ElectLeadersRequest {
             total_size += types::Int8.compute_size(&self.election_type)?;
         } else {
             if self.election_type != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 2 {

--- a/src/messages/elect_leaders_response.rs
+++ b/src/messages/elect_leaders_response.rs
@@ -88,7 +88,7 @@ impl Encodable for ElectLeadersResponse {
             types::Int16.encode(buf, &self.error_code)?;
         } else {
             if self.error_code != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 2 {
@@ -118,7 +118,7 @@ impl Encodable for ElectLeadersResponse {
             total_size += types::Int16.compute_size(&self.error_code)?;
         } else {
             if self.error_code != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 2 {

--- a/src/messages/fetch_request.rs
+++ b/src/messages/fetch_request.rs
@@ -134,7 +134,7 @@ impl Encodable for FetchPartition {
             types::Int32.encode(buf, &self.last_fetched_epoch)?;
         } else {
             if self.last_fetched_epoch != -1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 5 {
@@ -166,7 +166,7 @@ impl Encodable for FetchPartition {
             total_size += types::Int32.compute_size(&self.last_fetched_epoch)?;
         } else {
             if self.last_fetched_epoch != -1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 5 {
@@ -447,7 +447,7 @@ impl Encodable for FetchRequest {
             types::Int32.encode(buf, &self.replica_id)?;
         } else {
             if self.replica_id != -1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         types::Int32.encode(buf, &self.max_wait_ms)?;
@@ -478,7 +478,7 @@ impl Encodable for FetchRequest {
             }
         } else {
             if !self.forgotten_topics_data.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 11 {
@@ -542,7 +542,7 @@ impl Encodable for FetchRequest {
             total_size += types::Int32.compute_size(&self.replica_id)?;
         } else {
             if self.replica_id != -1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         total_size += types::Int32.compute_size(&self.max_wait_ms)?;
@@ -575,7 +575,7 @@ impl Encodable for FetchRequest {
             }
         } else {
             if !self.forgotten_topics_data.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 11 {
@@ -1027,7 +1027,7 @@ impl Encodable for ForgottenTopic {
             }
         } else {
             if !self.partitions.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 12 {
@@ -1064,7 +1064,7 @@ impl Encodable for ForgottenTopic {
             }
         } else {
             if !self.partitions.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 12 {
@@ -1200,14 +1200,14 @@ impl Encodable for ReplicaState {
             types::Int32.encode(buf, &self.replica_id)?;
         } else {
             if self.replica_id != -1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 15 {
             types::Int64.encode(buf, &self.replica_epoch)?;
         } else {
             if self.replica_epoch != -1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 12 {
@@ -1230,14 +1230,14 @@ impl Encodable for ReplicaState {
             total_size += types::Int32.compute_size(&self.replica_id)?;
         } else {
             if self.replica_id != -1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 15 {
             total_size += types::Int64.compute_size(&self.replica_epoch)?;
         } else {
             if self.replica_epoch != -1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 12 {

--- a/src/messages/fetch_response.rs
+++ b/src/messages/fetch_response.rs
@@ -73,14 +73,14 @@ impl Encodable for AbortedTransaction {
             types::Int64.encode(buf, &self.producer_id)?;
         } else {
             if self.producer_id != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {
             types::Int64.encode(buf, &self.first_offset)?;
         } else {
             if self.first_offset != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 12 {
@@ -103,14 +103,14 @@ impl Encodable for AbortedTransaction {
             total_size += types::Int64.compute_size(&self.producer_id)?;
         } else {
             if self.producer_id != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {
             total_size += types::Int64.compute_size(&self.first_offset)?;
         } else {
             if self.first_offset != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 12 {
@@ -231,14 +231,14 @@ impl Encodable for EpochEndOffset {
             types::Int32.encode(buf, &self.epoch)?;
         } else {
             if self.epoch != -1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 12 {
             types::Int64.encode(buf, &self.end_offset)?;
         } else {
             if self.end_offset != -1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 12 {
@@ -261,14 +261,14 @@ impl Encodable for EpochEndOffset {
             total_size += types::Int32.compute_size(&self.epoch)?;
         } else {
             if self.epoch != -1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 12 {
             total_size += types::Int64.compute_size(&self.end_offset)?;
         } else {
             if self.end_offset != -1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 12 {
@@ -437,7 +437,7 @@ impl Encodable for FetchResponse {
             types::Int32.encode(buf, &self.session_id)?;
         } else {
             if self.session_id != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 12 {
@@ -491,7 +491,7 @@ impl Encodable for FetchResponse {
             total_size += types::Int32.compute_size(&self.session_id)?;
         } else {
             if self.session_id != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 12 {
@@ -852,14 +852,14 @@ impl Encodable for LeaderIdAndEpoch {
             types::Int32.encode(buf, &self.leader_id)?;
         } else {
             if self.leader_id != -1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 12 {
             types::Int32.encode(buf, &self.leader_epoch)?;
         } else {
             if self.leader_epoch != -1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 12 {
@@ -882,14 +882,14 @@ impl Encodable for LeaderIdAndEpoch {
             total_size += types::Int32.compute_size(&self.leader_id)?;
         } else {
             if self.leader_id != -1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 12 {
             total_size += types::Int32.compute_size(&self.leader_epoch)?;
         } else {
             if self.leader_epoch != -1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 12 {
@@ -1038,28 +1038,28 @@ impl Encodable for NodeEndpoint {
             types::Int32.encode(buf, &self.node_id)?;
         } else {
             if self.node_id != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 16 {
             types::CompactString.encode(buf, &self.host)?;
         } else {
             if !self.host.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 16 {
             types::Int32.encode(buf, &self.port)?;
         } else {
             if self.port != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 16 {
             types::CompactString.encode(buf, &self.rack)?;
         } else {
             if !self.rack.is_none() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 12 {
@@ -1082,28 +1082,28 @@ impl Encodable for NodeEndpoint {
             total_size += types::Int32.compute_size(&self.node_id)?;
         } else {
             if self.node_id != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 16 {
             total_size += types::CompactString.compute_size(&self.host)?;
         } else {
             if !self.host.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 16 {
             total_size += types::Int32.compute_size(&self.port)?;
         } else {
             if self.port != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 16 {
             total_size += types::CompactString.compute_size(&self.rack)?;
         } else {
             if !self.rack.is_none() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 12 {
@@ -1381,7 +1381,7 @@ impl Encodable for PartitionData {
             types::Int32.encode(buf, &self.preferred_read_replica)?;
         } else {
             if self.preferred_read_replica != -1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 12 {
@@ -1473,7 +1473,7 @@ impl Encodable for PartitionData {
             total_size += types::Int32.compute_size(&self.preferred_read_replica)?;
         } else {
             if self.preferred_read_replica != -1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 12 {

--- a/src/messages/find_coordinator_request.rs
+++ b/src/messages/find_coordinator_request.rs
@@ -91,21 +91,21 @@ impl Encodable for FindCoordinatorRequest {
             }
         } else {
             if !self.key.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 1 {
             types::Int8.encode(buf, &self.key_type)?;
         } else {
             if self.key_type != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {
             types::CompactArray(types::CompactString).encode(buf, &self.coordinator_keys)?;
         } else {
             if !self.coordinator_keys.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
@@ -132,14 +132,14 @@ impl Encodable for FindCoordinatorRequest {
             }
         } else {
             if !self.key.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 1 {
             total_size += types::Int8.compute_size(&self.key_type)?;
         } else {
             if self.key_type != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {
@@ -147,7 +147,7 @@ impl Encodable for FindCoordinatorRequest {
                 types::CompactArray(types::CompactString).compute_size(&self.coordinator_keys)?;
         } else {
             if !self.coordinator_keys.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {

--- a/src/messages/find_coordinator_response.rs
+++ b/src/messages/find_coordinator_response.rs
@@ -129,35 +129,35 @@ impl Encodable for Coordinator {
             types::CompactString.encode(buf, &self.key)?;
         } else {
             if !self.key.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {
             types::Int32.encode(buf, &self.node_id)?;
         } else {
             if self.node_id != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {
             types::CompactString.encode(buf, &self.host)?;
         } else {
             if !self.host.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {
             types::Int32.encode(buf, &self.port)?;
         } else {
             if self.port != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {
             types::Int16.encode(buf, &self.error_code)?;
         } else {
             if self.error_code != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {
@@ -183,35 +183,35 @@ impl Encodable for Coordinator {
             total_size += types::CompactString.compute_size(&self.key)?;
         } else {
             if !self.key.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {
             total_size += types::Int32.compute_size(&self.node_id)?;
         } else {
             if self.node_id != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {
             total_size += types::CompactString.compute_size(&self.host)?;
         } else {
             if !self.host.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {
             total_size += types::Int32.compute_size(&self.port)?;
         } else {
             if self.port != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {
             total_size += types::Int16.compute_size(&self.error_code)?;
         } else {
             if self.error_code != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {
@@ -436,7 +436,7 @@ impl Encodable for FindCoordinatorResponse {
             types::Int16.encode(buf, &self.error_code)?;
         } else {
             if self.error_code != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 1 && version <= 3 {
@@ -450,7 +450,7 @@ impl Encodable for FindCoordinatorResponse {
             types::Int32.encode(buf, &self.node_id)?;
         } else {
             if self.node_id != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version <= 3 {
@@ -461,21 +461,21 @@ impl Encodable for FindCoordinatorResponse {
             }
         } else {
             if !self.host.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version <= 3 {
             types::Int32.encode(buf, &self.port)?;
         } else {
             if self.port != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.coordinators)?;
         } else {
             if !self.coordinators.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
@@ -501,7 +501,7 @@ impl Encodable for FindCoordinatorResponse {
             total_size += types::Int16.compute_size(&self.error_code)?;
         } else {
             if self.error_code != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 1 && version <= 3 {
@@ -515,7 +515,7 @@ impl Encodable for FindCoordinatorResponse {
             total_size += types::Int32.compute_size(&self.node_id)?;
         } else {
             if self.node_id != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version <= 3 {
@@ -526,14 +526,14 @@ impl Encodable for FindCoordinatorResponse {
             }
         } else {
             if !self.host.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version <= 3 {
             total_size += types::Int32.compute_size(&self.port)?;
         } else {
             if self.port != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {
@@ -541,7 +541,7 @@ impl Encodable for FindCoordinatorResponse {
                 types::CompactArray(types::Struct { version }).compute_size(&self.coordinators)?;
         } else {
             if !self.coordinators.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {

--- a/src/messages/heartbeat_request.rs
+++ b/src/messages/heartbeat_request.rs
@@ -116,7 +116,7 @@ impl Encodable for HeartbeatRequest {
             }
         } else {
             if !self.group_instance_id.is_none() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {
@@ -154,7 +154,7 @@ impl Encodable for HeartbeatRequest {
             }
         } else {
             if !self.group_instance_id.is_none() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {

--- a/src/messages/init_producer_id_request.rs
+++ b/src/messages/init_producer_id_request.rs
@@ -107,14 +107,14 @@ impl Encodable for InitProducerIdRequest {
             types::Int64.encode(buf, &self.producer_id)?;
         } else {
             if self.producer_id != -1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
             types::Int16.encode(buf, &self.producer_epoch)?;
         } else {
             if self.producer_epoch != -1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 2 {
@@ -143,14 +143,14 @@ impl Encodable for InitProducerIdRequest {
             total_size += types::Int64.compute_size(&self.producer_id)?;
         } else {
             if self.producer_id != -1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
             total_size += types::Int16.compute_size(&self.producer_epoch)?;
         } else {
             if self.producer_epoch != -1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 2 {

--- a/src/messages/join_group_request.rs
+++ b/src/messages/join_group_request.rs
@@ -175,7 +175,7 @@ impl Encodable for JoinGroupRequest {
             }
         } else {
             if !self.group_instance_id.is_none() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 6 {
@@ -229,7 +229,7 @@ impl Encodable for JoinGroupRequest {
             }
         } else {
             if !self.group_instance_id.is_none() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 6 {

--- a/src/messages/join_group_response.rs
+++ b/src/messages/join_group_response.rs
@@ -189,7 +189,7 @@ impl Encodable for JoinGroupResponse {
             types::Boolean.encode(buf, &self.skip_assignment)?;
         } else {
             if self.skip_assignment {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 6 {
@@ -240,7 +240,7 @@ impl Encodable for JoinGroupResponse {
             total_size += types::Boolean.compute_size(&self.skip_assignment)?;
         } else {
             if self.skip_assignment {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 6 {

--- a/src/messages/leader_and_isr_request.rs
+++ b/src/messages/leader_and_isr_request.rs
@@ -405,7 +405,7 @@ impl Encodable for LeaderAndIsrPartitionState {
             types::Int8.encode(buf, &self.leader_recovery_state)?;
         } else {
             if self.leader_recovery_state != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {
@@ -465,7 +465,7 @@ impl Encodable for LeaderAndIsrPartitionState {
             total_size += types::Int8.compute_size(&self.leader_recovery_state)?;
         } else {
             if self.leader_recovery_state != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {
@@ -732,7 +732,7 @@ impl Encodable for LeaderAndIsrRequest {
             types::Boolean.encode(buf, &self.is_k_raft_controller)?;
         } else {
             if self.is_k_raft_controller {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         types::Int32.encode(buf, &self.controller_epoch)?;
@@ -743,7 +743,7 @@ impl Encodable for LeaderAndIsrRequest {
             types::Int8.encode(buf, &self._type)?;
         } else {
             if self._type != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version <= 1 {
@@ -751,7 +751,7 @@ impl Encodable for LeaderAndIsrRequest {
                 .encode(buf, &self.ungrouped_partition_states)?;
         } else {
             if !self.ungrouped_partition_states.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 2 {
@@ -762,7 +762,7 @@ impl Encodable for LeaderAndIsrRequest {
             }
         } else {
             if !self.topic_states.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {
@@ -791,7 +791,7 @@ impl Encodable for LeaderAndIsrRequest {
             total_size += types::Boolean.compute_size(&self.is_k_raft_controller)?;
         } else {
             if self.is_k_raft_controller {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         total_size += types::Int32.compute_size(&self.controller_epoch)?;
@@ -802,7 +802,7 @@ impl Encodable for LeaderAndIsrRequest {
             total_size += types::Int8.compute_size(&self._type)?;
         } else {
             if self._type != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version <= 1 {
@@ -810,7 +810,7 @@ impl Encodable for LeaderAndIsrRequest {
                 .compute_size(&self.ungrouped_partition_states)?;
         } else {
             if !self.ungrouped_partition_states.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 2 {
@@ -823,7 +823,7 @@ impl Encodable for LeaderAndIsrRequest {
             }
         } else {
             if !self.topic_states.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {
@@ -1007,7 +1007,7 @@ impl Encodable for LeaderAndIsrTopicState {
             }
         } else {
             if !self.topic_name.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 5 {
@@ -1022,7 +1022,7 @@ impl Encodable for LeaderAndIsrTopicState {
             }
         } else {
             if !self.partition_states.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {
@@ -1049,7 +1049,7 @@ impl Encodable for LeaderAndIsrTopicState {
             }
         } else {
             if !self.topic_name.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 5 {
@@ -1065,7 +1065,7 @@ impl Encodable for LeaderAndIsrTopicState {
             }
         } else {
             if !self.partition_states.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {

--- a/src/messages/leader_and_isr_response.rs
+++ b/src/messages/leader_and_isr_response.rs
@@ -258,14 +258,14 @@ impl Encodable for LeaderAndIsrResponse {
             }
         } else {
             if !self.partition_errors.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 5 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
         } else {
             if !self.topics.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {
@@ -295,7 +295,7 @@ impl Encodable for LeaderAndIsrResponse {
             }
         } else {
             if !self.partition_errors.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 5 {
@@ -303,7 +303,7 @@ impl Encodable for LeaderAndIsrResponse {
                 types::CompactArray(types::Struct { version }).compute_size(&self.topics)?;
         } else {
             if !self.topics.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {
@@ -431,14 +431,14 @@ impl Encodable for LeaderAndIsrTopicError {
             types::Uuid.encode(buf, &self.topic_id)?;
         } else {
             if &self.topic_id != &Uuid::nil() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 5 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.partition_errors)?;
         } else {
             if !self.partition_errors.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {
@@ -461,7 +461,7 @@ impl Encodable for LeaderAndIsrTopicError {
             total_size += types::Uuid.compute_size(&self.topic_id)?;
         } else {
             if &self.topic_id != &Uuid::nil() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 5 {
@@ -469,7 +469,7 @@ impl Encodable for LeaderAndIsrTopicError {
                 .compute_size(&self.partition_errors)?;
         } else {
             if !self.partition_errors.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {

--- a/src/messages/leave_group_request.rs
+++ b/src/messages/leave_group_request.rs
@@ -92,7 +92,7 @@ impl Encodable for LeaveGroupRequest {
             types::String.encode(buf, &self.member_id)?;
         } else {
             if !self.member_id.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
@@ -103,7 +103,7 @@ impl Encodable for LeaveGroupRequest {
             }
         } else {
             if !self.members.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {
@@ -131,7 +131,7 @@ impl Encodable for LeaveGroupRequest {
             total_size += types::String.compute_size(&self.member_id)?;
         } else {
             if !self.member_id.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
@@ -144,7 +144,7 @@ impl Encodable for LeaveGroupRequest {
             }
         } else {
             if !self.members.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {
@@ -294,7 +294,7 @@ impl Encodable for MemberIdentity {
             }
         } else {
             if !self.member_id.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
@@ -305,7 +305,7 @@ impl Encodable for MemberIdentity {
             }
         } else {
             if !self.group_instance_id.is_none() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 5 {
@@ -335,7 +335,7 @@ impl Encodable for MemberIdentity {
             }
         } else {
             if !self.member_id.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
@@ -346,7 +346,7 @@ impl Encodable for MemberIdentity {
             }
         } else {
             if !self.group_instance_id.is_none() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 5 {

--- a/src/messages/leave_group_response.rs
+++ b/src/messages/leave_group_response.rs
@@ -95,7 +95,7 @@ impl Encodable for LeaveGroupResponse {
             }
         } else {
             if !self.members.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {
@@ -128,7 +128,7 @@ impl Encodable for LeaveGroupResponse {
             }
         } else {
             if !self.members.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {
@@ -274,7 +274,7 @@ impl Encodable for MemberResponse {
             }
         } else {
             if !self.member_id.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
@@ -290,14 +290,14 @@ impl Encodable for MemberResponse {
                 .map(|x| x.is_empty())
                 .unwrap_or_default()
             {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
             types::Int16.encode(buf, &self.error_code)?;
         } else {
             if self.error_code != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {
@@ -324,7 +324,7 @@ impl Encodable for MemberResponse {
             }
         } else {
             if !self.member_id.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
@@ -340,14 +340,14 @@ impl Encodable for MemberResponse {
                 .map(|x| x.is_empty())
                 .unwrap_or_default()
             {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
             total_size += types::Int16.compute_size(&self.error_code)?;
         } else {
             if self.error_code != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {

--- a/src/messages/list_groups_request.rs
+++ b/src/messages/list_groups_request.rs
@@ -73,14 +73,14 @@ impl Encodable for ListGroupsRequest {
             types::CompactArray(types::CompactString).encode(buf, &self.states_filter)?;
         } else {
             if !self.states_filter.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 5 {
             types::CompactArray(types::CompactString).encode(buf, &self.types_filter)?;
         } else {
             if !self.types_filter.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
@@ -104,7 +104,7 @@ impl Encodable for ListGroupsRequest {
                 types::CompactArray(types::CompactString).compute_size(&self.states_filter)?;
         } else {
             if !self.states_filter.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 5 {
@@ -112,7 +112,7 @@ impl Encodable for ListGroupsRequest {
                 types::CompactArray(types::CompactString).compute_size(&self.types_filter)?;
         } else {
             if !self.types_filter.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {

--- a/src/messages/list_offsets_request.rs
+++ b/src/messages/list_offsets_request.rs
@@ -106,7 +106,7 @@ impl Encodable for ListOffsetsPartition {
             types::Int32.encode(buf, &self.max_num_offsets)?;
         } else {
             if self.max_num_offsets != 1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 6 {
@@ -134,7 +134,7 @@ impl Encodable for ListOffsetsPartition {
             total_size += types::Int32.compute_size(&self.max_num_offsets)?;
         } else {
             if self.max_num_offsets != 1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 6 {
@@ -276,7 +276,7 @@ impl Encodable for ListOffsetsRequest {
             types::Int8.encode(buf, &self.isolation_level)?;
         } else {
             if self.isolation_level != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 6 {
@@ -305,7 +305,7 @@ impl Encodable for ListOffsetsRequest {
             total_size += types::Int8.compute_size(&self.isolation_level)?;
         } else {
             if self.isolation_level != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 6 {

--- a/src/messages/list_offsets_response.rs
+++ b/src/messages/list_offsets_response.rs
@@ -131,28 +131,28 @@ impl Encodable for ListOffsetsPartitionResponse {
             types::Array(types::Int64).encode(buf, &self.old_style_offsets)?;
         } else {
             if !self.old_style_offsets.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 1 {
             types::Int64.encode(buf, &self.timestamp)?;
         } else {
             if self.timestamp != -1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 1 {
             types::Int64.encode(buf, &self.offset)?;
         } else {
             if self.offset != -1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {
             types::Int32.encode(buf, &self.leader_epoch)?;
         } else {
             if self.leader_epoch != -1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 6 {
@@ -177,28 +177,28 @@ impl Encodable for ListOffsetsPartitionResponse {
             total_size += types::Array(types::Int64).compute_size(&self.old_style_offsets)?;
         } else {
             if !self.old_style_offsets.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 1 {
             total_size += types::Int64.compute_size(&self.timestamp)?;
         } else {
             if self.timestamp != -1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 1 {
             total_size += types::Int64.compute_size(&self.offset)?;
         } else {
             if self.offset != -1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 4 {
             total_size += types::Int32.compute_size(&self.leader_epoch)?;
         } else {
             if self.leader_epoch != -1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 6 {

--- a/src/messages/list_transactions_request.rs
+++ b/src/messages/list_transactions_request.rs
@@ -89,7 +89,7 @@ impl Encodable for ListTransactionsRequest {
             types::Int64.encode(buf, &self.duration_filter)?;
         } else {
             if self.duration_filter != -1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -113,7 +113,7 @@ impl Encodable for ListTransactionsRequest {
             total_size += types::Int64.compute_size(&self.duration_filter)?;
         } else {
             if self.duration_filter != -1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         let num_tagged_fields = self.unknown_tagged_fields.len();

--- a/src/messages/metadata_request.rs
+++ b/src/messages/metadata_request.rs
@@ -106,21 +106,21 @@ impl Encodable for MetadataRequest {
             types::Boolean.encode(buf, &self.allow_auto_topic_creation)?;
         } else {
             if !self.allow_auto_topic_creation {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 8 && version <= 10 {
             types::Boolean.encode(buf, &self.include_cluster_authorized_operations)?;
         } else {
             if self.include_cluster_authorized_operations {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 8 {
             types::Boolean.encode(buf, &self.include_topic_authorized_operations)?;
         } else {
             if self.include_topic_authorized_operations {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 9 {
@@ -149,7 +149,7 @@ impl Encodable for MetadataRequest {
             total_size += types::Boolean.compute_size(&self.allow_auto_topic_creation)?;
         } else {
             if !self.allow_auto_topic_creation {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 8 && version <= 10 {
@@ -157,14 +157,14 @@ impl Encodable for MetadataRequest {
                 types::Boolean.compute_size(&self.include_cluster_authorized_operations)?;
         } else {
             if self.include_cluster_authorized_operations {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 8 {
             total_size += types::Boolean.compute_size(&self.include_topic_authorized_operations)?;
         } else {
             if self.include_topic_authorized_operations {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 9 {

--- a/src/messages/metadata_response.rs
+++ b/src/messages/metadata_response.rs
@@ -152,7 +152,7 @@ impl Encodable for MetadataResponse {
             types::Int32.encode(buf, &self.cluster_authorized_operations)?;
         } else {
             if self.cluster_authorized_operations != -2147483648 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 9 {
@@ -200,7 +200,7 @@ impl Encodable for MetadataResponse {
             total_size += types::Int32.compute_size(&self.cluster_authorized_operations)?;
         } else {
             if self.cluster_authorized_operations != -2147483648 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 9 {
@@ -896,7 +896,7 @@ impl Encodable for MetadataResponseTopic {
             types::Int32.encode(buf, &self.topic_authorized_operations)?;
         } else {
             if self.topic_authorized_operations != -2147483648 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 9 {
@@ -937,7 +937,7 @@ impl Encodable for MetadataResponseTopic {
             total_size += types::Int32.compute_size(&self.topic_authorized_operations)?;
         } else {
             if self.topic_authorized_operations != -2147483648 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 9 {

--- a/src/messages/offset_commit_request.rs
+++ b/src/messages/offset_commit_request.rs
@@ -148,7 +148,7 @@ impl Encodable for OffsetCommitRequest {
             }
         } else {
             if !self.group_instance_id.is_none() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 2 && version <= 4 {
@@ -198,7 +198,7 @@ impl Encodable for OffsetCommitRequest {
             }
         } else {
             if !self.group_instance_id.is_none() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 2 && version <= 4 {
@@ -411,7 +411,7 @@ impl Encodable for OffsetCommitRequestPartition {
             types::Int64.encode(buf, &self.commit_timestamp)?;
         } else {
             if self.commit_timestamp != -1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 8 {
@@ -444,7 +444,7 @@ impl Encodable for OffsetCommitRequestPartition {
             total_size += types::Int64.compute_size(&self.commit_timestamp)?;
         } else {
             if self.commit_timestamp != -1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 8 {

--- a/src/messages/offset_fetch_request.rs
+++ b/src/messages/offset_fetch_request.rs
@@ -105,7 +105,7 @@ impl Encodable for OffsetFetchRequest {
             }
         } else {
             if !self.group_id.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version <= 7 {
@@ -121,21 +121,21 @@ impl Encodable for OffsetFetchRequest {
                 .map(|x| x.is_empty())
                 .unwrap_or_default()
             {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 8 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.groups)?;
         } else {
             if !self.groups.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 7 {
             types::Boolean.encode(buf, &self.require_stable)?;
         } else {
             if self.require_stable {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 6 {
@@ -162,7 +162,7 @@ impl Encodable for OffsetFetchRequest {
             }
         } else {
             if !self.group_id.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version <= 7 {
@@ -179,7 +179,7 @@ impl Encodable for OffsetFetchRequest {
                 .map(|x| x.is_empty())
                 .unwrap_or_default()
             {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 8 {
@@ -187,14 +187,14 @@ impl Encodable for OffsetFetchRequest {
                 types::CompactArray(types::Struct { version }).compute_size(&self.groups)?;
         } else {
             if !self.groups.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 7 {
             total_size += types::Boolean.compute_size(&self.require_stable)?;
         } else {
             if self.require_stable {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 6 {
@@ -365,7 +365,7 @@ impl Encodable for OffsetFetchRequestGroup {
             types::CompactString.encode(buf, &self.group_id)?;
         } else {
             if !self.group_id.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 9 {
@@ -383,7 +383,7 @@ impl Encodable for OffsetFetchRequestGroup {
                 .map(|x| x.is_empty())
                 .unwrap_or_default()
             {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 6 {
@@ -406,7 +406,7 @@ impl Encodable for OffsetFetchRequestGroup {
             total_size += types::CompactString.compute_size(&self.group_id)?;
         } else {
             if !self.group_id.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 9 {
@@ -425,7 +425,7 @@ impl Encodable for OffsetFetchRequestGroup {
                 .map(|x| x.is_empty())
                 .unwrap_or_default()
             {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 6 {
@@ -564,7 +564,7 @@ impl Encodable for OffsetFetchRequestTopic {
             }
         } else {
             if !self.name.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version <= 7 {
@@ -575,7 +575,7 @@ impl Encodable for OffsetFetchRequestTopic {
             }
         } else {
             if !self.partition_indexes.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 6 {
@@ -602,7 +602,7 @@ impl Encodable for OffsetFetchRequestTopic {
             }
         } else {
             if !self.name.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version <= 7 {
@@ -614,7 +614,7 @@ impl Encodable for OffsetFetchRequestTopic {
             }
         } else {
             if !self.partition_indexes.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 6 {
@@ -743,14 +743,14 @@ impl Encodable for OffsetFetchRequestTopics {
             types::CompactString.encode(buf, &self.name)?;
         } else {
             if !self.name.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 8 {
             types::CompactArray(types::Int32).encode(buf, &self.partition_indexes)?;
         } else {
             if !self.partition_indexes.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 6 {
@@ -773,7 +773,7 @@ impl Encodable for OffsetFetchRequestTopics {
             total_size += types::CompactString.compute_size(&self.name)?;
         } else {
             if !self.name.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 8 {
@@ -781,7 +781,7 @@ impl Encodable for OffsetFetchRequestTopics {
                 types::CompactArray(types::Int32).compute_size(&self.partition_indexes)?;
         } else {
             if !self.partition_indexes.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 6 {

--- a/src/messages/offset_fetch_response.rs
+++ b/src/messages/offset_fetch_response.rs
@@ -108,7 +108,7 @@ impl Encodable for OffsetFetchResponse {
             }
         } else {
             if !self.topics.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 2 && version <= 7 {
@@ -118,7 +118,7 @@ impl Encodable for OffsetFetchResponse {
             types::CompactArray(types::Struct { version }).encode(buf, &self.groups)?;
         } else {
             if !self.groups.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 6 {
@@ -149,7 +149,7 @@ impl Encodable for OffsetFetchResponse {
             }
         } else {
             if !self.topics.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 2 && version <= 7 {
@@ -160,7 +160,7 @@ impl Encodable for OffsetFetchResponse {
                 types::CompactArray(types::Struct { version }).compute_size(&self.groups)?;
         } else {
             if !self.groups.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 6 {
@@ -313,21 +313,21 @@ impl Encodable for OffsetFetchResponseGroup {
             types::CompactString.encode(buf, &self.group_id)?;
         } else {
             if !self.group_id.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 8 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
         } else {
             if !self.topics.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 8 {
             types::Int16.encode(buf, &self.error_code)?;
         } else {
             if self.error_code != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 6 {
@@ -350,7 +350,7 @@ impl Encodable for OffsetFetchResponseGroup {
             total_size += types::CompactString.compute_size(&self.group_id)?;
         } else {
             if !self.group_id.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 8 {
@@ -358,14 +358,14 @@ impl Encodable for OffsetFetchResponseGroup {
                 types::CompactArray(types::Struct { version }).compute_size(&self.topics)?;
         } else {
             if !self.topics.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 8 {
             total_size += types::Int16.compute_size(&self.error_code)?;
         } else {
             if self.error_code != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 6 {
@@ -535,14 +535,14 @@ impl Encodable for OffsetFetchResponsePartition {
             types::Int32.encode(buf, &self.partition_index)?;
         } else {
             if self.partition_index != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version <= 7 {
             types::Int64.encode(buf, &self.committed_offset)?;
         } else {
             if self.committed_offset != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 5 && version <= 7 {
@@ -561,14 +561,14 @@ impl Encodable for OffsetFetchResponsePartition {
                 .map(|x| x.is_empty())
                 .unwrap_or_default()
             {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version <= 7 {
             types::Int16.encode(buf, &self.error_code)?;
         } else {
             if self.error_code != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 6 {
@@ -591,14 +591,14 @@ impl Encodable for OffsetFetchResponsePartition {
             total_size += types::Int32.compute_size(&self.partition_index)?;
         } else {
             if self.partition_index != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version <= 7 {
             total_size += types::Int64.compute_size(&self.committed_offset)?;
         } else {
             if self.committed_offset != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 5 && version <= 7 {
@@ -617,14 +617,14 @@ impl Encodable for OffsetFetchResponsePartition {
                 .map(|x| x.is_empty())
                 .unwrap_or_default()
             {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version <= 7 {
             total_size += types::Int16.compute_size(&self.error_code)?;
         } else {
             if self.error_code != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 6 {
@@ -812,14 +812,14 @@ impl Encodable for OffsetFetchResponsePartitions {
             types::Int32.encode(buf, &self.partition_index)?;
         } else {
             if self.partition_index != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 8 {
             types::Int64.encode(buf, &self.committed_offset)?;
         } else {
             if self.committed_offset != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 8 {
@@ -834,14 +834,14 @@ impl Encodable for OffsetFetchResponsePartitions {
                 .map(|x| x.is_empty())
                 .unwrap_or_default()
             {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 8 {
             types::Int16.encode(buf, &self.error_code)?;
         } else {
             if self.error_code != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 6 {
@@ -864,14 +864,14 @@ impl Encodable for OffsetFetchResponsePartitions {
             total_size += types::Int32.compute_size(&self.partition_index)?;
         } else {
             if self.partition_index != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 8 {
             total_size += types::Int64.compute_size(&self.committed_offset)?;
         } else {
             if self.committed_offset != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 8 {
@@ -886,14 +886,14 @@ impl Encodable for OffsetFetchResponsePartitions {
                 .map(|x| x.is_empty())
                 .unwrap_or_default()
             {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 8 {
             total_size += types::Int16.compute_size(&self.error_code)?;
         } else {
             if self.error_code != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 6 {
@@ -1039,7 +1039,7 @@ impl Encodable for OffsetFetchResponseTopic {
             }
         } else {
             if !self.name.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version <= 7 {
@@ -1050,7 +1050,7 @@ impl Encodable for OffsetFetchResponseTopic {
             }
         } else {
             if !self.partitions.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 6 {
@@ -1077,7 +1077,7 @@ impl Encodable for OffsetFetchResponseTopic {
             }
         } else {
             if !self.name.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version <= 7 {
@@ -1090,7 +1090,7 @@ impl Encodable for OffsetFetchResponseTopic {
             }
         } else {
             if !self.partitions.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 6 {
@@ -1219,14 +1219,14 @@ impl Encodable for OffsetFetchResponseTopics {
             types::CompactString.encode(buf, &self.name)?;
         } else {
             if !self.name.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 8 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.partitions)?;
         } else {
             if !self.partitions.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 6 {
@@ -1249,7 +1249,7 @@ impl Encodable for OffsetFetchResponseTopics {
             total_size += types::CompactString.compute_size(&self.name)?;
         } else {
             if !self.name.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 8 {
@@ -1257,7 +1257,7 @@ impl Encodable for OffsetFetchResponseTopics {
                 types::CompactArray(types::Struct { version }).compute_size(&self.partitions)?;
         } else {
             if !self.partitions.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 6 {

--- a/src/messages/produce_request.rs
+++ b/src/messages/produce_request.rs
@@ -243,7 +243,7 @@ impl Encodable for ProduceRequest {
             }
         } else {
             if !self.transactional_id.is_none() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         types::Int16.encode(buf, &self.acks)?;
@@ -277,7 +277,7 @@ impl Encodable for ProduceRequest {
             }
         } else {
             if !self.transactional_id.is_none() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         total_size += types::Int16.compute_size(&self.acks)?;

--- a/src/messages/produce_response.rs
+++ b/src/messages/produce_response.rs
@@ -73,7 +73,7 @@ impl Encodable for BatchIndexAndErrorMessage {
             types::Int32.encode(buf, &self.batch_index)?;
         } else {
             if self.batch_index != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 8 {
@@ -84,7 +84,7 @@ impl Encodable for BatchIndexAndErrorMessage {
             }
         } else {
             if !self.batch_index_error_message.is_none() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 9 {
@@ -107,7 +107,7 @@ impl Encodable for BatchIndexAndErrorMessage {
             total_size += types::Int32.compute_size(&self.batch_index)?;
         } else {
             if self.batch_index != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 8 {
@@ -118,7 +118,7 @@ impl Encodable for BatchIndexAndErrorMessage {
             }
         } else {
             if !self.batch_index_error_message.is_none() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 9 {
@@ -243,14 +243,14 @@ impl Encodable for LeaderIdAndEpoch {
             types::Int32.encode(buf, &self.leader_id)?;
         } else {
             if self.leader_id != -1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 10 {
             types::Int32.encode(buf, &self.leader_epoch)?;
         } else {
             if self.leader_epoch != -1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 9 {
@@ -273,14 +273,14 @@ impl Encodable for LeaderIdAndEpoch {
             total_size += types::Int32.compute_size(&self.leader_id)?;
         } else {
             if self.leader_id != -1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 10 {
             total_size += types::Int32.compute_size(&self.leader_epoch)?;
         } else {
             if self.leader_epoch != -1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 9 {
@@ -429,28 +429,28 @@ impl Encodable for NodeEndpoint {
             types::Int32.encode(buf, &self.node_id)?;
         } else {
             if self.node_id != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 10 {
             types::CompactString.encode(buf, &self.host)?;
         } else {
             if !self.host.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 10 {
             types::Int32.encode(buf, &self.port)?;
         } else {
             if self.port != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 10 {
             types::CompactString.encode(buf, &self.rack)?;
         } else {
             if !self.rack.is_none() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 9 {
@@ -473,28 +473,28 @@ impl Encodable for NodeEndpoint {
             total_size += types::Int32.compute_size(&self.node_id)?;
         } else {
             if self.node_id != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 10 {
             total_size += types::CompactString.compute_size(&self.host)?;
         } else {
             if !self.host.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 10 {
             total_size += types::Int32.compute_size(&self.port)?;
         } else {
             if self.port != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 10 {
             total_size += types::CompactString.compute_size(&self.rack)?;
         } else {
             if !self.rack.is_none() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 9 {

--- a/src/messages/stop_replica_request.rs
+++ b/src/messages/stop_replica_request.rs
@@ -87,21 +87,21 @@ impl Encodable for StopReplicaPartitionState {
             types::Int32.encode(buf, &self.partition_index)?;
         } else {
             if self.partition_index != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
             types::Int32.encode(buf, &self.leader_epoch)?;
         } else {
             if self.leader_epoch != -1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
             types::Boolean.encode(buf, &self.delete_partition)?;
         } else {
             if self.delete_partition {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 2 {
@@ -124,21 +124,21 @@ impl Encodable for StopReplicaPartitionState {
             total_size += types::Int32.compute_size(&self.partition_index)?;
         } else {
             if self.partition_index != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
             total_size += types::Int32.compute_size(&self.leader_epoch)?;
         } else {
             if self.leader_epoch != -1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
             total_size += types::Boolean.compute_size(&self.delete_partition)?;
         } else {
             if self.delete_partition {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 2 {
@@ -266,14 +266,14 @@ impl Encodable for StopReplicaPartitionV0 {
             types::String.encode(buf, &self.topic_name)?;
         } else {
             if !self.topic_name.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version == 0 {
             types::Int32.encode(buf, &self.partition_index)?;
         } else {
             if self.partition_index != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 2 {
@@ -296,14 +296,14 @@ impl Encodable for StopReplicaPartitionV0 {
             total_size += types::String.compute_size(&self.topic_name)?;
         } else {
             if !self.topic_name.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version == 0 {
             total_size += types::Int32.compute_size(&self.partition_index)?;
         } else {
             if self.partition_index != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 2 {
@@ -509,7 +509,7 @@ impl Encodable for StopReplicaRequest {
             types::Boolean.encode(buf, &self.is_k_raft_controller)?;
         } else {
             if self.is_k_raft_controller {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         types::Int32.encode(buf, &self.controller_epoch)?;
@@ -520,14 +520,14 @@ impl Encodable for StopReplicaRequest {
             types::Boolean.encode(buf, &self.delete_partitions)?;
         } else {
             if self.delete_partitions {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version == 0 {
             types::Array(types::Struct { version }).encode(buf, &self.ungrouped_partitions)?;
         } else {
             if !self.ungrouped_partitions.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 1 && version <= 2 {
@@ -538,14 +538,14 @@ impl Encodable for StopReplicaRequest {
             }
         } else {
             if !self.topics.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.topic_states)?;
         } else {
             if !self.topic_states.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 2 {
@@ -569,7 +569,7 @@ impl Encodable for StopReplicaRequest {
             total_size += types::Boolean.compute_size(&self.is_k_raft_controller)?;
         } else {
             if self.is_k_raft_controller {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         total_size += types::Int32.compute_size(&self.controller_epoch)?;
@@ -580,7 +580,7 @@ impl Encodable for StopReplicaRequest {
             total_size += types::Boolean.compute_size(&self.delete_partitions)?;
         } else {
             if self.delete_partitions {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version == 0 {
@@ -588,7 +588,7 @@ impl Encodable for StopReplicaRequest {
                 types::Array(types::Struct { version }).compute_size(&self.ungrouped_partitions)?;
         } else {
             if !self.ungrouped_partitions.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 1 && version <= 2 {
@@ -600,7 +600,7 @@ impl Encodable for StopReplicaRequest {
             }
         } else {
             if !self.topics.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
@@ -608,7 +608,7 @@ impl Encodable for StopReplicaRequest {
                 types::CompactArray(types::Struct { version }).compute_size(&self.topic_states)?;
         } else {
             if !self.topic_states.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 2 {
@@ -767,14 +767,14 @@ impl Encodable for StopReplicaTopicState {
             types::CompactString.encode(buf, &self.topic_name)?;
         } else {
             if !self.topic_name.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.partition_states)?;
         } else {
             if !self.partition_states.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 2 {
@@ -797,7 +797,7 @@ impl Encodable for StopReplicaTopicState {
             total_size += types::CompactString.compute_size(&self.topic_name)?;
         } else {
             if !self.topic_name.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
@@ -805,7 +805,7 @@ impl Encodable for StopReplicaTopicState {
                 .compute_size(&self.partition_states)?;
         } else {
             if !self.partition_states.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 2 {
@@ -930,7 +930,7 @@ impl Encodable for StopReplicaTopicV1 {
             }
         } else {
             if !self.name.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 1 && version <= 2 {
@@ -941,7 +941,7 @@ impl Encodable for StopReplicaTopicV1 {
             }
         } else {
             if !self.partition_indexes.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 2 {
@@ -968,7 +968,7 @@ impl Encodable for StopReplicaTopicV1 {
             }
         } else {
             if !self.name.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 1 && version <= 2 {
@@ -980,7 +980,7 @@ impl Encodable for StopReplicaTopicV1 {
             }
         } else {
             if !self.partition_indexes.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 2 {

--- a/src/messages/sync_group_request.rs
+++ b/src/messages/sync_group_request.rs
@@ -158,7 +158,7 @@ impl Encodable for SyncGroupRequest {
             }
         } else {
             if !self.group_instance_id.is_none() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 5 {
@@ -207,7 +207,7 @@ impl Encodable for SyncGroupRequest {
             }
         } else {
             if !self.group_instance_id.is_none() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 5 {

--- a/src/messages/txn_offset_commit_request.rs
+++ b/src/messages/txn_offset_commit_request.rs
@@ -169,21 +169,21 @@ impl Encodable for TxnOffsetCommitRequest {
             types::Int32.encode(buf, &self.generation_id)?;
         } else {
             if self.generation_id != -1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
             types::CompactString.encode(buf, &self.member_id)?;
         } else {
             if &self.member_id != "" {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
             types::CompactString.encode(buf, &self.group_instance_id)?;
         } else {
             if !self.group_instance_id.is_none() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
@@ -223,21 +223,21 @@ impl Encodable for TxnOffsetCommitRequest {
             total_size += types::Int32.compute_size(&self.generation_id)?;
         } else {
             if self.generation_id != -1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
             total_size += types::CompactString.compute_size(&self.member_id)?;
         } else {
             if &self.member_id != "" {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
             total_size += types::CompactString.compute_size(&self.group_instance_id)?;
         } else {
             if !self.group_instance_id.is_none() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {

--- a/src/messages/update_features_request.rs
+++ b/src/messages/update_features_request.rs
@@ -103,14 +103,14 @@ impl Encodable for FeatureUpdateKey {
             types::Boolean.encode(buf, &self.allow_downgrade)?;
         } else {
             if self.allow_downgrade {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 1 {
             types::Int8.encode(buf, &self.upgrade_type)?;
         } else {
             if self.upgrade_type != 1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -133,14 +133,14 @@ impl Encodable for FeatureUpdateKey {
             total_size += types::Boolean.compute_size(&self.allow_downgrade)?;
         } else {
             if self.allow_downgrade {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 1 {
             total_size += types::Int8.compute_size(&self.upgrade_type)?;
         } else {
             if self.upgrade_type != 1 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -279,7 +279,7 @@ impl Encodable for UpdateFeaturesRequest {
             types::Boolean.encode(buf, &self.validate_only)?;
         } else {
             if self.validate_only {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -303,7 +303,7 @@ impl Encodable for UpdateFeaturesRequest {
             total_size += types::Boolean.compute_size(&self.validate_only)?;
         } else {
             if self.validate_only {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         let num_tagged_fields = self.unknown_tagged_fields.len();

--- a/src/messages/update_metadata_request.rs
+++ b/src/messages/update_metadata_request.rs
@@ -342,7 +342,7 @@ impl Encodable for UpdateMetadataEndpoint {
             types::Int32.encode(buf, &self.port)?;
         } else {
             if self.port != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 1 {
@@ -353,7 +353,7 @@ impl Encodable for UpdateMetadataEndpoint {
             }
         } else {
             if !self.host.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
@@ -367,7 +367,7 @@ impl Encodable for UpdateMetadataEndpoint {
             types::Int16.encode(buf, &self.security_protocol)?;
         } else {
             if self.security_protocol != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 6 {
@@ -390,7 +390,7 @@ impl Encodable for UpdateMetadataEndpoint {
             total_size += types::Int32.compute_size(&self.port)?;
         } else {
             if self.port != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 1 {
@@ -401,7 +401,7 @@ impl Encodable for UpdateMetadataEndpoint {
             }
         } else {
             if !self.host.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 3 {
@@ -415,7 +415,7 @@ impl Encodable for UpdateMetadataEndpoint {
             total_size += types::Int16.compute_size(&self.security_protocol)?;
         } else {
             if self.security_protocol != 0 {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 6 {
@@ -958,7 +958,7 @@ impl Encodable for UpdateMetadataRequest {
             types::Boolean.encode(buf, &self.is_k_raft_controller)?;
         } else {
             if self.is_k_raft_controller {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         types::Int32.encode(buf, &self.controller_epoch)?;
@@ -970,7 +970,7 @@ impl Encodable for UpdateMetadataRequest {
                 .encode(buf, &self.ungrouped_partition_states)?;
         } else {
             if !self.ungrouped_partition_states.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 5 {
@@ -981,7 +981,7 @@ impl Encodable for UpdateMetadataRequest {
             }
         } else {
             if !self.topic_states.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 6 {
@@ -1028,7 +1028,7 @@ impl Encodable for UpdateMetadataRequest {
             total_size += types::Boolean.compute_size(&self.is_k_raft_controller)?;
         } else {
             if self.is_k_raft_controller {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         total_size += types::Int32.compute_size(&self.controller_epoch)?;
@@ -1040,7 +1040,7 @@ impl Encodable for UpdateMetadataRequest {
                 .compute_size(&self.ungrouped_partition_states)?;
         } else {
             if !self.ungrouped_partition_states.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 5 {
@@ -1053,7 +1053,7 @@ impl Encodable for UpdateMetadataRequest {
             }
         } else {
             if !self.topic_states.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 6 {
@@ -1262,7 +1262,7 @@ impl Encodable for UpdateMetadataTopicState {
             }
         } else {
             if !self.topic_name.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 7 {
@@ -1277,7 +1277,7 @@ impl Encodable for UpdateMetadataTopicState {
             }
         } else {
             if !self.partition_states.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 6 {
@@ -1304,7 +1304,7 @@ impl Encodable for UpdateMetadataTopicState {
             }
         } else {
             if !self.topic_name.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 7 {
@@ -1320,7 +1320,7 @@ impl Encodable for UpdateMetadataTopicState {
             }
         } else {
             if !self.partition_states.is_empty() {
-                bail!("failed to encode");
+                bail!("A field is set that is not available on the selected protocol version");
             }
         }
         if version >= 6 {


### PR DESCRIPTION
This PR replaces the incredibly generic "failed to encode" error with a more specific "A field is set that is not available on the selected protocol version" error.

While it might be possible to put more detail into the error, I've intentionally kept it simple to keep build time and binary size down.

Lets land this before https://github.com/tychedelia/kafka-protocol-rs/pull/95