### PR TITLE
Decode unsupported version fallback for ApiVersions

### DIFF
--- a/tests/all_tests/api_versions.rs
+++ b/tests/all_tests/api_versions.rs
@@ -1,6 +1,7 @@
 use bytes::Bytes;
-use kafka_protocol::messages::ApiVersionsRequest;
+use kafka_protocol::messages::{ApiVersionsRequest, ApiVersionsResponse};
 use kafka_protocol::protocol::Decodable;
+use kafka_protocol::ResponseError::UnsupportedVersion;
 
 #[test]
 fn api_versions() {
@@ -12,4 +13,15 @@ fn api_versions() {
     let res = ApiVersionsRequest::decode(&mut Bytes::from(bytes.to_vec()), 3).unwrap();
     assert_eq!(res.client_software_name.to_string(), "apache-kafka-java");
     assert_eq!(res.client_software_version.to_string(), "2.8.0");
+}
+
+#[test]
+fn api_versions_unsupported_version_response() {
+    let bytes: [u8; 12] = [
+        0x00, 0x23, 0x00, 0x00, 0x00, 0x01, 0x00, 0x12, 0x00, 0x00, 0x00, 0x03,
+    ];
+
+    let res = ApiVersionsResponse::decode(&mut Bytes::from(bytes.to_vec()), 4).unwrap();
+    assert_eq!(res.api_keys.len(), 1);
+    assert_eq!(res.error_code, UnsupportedVersion.code());
 }


### PR DESCRIPTION
Hey 👋 

I run into a problem with parsing ApiVersions response.

My Kafka Server supports ApiVersions v0-v3, but my client supports v0-v4.
When it connects to the server, it uses ApiVersions v4 as the first request, but the server does not support this, so it responds with ApiVersions v0, error code 35 and it sends `ApiVersions min:0, max:3` in api_keys field, so that the client can retry with v3.

This behaviour is described in [Retrieving Supported API versions](https://kafka.apache.org/protocol#api_versions).
and in [KIP-511](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=125309609#KIP511:CollectandExposeClient'sNameandVersionintheBrokers-ApiVersionsRequest/ResponseHandling).

Because api_version is not in the part of the response, we need to first check `error_code`, to figure out this edge case and error_code is part of `decode`.

I could of course check if ApiKey is ApiVersions, peek into buffer, parse error code and downgrade version whenever I call decode, but that's a bit cumbersome.

It would be convenient to have it as a part of kafka-protocol, what do you think?
Thanks!