### PR TITLE
[Breaking Change] Remove unneeded trait bounds from Records::encode/Records::decode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- `Records::encode`/`Records::decode` no longer has unneeded trait bounds.
+
 ## v0.14.0
 
 - `Records::encode`/`Records::decode` is now reverted back to their original API, instead `encode_with_custom_compression` and `decode_with_custom_compression` is provided for custom compression.

--- a/src/records.rs
+++ b/src/records.rs
@@ -158,16 +158,11 @@ const MAGIC_BYTE_OFFSET: usize = 16;
 impl RecordBatchEncoder {
     /// Encode records into given buffer, using provided encoding options that select the encoding
     /// strategy based on version.
-    pub fn encode<'a, B, I, CF>(
-        buf: &mut B,
-        records: I,
-        options: &RecordEncodeOptions,
-    ) -> Result<()>
+    pub fn encode<'a, B, I>(buf: &mut B, records: I, options: &RecordEncodeOptions) -> Result<()>
     where
         B: ByteBufMut,
         I: IntoIterator<Item = &'a Record>,
         I::IntoIter: Clone,
-        CF: Fn(&mut BytesMut, &mut B, Compression) -> Result<()>,
     {
         Self::encode_with_custom_compression(
             buf,
@@ -507,10 +502,7 @@ impl RecordBatchEncoder {
 
 impl RecordBatchDecoder {
     /// Decode the provided buffer into a vec of records.
-    pub fn decode<B: ByteBuf, F>(buf: &mut B) -> Result<Vec<Record>>
-    where
-        F: Fn(&mut bytes::Bytes, Compression) -> Result<B>,
-    {
+    pub fn decode<B: ByteBuf>(buf: &mut B) -> Result<Vec<Record>> {
         Self::decode_with_custom_compression(
             buf,
             None::<fn(&mut bytes::Bytes, Compression) -> Result<B>>,

--- a/tests/all_tests/fetch_response.rs
+++ b/tests/all_tests/fetch_response.rs
@@ -125,11 +125,7 @@ mod client_tests {
                 assert_eq!(partition.aborted_transactions.as_ref().unwrap().len(), 0);
 
                 let mut records = partition.records.unwrap();
-                let records = RecordBatchDecoder::decode_with_custom_compression(
-                    &mut records,
-                    Some(decompress_record_batch_data),
-                )
-                .unwrap();
+                let records = RecordBatchDecoder::decode(&mut records).unwrap();
                 assert_eq!(records.len(), 1);
                 for record in records {
                     assert_eq!(
@@ -165,11 +161,7 @@ mod client_tests {
                 assert_eq!(partition.aborted_transactions.as_ref().unwrap().len(), 0);
 
                 let mut records = partition.records.unwrap();
-                let records = RecordBatchDecoder::decode_with_custom_compression(
-                    &mut records,
-                    Some(decompress_record_batch_data),
-                )
-                .unwrap();
+                let records = RecordBatchDecoder::decode(&mut records).unwrap();
                 assert_eq!(records.len(), 1);
             }
         }

--- a/tests/all_tests/produce_fetch.rs
+++ b/tests/all_tests/produce_fetch.rs
@@ -67,14 +67,13 @@ fn message_set_v1_produce_fetch() {
     ];
 
     let mut encoded = BytesMut::new();
-    RecordBatchEncoder::encode_with_custom_compression(
+    RecordBatchEncoder::encode(
         &mut encoded,
         &records,
         &RecordEncodeOptions {
             version: 1,
             compression: Compression::None,
         },
-        Some(compress_record_batch_data),
     )
     .unwrap();
 


### PR DESCRIPTION
Wow, I really messed this one up. Sorry everyone.

In https://github.com/tychedelia/kafka-protocol-rs/pull/100 I left the trait bounds in which completely failed to address the actual issue of making the function difficult to call, while also making it more confusing (what are the trait bounds for??)

This PR fixes the issue.

I've also adjusted some of the unit tests, to verify that I have actually resolved the issue, which I should have done in the first place