### PR TITLE
feat: return compression information when decoding if possible

### DIFF
--- a/src/records.rs
+++ b/src/records.rs
@@ -121,6 +121,26 @@ struct BatchDecodeInfo {
     producer_epoch: i16,
 }
 
+/// Record compression for a set of records.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RecordCompression {
+    /// The set of records was a record batch with the given `Compression`.
+    RecordBatch(Compression),
+    /// The set of records was a message set and does not have a well-defined `Compression`.
+    MessageSet,
+}
+
+/// Decoded records plus information about compression.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecordSet {
+    /// Compression used for this set of records
+    pub compression: RecordCompression,
+    /// Version used to encode the set of records
+    pub version: i8,
+    /// Records decoded in this set
+    pub records: Vec<Record>,
+}
+
 /// A Kafka message containing key, payload value, and all associated metadata.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Record {
@@ -523,26 +543,50 @@ impl RecordBatchDecoder {
     {
         let mut records = Vec::new();
         while buf.has_remaining() {
-            Self::decode_batch(buf, &mut records, decompressor.as_ref())?;
+            let _ = Self::decode_into_vec(buf, &mut records, decompressor.as_ref())?;
         }
         Ok(records)
     }
-    fn decode_batch<B: ByteBuf, F>(
+
+    /// Decode the provided buffer into a vec of RecordSets.
+    pub fn decode_batches<B: ByteBuf>(buf: &mut B) -> Result<Vec<RecordSet>> {
+        let mut batches = Vec::new();
+        while buf.has_remaining() {
+            let mut records = Vec::new();
+            let (version, compression) = Self::decode_into_vec(
+                buf,
+                &mut records,
+                None::<fn(&mut bytes::Bytes, Compression) -> Result<B>>.as_ref(),
+            )?;
+            batches.push(RecordSet {
+                version,
+                compression,
+                records,
+            });
+        }
+        Ok(batches)
+    }
+
+    fn decode_into_vec<B: ByteBuf, F>(
         buf: &mut B,
         records: &mut Vec<Record>,
         decompress_func: Option<&F>,
-    ) -> Result<()>
+    ) -> Result<(i8, RecordCompression)>
     where
         F: Fn(&mut bytes::Bytes, Compression) -> Result<B>,
     {
         let version = buf.try_peek_bytes(MAGIC_BYTE_OFFSET..(MAGIC_BYTE_OFFSET + 1))?[0] as i8;
-        match version {
-            0..=1 => Record::decode_legacy(buf, version, records),
-            2 => Self::decode_new_batch(buf, version, records, decompress_func),
+        let compression = match version {
+            0..=1 => {
+                Record::decode_legacy(buf, version, records).map(|()| RecordCompression::MessageSet)
+            }
+            2 => Self::decode_new_batch(buf, version, records, decompress_func)
+                .map(RecordCompression::RecordBatch),
             _ => {
                 bail!("Unknown record batch version ({})", version);
             }
-        }
+        }?;
+        Ok((version, compression))
     }
     fn decode_new_records<B: ByteBuf>(
         buf: &mut B,
@@ -561,7 +605,7 @@ impl RecordBatchDecoder {
         version: i8,
         records: &mut Vec<Record>,
         decompress_func: Option<&F>,
-    ) -> Result<()>
+    ) -> Result<Compression>
     where
         F: Fn(&mut bytes::Bytes, Compression) -> Result<B>,
     {
@@ -690,7 +734,7 @@ impl RecordBatchDecoder {
             };
         }
 
-        Ok(())
+        Ok(compression)
     }
 }
 

