### PR TITLE
fix: `impl Borrow<[u8]> for StrBytes`, not `Borrow<str>`

### DIFF
--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -109,9 +109,12 @@ mod str_bytes {
         }
     }
 
-    impl Borrow<str> for StrBytes {
-        fn borrow(&self) -> &str {
-            self.as_str()
+    impl Borrow<[u8]> for StrBytes {
+        fn borrow(&self) -> &[u8] {
+            // Note that there is an equivalent Hash implementation between
+            // &[u8] and StrBytes, which makes this impl correct
+            // as described in the `std::borrow::Borrow` docs.
+            self.as_bytes()
         }
     }
 }

--- a/src/records.rs
+++ b/src/records.rs
@@ -1145,7 +1145,7 @@ mod tests {
     use super::{Record, TimestampType};
 
     #[test]
-    fn lookup_header_via_str() {
+    fn lookup_header_via_u8_slice() {
         let record = Record {
             transactional: false,
             control: false,
@@ -1168,8 +1168,8 @@ mod tests {
             Bytes::from("some-value"),
             record
                 .headers
-                // This relies on `impl Borrow<str> for StrBytes`
-                .get("some-key")
+                // This relies on `impl Borrow<[u8]> for StrBytes`
+                .get("some-key".as_bytes())
                 .expect("key exists in headers")
                 .as_ref()
                 .expect("value is present")

--- a/src/records.rs
+++ b/src/records.rs
@@ -1158,7 +1158,11 @@ mod tests {
             timestamp: Default::default(),
             key: Default::default(),
             value: Default::default(),
-            headers: [("some-key".into(), Some("some-value".into()))].into(),
+            headers: [
+                ("some-key".into(), Some("some-value".into())),
+                ("other-header".into(), None),
+            ]
+            .into(),
         };
         assert_eq!(
             Bytes::from("some-value"),


### PR DESCRIPTION
The [condition on equivalent Hash implementations for implementing Borrow](https://doc.rust-lang.org/std/borrow/trait.Borrow.html#examples) is not satisfied for `&str` and `StrBytes` but it is for `&[u8]` and `StrBytes`.

It failed to work when using the crate and the Hash implementations `StrBytes`/`str` do indeed give different results unlike `StrBytes`/`[u8]` so why did the test work?
[Looking at the implementation of `IndexMap::get`](https://docs.rs/indexmap/latest/src/indexmap/map.rs.html#759-765) shows us that the lookup key is only hashed if the map has more than one entry.
`Borrow` is tricky indeed :smile: 

See #115 