### PR TITLE
Remove unnecessary generics from encode and decode functions

### DIFF
--- a/src/records.rs
+++ b/src/records.rs
@@ -158,16 +158,11 @@ const MAGIC_BYTE_OFFSET: usize = 16;
 impl RecordBatchEncoder {
     /// Encode records into given buffer, using provided encoding options that select the encoding
     /// strategy based on version.
-    pub fn encode<'a, B, I, CF>(
-        buf: &mut B,
-        records: I,
-        options: &RecordEncodeOptions,
-    ) -> Result<()>
+    pub fn encode<'a, B, I>(buf: &mut B, records: I, options: &RecordEncodeOptions) -> Result<()>
     where
         B: ByteBufMut,
         I: IntoIterator<Item = &'a Record>,
         I::IntoIter: Clone,
-        CF: Fn(&mut BytesMut, &mut B, Compression) -> Result<()>,
     {
         Self::encode_with_custom_compression(
             buf,
@@ -507,10 +502,7 @@ impl RecordBatchEncoder {
 
 impl RecordBatchDecoder {
     /// Decode the provided buffer into a vec of records.
-    pub fn decode<B: ByteBuf, F>(buf: &mut B) -> Result<Vec<Record>>
-    where
-        F: Fn(&mut bytes::Bytes, Compression) -> Result<B>,
-    {
+    pub fn decode<B: ByteBuf>(buf: &mut B) -> Result<Vec<Record>> {
         Self::decode_with_custom_compression(
             buf,
             None::<fn(&mut bytes::Bytes, Compression) -> Result<B>>,


### PR DESCRIPTION
The `RecordBatchEncoder::encode` and `RecordBatchEncoder::decode` functions have a generic for the compression function closure.

This makes calling these APIs require naming these generics, when this is not necessary.

For example, to call `RecordBatchDecoder::decode`, you have to do this:

```rust
RecordBatchDecoder::decode::<
    bytes::Bytes,
    fn(&mut bytes::Bytes, Compression) -> anyhow::Result<bytes::Bytes>,
>(&mut records)
```

Or you get this error:
```
error[E0283]: type annotations needed
   --> src/clients/consumer.rs:368:52
    |
368 | ...                   let Ok(part_records) = RecordBatchDecoder::decode(&mut part_records)
    |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `F` declared on the associated function `decode`
    |
    = note: multiple `impl`s satisfying `for<'a> _: Fn(&'a mut bytes::Bytes, Compression)` found in the following crates: `alloc`, `core`:
            - impl<A, F> Fn<A> for &F
              where A: std::marker::Tuple, F: Fn<A>, F: ?Sized;
            - impl<Args, F, A> Fn<Args> for Box<F, A>
              where Args: std::marker::Tuple, F: Fn<Args>, A: Allocator, F: ?Sized;
note: required by a bound in `kafka_protocol::records::RecordBatchDecoder::decode`
   --> /home/eb/.cargo/registry/src/index.crates.io-6f17d22bba15001f/kafka-protocol-0.14.0/src/records.rs:512:12
    |
510 |     pub fn decode<B: ByteBuf, F>(buf: &mut B) -> Result<Vec<Record>>
    |            ------ required by a bound in this associated function
511 |     where
512 |         F: Fn(&mut bytes::Bytes, Compression) -> Result<B>,
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RecordBatchDecoder::decode`
help: consider specifying the generic arguments
    |
368 |                             let Ok(part_records) = RecordBatchDecoder::decode::<bytes::Bytes, F>(&mut part_records)
    |                                                                              +++++++++++++++++++
```

We can remove the generic for the closure and the compiler can now infer the types:

```rust
RecordBatchDecoder::decode(&mut part_records)
```