--- a/tests/all_tests/fetch_response.rs
+++ b/tests/all_tests/fetch_response.rs
@@ -86,13 +86,13 @@ mod client_tests {
                 assert_eq!(partition.aborted_transactions.as_ref().unwrap().len(), 0);
 
                 let mut records = partition.records.unwrap();
-                let records = RecordBatchDecoder::decode_with_custom_compression(
+                let decoded = RecordBatchDecoder::decode_with_custom_compression(
                     &mut records,
                     Some(decompress_record_batch_data),
                 )
                 .unwrap();
-                assert_eq!(records.len(), 1);
-                for record in records {
+                assert_eq!(decoded.records.len(), 1);
+                for record in decoded.records {
                     assert_eq!(
                         String::from_utf8(record.key.unwrap().to_vec()).unwrap(),
                         "hello"
@@ -125,9 +125,9 @@ mod client_tests {
                 assert_eq!(partition.aborted_transactions.as_ref().unwrap().len(), 0);
 
                 let mut records = partition.records.unwrap();
-                let records = RecordBatchDecoder::decode(&mut records).unwrap();
-                assert_eq!(records.len(), 1);
-                for record in records {
+                let decoded = RecordBatchDecoder::decode(&mut records).unwrap();
+                assert_eq!(decoded.records.len(), 1);
+                for record in decoded.records {
                     assert_eq!(
                         String::from_utf8(record.key.unwrap().to_vec()).unwrap(),
                         "hiiii"
@@ -161,8 +161,8 @@ mod client_tests {
                 assert_eq!(partition.aborted_transactions.as_ref().unwrap().len(), 0);
 
                 let mut records = partition.records.unwrap();
-                let records = RecordBatchDecoder::decode(&mut records).unwrap();
-                assert_eq!(records.len(), 1);
+                let decoded = RecordBatchDecoder::decode(&mut records).unwrap();
+                assert_eq!(decoded.records.len(), 1);
             }
         }
     }

--- a/tests/all_tests/fetch_response.rs
+++ b/tests/all_tests/fetch_response.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "client")]
 mod client_tests {
     use bytes::Bytes;
-    use kafka_protocol::records::Compression;
+    use kafka_protocol::records::{Compression, RecordCompression};
     use kafka_protocol::{
         messages::FetchResponse, protocol::Decodable, records::RecordBatchDecoder,
     };
@@ -91,6 +91,11 @@ mod client_tests {
                     Some(decompress_record_batch_data),
                 )
                 .unwrap();
+                assert_eq!(
+                    decoded.compression,
+                    RecordCompression::RecordBatch(Compression::None)
+                );
+                assert_eq!(decoded.version, 2);
                 assert_eq!(decoded.records.len(), 1);
                 for record in decoded.records {
                     assert_eq!(
@@ -126,6 +131,11 @@ mod client_tests {
 
                 let mut records = partition.records.unwrap();
                 let decoded = RecordBatchDecoder::decode(&mut records).unwrap();
+                assert_eq!(
+                    decoded.compression,
+                    RecordCompression::RecordBatch(Compression::None)
+                );
+                assert_eq!(decoded.version, 2);
                 assert_eq!(decoded.records.len(), 1);
                 for record in decoded.records {
                     assert_eq!(
@@ -162,6 +172,11 @@ mod client_tests {
 
                 let mut records = partition.records.unwrap();
                 let decoded = RecordBatchDecoder::decode(&mut records).unwrap();
+                assert_eq!(
+                    decoded.compression,
+                    RecordCompression::RecordBatch(Compression::None)
+                );
+                assert_eq!(decoded.version, 2);
                 assert_eq!(decoded.records.len(), 1);
             }
         }

--- a/tests/all_tests/fetch_response.rs
+++ b/tests/all_tests/fetch_response.rs
@@ -171,7 +171,10 @@ mod client_tests {
                 assert_eq!(partition.aborted_transactions.as_ref().unwrap().len(), 0);
 
                 let mut records = partition.records.unwrap();
-                let decoded = RecordBatchDecoder::decode(&mut records).unwrap();
+                let decoded = RecordBatchDecoder::decode_all(&mut records).unwrap();
+                let [decoded] = decoded.as_slice() else {
+                    panic!("expected exactly one record");
+                };
                 assert_eq!(
                     decoded.compression,
                     RecordCompression::RecordBatch(Compression::None)


### PR DESCRIPTION
This doesn't support getting compression for record encoding v0/v1 aka message sets.

Closes https://github.com/tychedelia/kafka-protocol-rs/issues/116