### PR TITLE
feat: impl Borrow<[u8]> for StrBytes

### DIFF
--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -15,6 +15,7 @@ pub mod types;
 
 mod str_bytes {
     use bytes::Bytes;
+    use std::borrow::Borrow;
     use std::convert::TryFrom;
     use std::fmt::{Debug, Display, Formatter};
     use std::ops::Deref;
@@ -105,6 +106,12 @@ mod str_bytes {
     impl PartialEq<str> for StrBytes {
         fn eq(&self, other: &str) -> bool {
             self.as_str().eq(other)
+        }
+    }
+
+    impl Borrow<[u8]> for StrBytes {
+        fn borrow(&self) -> &[u8] {
+            self.as_bytes()
         }
     }
 }


### PR DESCRIPTION
This makes it possible to lookup a header without having to create a StrBytes, which isn't possible right now as far as I can tell.