### PR TITLE
[Breaking change] Fix calling `Records::encode` / `Records::decode` with None

### DIFF
--- a/tests/all_tests/fetch_response.rs
+++ b/tests/all_tests/fetch_response.rs
@@ -86,9 +86,11 @@ mod client_tests {
                 assert_eq!(partition.aborted_transactions.as_ref().unwrap().len(), 0);
 
                 let mut records = partition.records.unwrap();
-                let records =
-                    RecordBatchDecoder::decode(&mut records, Some(decompress_record_batch_data))
-                        .unwrap();
+                let records = RecordBatchDecoder::decode_with_custom_compression(
+                    &mut records,
+                    Some(decompress_record_batch_data),
+                )
+                .unwrap();
                 assert_eq!(records.len(), 1);
                 for record in records {
                     assert_eq!(
@@ -123,9 +125,11 @@ mod client_tests {
                 assert_eq!(partition.aborted_transactions.as_ref().unwrap().len(), 0);
 
                 let mut records = partition.records.unwrap();
-                let records =
-                    RecordBatchDecoder::decode(&mut records, Some(decompress_record_batch_data))
-                        .unwrap();
+                let records = RecordBatchDecoder::decode_with_custom_compression(
+                    &mut records,
+                    Some(decompress_record_batch_data),
+                )
+                .unwrap();
                 assert_eq!(records.len(), 1);
                 for record in records {
                     assert_eq!(
@@ -161,9 +165,11 @@ mod client_tests {
                 assert_eq!(partition.aborted_transactions.as_ref().unwrap().len(), 0);
 
                 let mut records = partition.records.unwrap();
-                let records =
-                    RecordBatchDecoder::decode(&mut records, Some(decompress_record_batch_data))
-                        .unwrap();
+                let records = RecordBatchDecoder::decode_with_custom_compression(
+                    &mut records,
+                    Some(decompress_record_batch_data),
+                )
+                .unwrap();
                 assert_eq!(records.len(), 1);
             }
         }

--- a/tests/all_tests/produce_fetch.rs
+++ b/tests/all_tests/produce_fetch.rs
@@ -32,7 +32,7 @@ fn record_batch_produce_fetch() {
     ];
 
     let mut encoded = BytesMut::new();
-    RecordBatchEncoder::encode(
+    RecordBatchEncoder::encode_with_custom_compression(
         &mut encoded,
         &records,
         &RecordEncodeOptions {
@@ -67,7 +67,7 @@ fn message_set_v1_produce_fetch() {
     ];
 
     let mut encoded = BytesMut::new();
-    RecordBatchEncoder::encode(
+    RecordBatchEncoder::encode_with_custom_compression(
         &mut encoded,
         &records,
         &RecordEncodeOptions {
@@ -196,9 +196,11 @@ fn fetch_records(
     );
 
     let mut fetched_records = partition_response.records.clone().unwrap();
-    let fetched_records =
-        RecordBatchDecoder::decode(&mut fetched_records, Some(decompress_record_batch_data))
-            .unwrap();
+    let fetched_records = RecordBatchDecoder::decode_with_custom_compression(
+        &mut fetched_records,
+        Some(decompress_record_batch_data),
+    )
+    .unwrap();
 
     eprintln!("{expected:#?}");
     eprintln!("{fetched_records:#?}");


### PR DESCRIPTION
Calling encode or decode with the correct compression automatically chosen is very difficult. Providing None results in an error like this:

```
 1  error[E0283]: type annotations needed
    --> kafka-fetch-rewrite/src/lib.rs:87:88
     |
 87  | ...                   RecordBatchDecoder::decode(&mut records_bytes.clone(), None)
     |                       --------------------------                             ^^^^ cannot infer type of the type parameter `T` declared on the enum `Option`
     |                       |
     |                       required by a bound introduced by this call
     |
     = note: multiple `impl`s satisfying `for<'a> _: Fn(&'a mut bytes::Bytes, kafka_protocol::records::Compression)` found in the following crates: `alloc`, `core`:
             - impl<A, F> std::ops::Fn<A> for &F
               where A: std::marker::Tuple, F: std::ops::Fn<A>, F: ?Sized;
             - impl<Args, F, A> std::ops::Fn<Args> for std::boxed::Box<F, A>
               where Args: std::marker::Tuple, F: std::ops::Fn<Args>, A: std::alloc::Allocator, F: ?Sized;
 note: required by a bound in `kafka_protocol::records::RecordBatchDecoder::decode`
    --> /home/rukai/.cargo/registry/src/index.crates.io-6f17d22bba15001f/kafka-protocol-0.13.0/src/records.rs:495:12
     |
 493 |     pub fn decode<B: ByteBuf, F>(buf: &mut B, decompressor: Option<F>) -> Result<Vec<Record>>
     |            ------ required by a bound in this associated function
 494 |     where
 495 |         F: Fn(&mut bytes::Bytes, Compression) -> Result<B>,
     |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RecordBatchDecoder::decode`
 help: consider specifying the generic argument
     |
 87  |                                 RecordBatchDecoder::decode(&mut records_bytes.clone(), None::<T>)
     |                                                                                            +++++
```

For which the fix is to change the `None` to `None::<fn(&mut bytes::Bytes, Compression) -> Result<Bytes>>`.
This is a pretty poor experience.

To fix this I am making `decode`/`encode` provide the correct None value, and have the original implementation moved to `decode_with_custom_compression`/`encode_with_custom_compression`.

@pdeva heads up that you will want to adjust your project to call `decode_with_custom_compression` instead of `decode`.