### PR TITLE
VersionRange additions

### DIFF
--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -1,10 +1,10 @@
 //! Most types are used internally in encoding/decoding, and are not required by typical use cases
 //! for interacting with the protocol. However, types can be used for decoding partial messages,
 //! or rewriting parts of an encoded message.
-use std::borrow::Borrow;
 use std::cmp;
 use std::collections::BTreeMap;
 use std::ops::RangeBounds;
+use std::{borrow::Borrow, fmt::Display};
 
 use anyhow::{bail, Result};
 use buf::{ByteBuf, ByteBufMut};
@@ -128,7 +128,7 @@ pub(crate) trait Decoder<Value> {
 }
 
 /// The range of versions (min, max) allowed for agiven message.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub struct VersionRange {
     /// The minimum version in the range.
     pub min: i16,
@@ -148,6 +148,12 @@ impl VersionRange {
             min: cmp::max(self.min, other.min),
             max: cmp::min(self.max, other.max),
         }
+    }
+}
+
+impl Display for VersionRange {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}..{}", self.min, self.max)
     }
 }
 


### PR DESCRIPTION
This PR introduces 2 new pieces of functionality around VersionRange.
These were required to implement a unit test in my project that compares the currently supported versions of the project against the supported versions of the kafka-protocol crate.

The additions are:
* Add PartialEq impl for VersionRange
  + allows for direct comparison between ranges which seems like a reasonable operation.
* Add Display impl for VersionRange
  + It takes the format `0..10` where min is 0 and max is 10
  + This compact format will be nice for logs and error messages.
  + Possibly we should do `0 to 10` or `0-10` or `0..=10` instead, since in regular rust `0..10` would mean an exclusive 10.