### PR TITLE
Add version validation to encode/decode

### DIFF
--- a/protocol_codegen/src/generate_messages/generate.rs
+++ b/protocol_codegen/src/generate_messages/generate.rs
@@ -1163,6 +1163,8 @@ impl PreparedStruct {
                 "fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> "
             )?;
             w.block(|w| {
+                self.write_version_validation(w)?;
+
                 for prepared_field in &self.prepared_fields {
                     write_encode_field(w, prepared_field, self.valid_versions, false)?;
                 }
@@ -1210,6 +1212,7 @@ impl PreparedStruct {
                 "fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> "
             )?;
             w.block(|w| {
+                self.write_version_validation(w)?;
                 for prepared_field in &self.prepared_fields {
                     write_decode_field(w, prepared_field, self.valid_versions)?;
                 }
@@ -1297,6 +1300,29 @@ impl PreparedStruct {
         writeln!(w)?;
         writeln!(w)?;
 
+        Ok(())
+    }
+
+    fn write_version_validation<W: Write>(&self, w: &mut CodeWriter<W>) -> Result<(), Error> {
+        let name = &self.name;
+        match self.valid_versions {
+            VersionSpec::None => {}
+            VersionSpec::Exact(exact) => {
+                writeln!(w, "if version != {} {{", exact)?;
+                writeln!(w, "    bail!(\"{name} v{{}} is not supported\", version);")?;
+                writeln!(w, "}}")?;
+            }
+            VersionSpec::Since(since) => {
+                writeln!(w, "if version >= {} {{", since)?;
+                writeln!(w, "    bail!(\"{name} v{{}} is not supported\", version);")?;
+                writeln!(w, "}}")?;
+            }
+            VersionSpec::Range(start, end) => {
+                writeln!(w, "if version < {start} || version > {end} {{")?;
+                writeln!(w, "    bail!(\"{name} v{{}} is not supported\", version);")?;
+                writeln!(w, "}}")?;
+            }
+        }
         Ok(())
     }
 }

--- a/protocol_codegen/src/generate_messages/generate.rs
+++ b/protocol_codegen/src/generate_messages/generate.rs
@@ -1304,22 +1304,30 @@ impl PreparedStruct {
     }
 
     fn write_version_validation<W: Write>(&self, w: &mut CodeWriter<W>) -> Result<(), Error> {
-        let name = &self.name;
         match self.valid_versions {
             VersionSpec::None => {}
             VersionSpec::Exact(exact) => {
-                writeln!(w, "if version != {} {{", exact)?;
-                writeln!(w, "    bail!(\"{name} v{{}} is not supported\", version);")?;
+                writeln!(w, "if version != {exact} {{")?;
+                writeln!(
+                    w,
+                    "    bail!(\"specified version not supported by this message type\");"
+                )?;
                 writeln!(w, "}}")?;
             }
             VersionSpec::Since(since) => {
-                writeln!(w, "if version >= {} {{", since)?;
-                writeln!(w, "    bail!(\"{name} v{{}} is not supported\", version);")?;
+                writeln!(w, "if version >= {since} {{")?;
+                writeln!(
+                    w,
+                    "    bail!(\"specified version not supported by this message type\");"
+                )?;
                 writeln!(w, "}}")?;
             }
             VersionSpec::Range(start, end) => {
                 writeln!(w, "if version < {start} || version > {end} {{")?;
-                writeln!(w, "    bail!(\"{name} v{{}} is not supported\", version);")?;
+                writeln!(
+                    w,
+                    "    bail!(\"specified version not supported by this message type\");"
+                )?;
                 writeln!(w, "}}")?;
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,8 +21,8 @@
 //! request_header.correlation_id = 1;
 //! request_header.client_id = Some(StrBytes::from_static_str("test-client"));
 //! let mut buf = BytesMut::new();
-//! request_header.encode(&mut buf, 3);
-//! assert_eq!(request_header, RequestHeader::decode(&mut buf, 3).unwrap());
+//! request_header.encode(&mut buf, 2);
+//! assert_eq!(request_header, RequestHeader::decode(&mut buf, 2).unwrap());
 //! ```
 //! Note that every message implementation of [`Encodable::encode`](crate::protocol::Encodable::encode)
 //! and [`Decodable::decode`](crate::protocol::Decodable::decode) requires a version to be provided

--- a/src/messages/add_offsets_to_txn_request.rs
+++ b/src/messages/add_offsets_to_txn_request.rs
@@ -97,6 +97,9 @@ impl AddOffsetsToTxnRequest {
 #[cfg(feature = "client")]
 impl Encodable for AddOffsetsToTxnRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 4 {
+            bail!("AddOffsetsToTxnRequest v{} is not supported", version);
+        }
         if version >= 3 {
             types::CompactString.encode(buf, &self.transactional_id)?;
         } else {
@@ -156,6 +159,9 @@ impl Encodable for AddOffsetsToTxnRequest {
 #[cfg(feature = "broker")]
 impl Decodable for AddOffsetsToTxnRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 4 {
+            bail!("AddOffsetsToTxnRequest v{} is not supported", version);
+        }
         let transactional_id = if version >= 3 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/add_offsets_to_txn_request.rs
+++ b/src/messages/add_offsets_to_txn_request.rs
@@ -98,7 +98,7 @@ impl AddOffsetsToTxnRequest {
 impl Encodable for AddOffsetsToTxnRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 4 {
-            bail!("AddOffsetsToTxnRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 3 {
             types::CompactString.encode(buf, &self.transactional_id)?;
@@ -160,7 +160,7 @@ impl Encodable for AddOffsetsToTxnRequest {
 impl Decodable for AddOffsetsToTxnRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 4 {
-            bail!("AddOffsetsToTxnRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let transactional_id = if version >= 3 {
             types::CompactString.decode(buf)?

--- a/src/messages/add_offsets_to_txn_response.rs
+++ b/src/messages/add_offsets_to_txn_response.rs
@@ -69,6 +69,9 @@ impl AddOffsetsToTxnResponse {
 #[cfg(feature = "broker")]
 impl Encodable for AddOffsetsToTxnResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 4 {
+            bail!("AddOffsetsToTxnResponse v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 3 {
@@ -108,6 +111,9 @@ impl Encodable for AddOffsetsToTxnResponse {
 #[cfg(feature = "client")]
 impl Decodable for AddOffsetsToTxnResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 4 {
+            bail!("AddOffsetsToTxnResponse v{} is not supported", version);
+        }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();

--- a/src/messages/add_offsets_to_txn_response.rs
+++ b/src/messages/add_offsets_to_txn_response.rs
@@ -70,7 +70,7 @@ impl AddOffsetsToTxnResponse {
 impl Encodable for AddOffsetsToTxnResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 4 {
-            bail!("AddOffsetsToTxnResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -112,7 +112,7 @@ impl Encodable for AddOffsetsToTxnResponse {
 impl Decodable for AddOffsetsToTxnResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 4 {
-            bail!("AddOffsetsToTxnResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;

--- a/src/messages/add_partitions_to_txn_request.rs
+++ b/src/messages/add_partitions_to_txn_request.rs
@@ -112,7 +112,7 @@ impl AddPartitionsToTxnRequest {
 impl Encodable for AddPartitionsToTxnRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 5 {
-            bail!("AddPartitionsToTxnRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 4 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.transactions)?;
@@ -241,7 +241,7 @@ impl Encodable for AddPartitionsToTxnRequest {
 impl Decodable for AddPartitionsToTxnRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 5 {
-            bail!("AddPartitionsToTxnRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let transactions = if version >= 4 {
             types::CompactArray(types::Struct { version }).decode(buf)?
@@ -368,7 +368,7 @@ impl AddPartitionsToTxnTopic {
 impl Encodable for AddPartitionsToTxnTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 5 {
-            bail!("AddPartitionsToTxnTopic v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 3 {
             types::CompactString.encode(buf, &self.name)?;
@@ -426,7 +426,7 @@ impl Encodable for AddPartitionsToTxnTopic {
 impl Decodable for AddPartitionsToTxnTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 5 {
-            bail!("AddPartitionsToTxnTopic v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = if version >= 3 {
             types::CompactString.decode(buf)?
@@ -566,10 +566,7 @@ impl AddPartitionsToTxnTransaction {
 impl Encodable for AddPartitionsToTxnTransaction {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 5 {
-            bail!(
-                "AddPartitionsToTxnTransaction v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         if version >= 4 {
             types::CompactString.encode(buf, &self.transactional_id)?;
@@ -678,10 +675,7 @@ impl Encodable for AddPartitionsToTxnTransaction {
 impl Decodable for AddPartitionsToTxnTransaction {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 5 {
-            bail!(
-                "AddPartitionsToTxnTransaction v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         let transactional_id = if version >= 4 {
             types::CompactString.decode(buf)?

--- a/src/messages/add_partitions_to_txn_request.rs
+++ b/src/messages/add_partitions_to_txn_request.rs
@@ -111,6 +111,9 @@ impl AddPartitionsToTxnRequest {
 #[cfg(feature = "client")]
 impl Encodable for AddPartitionsToTxnRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 5 {
+            bail!("AddPartitionsToTxnRequest v{} is not supported", version);
+        }
         if version >= 4 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.transactions)?;
         } else {
@@ -237,6 +240,9 @@ impl Encodable for AddPartitionsToTxnRequest {
 #[cfg(feature = "broker")]
 impl Decodable for AddPartitionsToTxnRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 5 {
+            bail!("AddPartitionsToTxnRequest v{} is not supported", version);
+        }
         let transactions = if version >= 4 {
             types::CompactArray(types::Struct { version }).decode(buf)?
         } else {
@@ -361,6 +367,9 @@ impl AddPartitionsToTxnTopic {
 #[cfg(feature = "client")]
 impl Encodable for AddPartitionsToTxnTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 5 {
+            bail!("AddPartitionsToTxnTopic v{} is not supported", version);
+        }
         if version >= 3 {
             types::CompactString.encode(buf, &self.name)?;
         } else {
@@ -416,6 +425,9 @@ impl Encodable for AddPartitionsToTxnTopic {
 #[cfg(feature = "broker")]
 impl Decodable for AddPartitionsToTxnTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 5 {
+            bail!("AddPartitionsToTxnTopic v{} is not supported", version);
+        }
         let name = if version >= 3 {
             types::CompactString.decode(buf)?
         } else {
@@ -553,6 +565,12 @@ impl AddPartitionsToTxnTransaction {
 #[cfg(feature = "client")]
 impl Encodable for AddPartitionsToTxnTransaction {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 5 {
+            bail!(
+                "AddPartitionsToTxnTransaction v{} is not supported",
+                version
+            );
+        }
         if version >= 4 {
             types::CompactString.encode(buf, &self.transactional_id)?;
         } else {
@@ -659,6 +677,12 @@ impl Encodable for AddPartitionsToTxnTransaction {
 #[cfg(feature = "broker")]
 impl Decodable for AddPartitionsToTxnTransaction {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 5 {
+            bail!(
+                "AddPartitionsToTxnTransaction v{} is not supported",
+                version
+            );
+        }
         let transactional_id = if version >= 4 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/add_partitions_to_txn_response.rs
+++ b/src/messages/add_partitions_to_txn_response.rs
@@ -69,6 +69,12 @@ impl AddPartitionsToTxnPartitionResult {
 #[cfg(feature = "broker")]
 impl Encodable for AddPartitionsToTxnPartitionResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 5 {
+            bail!(
+                "AddPartitionsToTxnPartitionResult v{} is not supported",
+                version
+            );
+        }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int16.encode(buf, &self.partition_error_code)?;
         if version >= 3 {
@@ -108,6 +114,12 @@ impl Encodable for AddPartitionsToTxnPartitionResult {
 #[cfg(feature = "client")]
 impl Decodable for AddPartitionsToTxnPartitionResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 5 {
+            bail!(
+                "AddPartitionsToTxnPartitionResult v{} is not supported",
+                version
+            );
+        }
         let partition_index = types::Int32.decode(buf)?;
         let partition_error_code = types::Int16.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
@@ -226,6 +238,9 @@ impl AddPartitionsToTxnResponse {
 #[cfg(feature = "broker")]
 impl Encodable for AddPartitionsToTxnResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 5 {
+            bail!("AddPartitionsToTxnResponse v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         if version >= 4 {
             types::Int16.encode(buf, &self.error_code)?;
@@ -311,6 +326,9 @@ impl Encodable for AddPartitionsToTxnResponse {
 #[cfg(feature = "client")]
 impl Decodable for AddPartitionsToTxnResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 5 {
+            bail!("AddPartitionsToTxnResponse v{} is not supported", version);
+        }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = if version >= 4 {
             types::Int16.decode(buf)?
@@ -420,6 +438,9 @@ impl AddPartitionsToTxnResult {
 #[cfg(feature = "broker")]
 impl Encodable for AddPartitionsToTxnResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 5 {
+            bail!("AddPartitionsToTxnResult v{} is not supported", version);
+        }
         if version >= 4 {
             types::CompactString.encode(buf, &self.transactional_id)?;
         } else {
@@ -484,6 +505,9 @@ impl Encodable for AddPartitionsToTxnResult {
 #[cfg(feature = "client")]
 impl Decodable for AddPartitionsToTxnResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 5 {
+            bail!("AddPartitionsToTxnResult v{} is not supported", version);
+        }
         let transactional_id = if version >= 4 {
             types::CompactString.decode(buf)?
         } else {
@@ -582,6 +606,12 @@ impl AddPartitionsToTxnTopicResult {
 #[cfg(feature = "broker")]
 impl Encodable for AddPartitionsToTxnTopicResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 5 {
+            bail!(
+                "AddPartitionsToTxnTopicResult v{} is not supported",
+                version
+            );
+        }
         if version >= 3 {
             types::CompactString.encode(buf, &self.name)?;
         } else {
@@ -640,6 +670,12 @@ impl Encodable for AddPartitionsToTxnTopicResult {
 #[cfg(feature = "client")]
 impl Decodable for AddPartitionsToTxnTopicResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 5 {
+            bail!(
+                "AddPartitionsToTxnTopicResult v{} is not supported",
+                version
+            );
+        }
         let name = if version >= 3 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/add_partitions_to_txn_response.rs
+++ b/src/messages/add_partitions_to_txn_response.rs
@@ -70,10 +70,7 @@ impl AddPartitionsToTxnPartitionResult {
 impl Encodable for AddPartitionsToTxnPartitionResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 5 {
-            bail!(
-                "AddPartitionsToTxnPartitionResult v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int16.encode(buf, &self.partition_error_code)?;
@@ -115,10 +112,7 @@ impl Encodable for AddPartitionsToTxnPartitionResult {
 impl Decodable for AddPartitionsToTxnPartitionResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 5 {
-            bail!(
-                "AddPartitionsToTxnPartitionResult v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         let partition_index = types::Int32.decode(buf)?;
         let partition_error_code = types::Int16.decode(buf)?;
@@ -239,7 +233,7 @@ impl AddPartitionsToTxnResponse {
 impl Encodable for AddPartitionsToTxnResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 5 {
-            bail!("AddPartitionsToTxnResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         if version >= 4 {
@@ -327,7 +321,7 @@ impl Encodable for AddPartitionsToTxnResponse {
 impl Decodable for AddPartitionsToTxnResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 5 {
-            bail!("AddPartitionsToTxnResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = if version >= 4 {
@@ -439,7 +433,7 @@ impl AddPartitionsToTxnResult {
 impl Encodable for AddPartitionsToTxnResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 5 {
-            bail!("AddPartitionsToTxnResult v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 4 {
             types::CompactString.encode(buf, &self.transactional_id)?;
@@ -506,7 +500,7 @@ impl Encodable for AddPartitionsToTxnResult {
 impl Decodable for AddPartitionsToTxnResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 5 {
-            bail!("AddPartitionsToTxnResult v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let transactional_id = if version >= 4 {
             types::CompactString.decode(buf)?
@@ -607,10 +601,7 @@ impl AddPartitionsToTxnTopicResult {
 impl Encodable for AddPartitionsToTxnTopicResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 5 {
-            bail!(
-                "AddPartitionsToTxnTopicResult v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         if version >= 3 {
             types::CompactString.encode(buf, &self.name)?;
@@ -671,10 +662,7 @@ impl Encodable for AddPartitionsToTxnTopicResult {
 impl Decodable for AddPartitionsToTxnTopicResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 5 {
-            bail!(
-                "AddPartitionsToTxnTopicResult v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         let name = if version >= 3 {
             types::CompactString.decode(buf)?

--- a/src/messages/add_raft_voter_request.rs
+++ b/src/messages/add_raft_voter_request.rs
@@ -112,7 +112,7 @@ impl AddRaftVoterRequest {
 impl Encodable for AddRaftVoterRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("AddRaftVoterRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::CompactString.encode(buf, &self.cluster_id)?;
         types::Int32.encode(buf, &self.timeout_ms)?;
@@ -157,7 +157,7 @@ impl Encodable for AddRaftVoterRequest {
 impl Decodable for AddRaftVoterRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("AddRaftVoterRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let cluster_id = types::CompactString.decode(buf)?;
         let timeout_ms = types::Int32.decode(buf)?;
@@ -268,7 +268,7 @@ impl Listener {
 impl Encodable for Listener {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("Listener v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::CompactString.encode(buf, &self.name)?;
         types::CompactString.encode(buf, &self.host)?;
@@ -308,7 +308,7 @@ impl Encodable for Listener {
 impl Decodable for Listener {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("Listener v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = types::CompactString.decode(buf)?;
         let host = types::CompactString.decode(buf)?;

--- a/src/messages/add_raft_voter_request.rs
+++ b/src/messages/add_raft_voter_request.rs
@@ -111,6 +111,9 @@ impl AddRaftVoterRequest {
 #[cfg(feature = "client")]
 impl Encodable for AddRaftVoterRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("AddRaftVoterRequest v{} is not supported", version);
+        }
         types::CompactString.encode(buf, &self.cluster_id)?;
         types::Int32.encode(buf, &self.timeout_ms)?;
         types::Int32.encode(buf, &self.voter_id)?;
@@ -153,6 +156,9 @@ impl Encodable for AddRaftVoterRequest {
 #[cfg(feature = "broker")]
 impl Decodable for AddRaftVoterRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("AddRaftVoterRequest v{} is not supported", version);
+        }
         let cluster_id = types::CompactString.decode(buf)?;
         let timeout_ms = types::Int32.decode(buf)?;
         let voter_id = types::Int32.decode(buf)?;
@@ -261,6 +267,9 @@ impl Listener {
 #[cfg(feature = "client")]
 impl Encodable for Listener {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("Listener v{} is not supported", version);
+        }
         types::CompactString.encode(buf, &self.name)?;
         types::CompactString.encode(buf, &self.host)?;
         types::UInt16.encode(buf, &self.port)?;
@@ -298,6 +307,9 @@ impl Encodable for Listener {
 #[cfg(feature = "broker")]
 impl Decodable for Listener {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("Listener v{} is not supported", version);
+        }
         let name = types::CompactString.decode(buf)?;
         let host = types::CompactString.decode(buf)?;
         let port = types::UInt16.decode(buf)?;

--- a/src/messages/add_raft_voter_response.rs
+++ b/src/messages/add_raft_voter_response.rs
@@ -83,6 +83,9 @@ impl AddRaftVoterResponse {
 #[cfg(feature = "broker")]
 impl Encodable for AddRaftVoterResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("AddRaftVoterResponse v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
         types::CompactString.encode(buf, &self.error_message)?;
@@ -120,6 +123,9 @@ impl Encodable for AddRaftVoterResponse {
 #[cfg(feature = "client")]
 impl Decodable for AddRaftVoterResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("AddRaftVoterResponse v{} is not supported", version);
+        }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let error_message = types::CompactString.decode(buf)?;

--- a/src/messages/add_raft_voter_response.rs
+++ b/src/messages/add_raft_voter_response.rs
@@ -84,7 +84,7 @@ impl AddRaftVoterResponse {
 impl Encodable for AddRaftVoterResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("AddRaftVoterResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -124,7 +124,7 @@ impl Encodable for AddRaftVoterResponse {
 impl Decodable for AddRaftVoterResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("AddRaftVoterResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;

--- a/src/messages/allocate_producer_ids_request.rs
+++ b/src/messages/allocate_producer_ids_request.rs
@@ -70,7 +70,7 @@ impl AllocateProducerIdsRequest {
 impl Encodable for AllocateProducerIdsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("AllocateProducerIdsRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.broker_id)?;
         types::Int64.encode(buf, &self.broker_epoch)?;
@@ -108,7 +108,7 @@ impl Encodable for AllocateProducerIdsRequest {
 impl Decodable for AllocateProducerIdsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("AllocateProducerIdsRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let broker_id = types::Int32.decode(buf)?;
         let broker_epoch = types::Int64.decode(buf)?;

--- a/src/messages/allocate_producer_ids_request.rs
+++ b/src/messages/allocate_producer_ids_request.rs
@@ -69,6 +69,9 @@ impl AllocateProducerIdsRequest {
 #[cfg(feature = "client")]
 impl Encodable for AllocateProducerIdsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("AllocateProducerIdsRequest v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.broker_id)?;
         types::Int64.encode(buf, &self.broker_epoch)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -104,6 +107,9 @@ impl Encodable for AllocateProducerIdsRequest {
 #[cfg(feature = "broker")]
 impl Decodable for AllocateProducerIdsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("AllocateProducerIdsRequest v{} is not supported", version);
+        }
         let broker_id = types::Int32.decode(buf)?;
         let broker_epoch = types::Int64.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();

--- a/src/messages/allocate_producer_ids_response.rs
+++ b/src/messages/allocate_producer_ids_response.rs
@@ -97,6 +97,9 @@ impl AllocateProducerIdsResponse {
 #[cfg(feature = "broker")]
 impl Encodable for AllocateProducerIdsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("AllocateProducerIdsResponse v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
         types::Int64.encode(buf, &self.producer_id_start)?;
@@ -136,6 +139,9 @@ impl Encodable for AllocateProducerIdsResponse {
 #[cfg(feature = "client")]
 impl Decodable for AllocateProducerIdsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("AllocateProducerIdsResponse v{} is not supported", version);
+        }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let producer_id_start = types::Int64.decode(buf)?;

--- a/src/messages/allocate_producer_ids_response.rs
+++ b/src/messages/allocate_producer_ids_response.rs
@@ -98,7 +98,7 @@ impl AllocateProducerIdsResponse {
 impl Encodable for AllocateProducerIdsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("AllocateProducerIdsResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -140,7 +140,7 @@ impl Encodable for AllocateProducerIdsResponse {
 impl Decodable for AllocateProducerIdsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("AllocateProducerIdsResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;

--- a/src/messages/alter_client_quotas_request.rs
+++ b/src/messages/alter_client_quotas_request.rs
@@ -69,6 +69,9 @@ impl AlterClientQuotasRequest {
 #[cfg(feature = "client")]
 impl Encodable for AlterClientQuotasRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("AlterClientQuotasRequest v{} is not supported", version);
+        }
         if version >= 1 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.entries)?;
         } else {
@@ -117,6 +120,9 @@ impl Encodable for AlterClientQuotasRequest {
 #[cfg(feature = "broker")]
 impl Decodable for AlterClientQuotasRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("AlterClientQuotasRequest v{} is not supported", version);
+        }
         let entries = if version >= 1 {
             types::CompactArray(types::Struct { version }).decode(buf)?
         } else {
@@ -208,6 +214,9 @@ impl EntityData {
 #[cfg(feature = "client")]
 impl Encodable for EntityData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("EntityData v{} is not supported", version);
+        }
         if version >= 1 {
             types::CompactString.encode(buf, &self.entity_type)?;
         } else {
@@ -263,6 +272,9 @@ impl Encodable for EntityData {
 #[cfg(feature = "broker")]
 impl Decodable for EntityData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("EntityData v{} is not supported", version);
+        }
         let entity_type = if version >= 1 {
             types::CompactString.decode(buf)?
         } else {
@@ -358,6 +370,9 @@ impl EntryData {
 #[cfg(feature = "client")]
 impl Encodable for EntryData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("EntryData v{} is not supported", version);
+        }
         if version >= 1 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.entity)?;
         } else {
@@ -414,6 +429,9 @@ impl Encodable for EntryData {
 #[cfg(feature = "broker")]
 impl Decodable for EntryData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("EntryData v{} is not supported", version);
+        }
         let entity = if version >= 1 {
             types::CompactArray(types::Struct { version }).decode(buf)?
         } else {
@@ -523,6 +541,9 @@ impl OpData {
 #[cfg(feature = "client")]
 impl Encodable for OpData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("OpData v{} is not supported", version);
+        }
         if version >= 1 {
             types::CompactString.encode(buf, &self.key)?;
         } else {
@@ -572,6 +593,9 @@ impl Encodable for OpData {
 #[cfg(feature = "broker")]
 impl Decodable for OpData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("OpData v{} is not supported", version);
+        }
         let key = if version >= 1 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/alter_client_quotas_request.rs
+++ b/src/messages/alter_client_quotas_request.rs
@@ -70,7 +70,7 @@ impl AlterClientQuotasRequest {
 impl Encodable for AlterClientQuotasRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("AlterClientQuotasRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 1 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.entries)?;
@@ -121,7 +121,7 @@ impl Encodable for AlterClientQuotasRequest {
 impl Decodable for AlterClientQuotasRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("AlterClientQuotasRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let entries = if version >= 1 {
             types::CompactArray(types::Struct { version }).decode(buf)?
@@ -215,7 +215,7 @@ impl EntityData {
 impl Encodable for EntityData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("EntityData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 1 {
             types::CompactString.encode(buf, &self.entity_type)?;
@@ -273,7 +273,7 @@ impl Encodable for EntityData {
 impl Decodable for EntityData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("EntityData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let entity_type = if version >= 1 {
             types::CompactString.decode(buf)?
@@ -371,7 +371,7 @@ impl EntryData {
 impl Encodable for EntryData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("EntryData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 1 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.entity)?;
@@ -430,7 +430,7 @@ impl Encodable for EntryData {
 impl Decodable for EntryData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("EntryData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let entity = if version >= 1 {
             types::CompactArray(types::Struct { version }).decode(buf)?
@@ -542,7 +542,7 @@ impl OpData {
 impl Encodable for OpData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("OpData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 1 {
             types::CompactString.encode(buf, &self.key)?;
@@ -594,7 +594,7 @@ impl Encodable for OpData {
 impl Decodable for OpData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("OpData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let key = if version >= 1 {
             types::CompactString.decode(buf)?

--- a/src/messages/alter_client_quotas_response.rs
+++ b/src/messages/alter_client_quotas_response.rs
@@ -70,7 +70,7 @@ impl AlterClientQuotasResponse {
 impl Encodable for AlterClientQuotasResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("AlterClientQuotasResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         if version >= 1 {
@@ -121,7 +121,7 @@ impl Encodable for AlterClientQuotasResponse {
 impl Decodable for AlterClientQuotasResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("AlterClientQuotasResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let entries = if version >= 1 {
@@ -215,7 +215,7 @@ impl EntityData {
 impl Encodable for EntityData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("EntityData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 1 {
             types::CompactString.encode(buf, &self.entity_type)?;
@@ -273,7 +273,7 @@ impl Encodable for EntityData {
 impl Decodable for EntityData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("EntityData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let entity_type = if version >= 1 {
             types::CompactString.decode(buf)?
@@ -385,7 +385,7 @@ impl EntryData {
 impl Encodable for EntryData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("EntryData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 1 {
@@ -446,7 +446,7 @@ impl Encodable for EntryData {
 impl Decodable for EntryData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("EntryData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let error_code = types::Int16.decode(buf)?;
         let error_message = if version >= 1 {

--- a/src/messages/alter_client_quotas_response.rs
+++ b/src/messages/alter_client_quotas_response.rs
@@ -69,6 +69,9 @@ impl AlterClientQuotasResponse {
 #[cfg(feature = "broker")]
 impl Encodable for AlterClientQuotasResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("AlterClientQuotasResponse v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         if version >= 1 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.entries)?;
@@ -117,6 +120,9 @@ impl Encodable for AlterClientQuotasResponse {
 #[cfg(feature = "client")]
 impl Decodable for AlterClientQuotasResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("AlterClientQuotasResponse v{} is not supported", version);
+        }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let entries = if version >= 1 {
             types::CompactArray(types::Struct { version }).decode(buf)?
@@ -208,6 +214,9 @@ impl EntityData {
 #[cfg(feature = "broker")]
 impl Encodable for EntityData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("EntityData v{} is not supported", version);
+        }
         if version >= 1 {
             types::CompactString.encode(buf, &self.entity_type)?;
         } else {
@@ -263,6 +272,9 @@ impl Encodable for EntityData {
 #[cfg(feature = "client")]
 impl Decodable for EntityData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("EntityData v{} is not supported", version);
+        }
         let entity_type = if version >= 1 {
             types::CompactString.decode(buf)?
         } else {
@@ -372,6 +384,9 @@ impl EntryData {
 #[cfg(feature = "broker")]
 impl Encodable for EntryData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("EntryData v{} is not supported", version);
+        }
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 1 {
             types::CompactString.encode(buf, &self.error_message)?;
@@ -430,6 +445,9 @@ impl Encodable for EntryData {
 #[cfg(feature = "client")]
 impl Decodable for EntryData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("EntryData v{} is not supported", version);
+        }
         let error_code = types::Int16.decode(buf)?;
         let error_message = if version >= 1 {
             types::CompactString.decode(buf)?

--- a/src/messages/alter_configs_request.rs
+++ b/src/messages/alter_configs_request.rs
@@ -69,6 +69,9 @@ impl AlterConfigsRequest {
 #[cfg(feature = "client")]
 impl Encodable for AlterConfigsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 2 {
+            bail!("AlterConfigsRequest v{} is not supported", version);
+        }
         if version >= 2 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.resources)?;
         } else {
@@ -117,6 +120,9 @@ impl Encodable for AlterConfigsRequest {
 #[cfg(feature = "broker")]
 impl Decodable for AlterConfigsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 2 {
+            bail!("AlterConfigsRequest v{} is not supported", version);
+        }
         let resources = if version >= 2 {
             types::CompactArray(types::Struct { version }).decode(buf)?
         } else {
@@ -222,6 +228,9 @@ impl AlterConfigsResource {
 #[cfg(feature = "client")]
 impl Encodable for AlterConfigsResource {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 2 {
+            bail!("AlterConfigsResource v{} is not supported", version);
+        }
         types::Int8.encode(buf, &self.resource_type)?;
         if version >= 2 {
             types::CompactString.encode(buf, &self.resource_name)?;
@@ -280,6 +289,9 @@ impl Encodable for AlterConfigsResource {
 #[cfg(feature = "broker")]
 impl Decodable for AlterConfigsResource {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 2 {
+            bail!("AlterConfigsResource v{} is not supported", version);
+        }
         let resource_type = types::Int8.decode(buf)?;
         let resource_name = if version >= 2 {
             types::CompactString.decode(buf)?
@@ -378,6 +390,9 @@ impl AlterableConfig {
 #[cfg(feature = "client")]
 impl Encodable for AlterableConfig {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 2 {
+            bail!("AlterableConfig v{} is not supported", version);
+        }
         if version >= 2 {
             types::CompactString.encode(buf, &self.name)?;
         } else {
@@ -433,6 +448,9 @@ impl Encodable for AlterableConfig {
 #[cfg(feature = "broker")]
 impl Decodable for AlterableConfig {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 2 {
+            bail!("AlterableConfig v{} is not supported", version);
+        }
         let name = if version >= 2 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/alter_configs_request.rs
+++ b/src/messages/alter_configs_request.rs
@@ -70,7 +70,7 @@ impl AlterConfigsRequest {
 impl Encodable for AlterConfigsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 2 {
-            bail!("AlterConfigsRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 2 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.resources)?;
@@ -121,7 +121,7 @@ impl Encodable for AlterConfigsRequest {
 impl Decodable for AlterConfigsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 2 {
-            bail!("AlterConfigsRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let resources = if version >= 2 {
             types::CompactArray(types::Struct { version }).decode(buf)?
@@ -229,7 +229,7 @@ impl AlterConfigsResource {
 impl Encodable for AlterConfigsResource {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 2 {
-            bail!("AlterConfigsResource v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int8.encode(buf, &self.resource_type)?;
         if version >= 2 {
@@ -290,7 +290,7 @@ impl Encodable for AlterConfigsResource {
 impl Decodable for AlterConfigsResource {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 2 {
-            bail!("AlterConfigsResource v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let resource_type = types::Int8.decode(buf)?;
         let resource_name = if version >= 2 {
@@ -391,7 +391,7 @@ impl AlterableConfig {
 impl Encodable for AlterableConfig {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 2 {
-            bail!("AlterableConfig v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 2 {
             types::CompactString.encode(buf, &self.name)?;
@@ -449,7 +449,7 @@ impl Encodable for AlterableConfig {
 impl Decodable for AlterableConfig {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 2 {
-            bail!("AlterableConfig v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = if version >= 2 {
             types::CompactString.decode(buf)?

--- a/src/messages/alter_configs_response.rs
+++ b/src/messages/alter_configs_response.rs
@@ -98,7 +98,7 @@ impl AlterConfigsResourceResponse {
 impl Encodable for AlterConfigsResourceResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 2 {
-            bail!("AlterConfigsResourceResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 2 {
@@ -160,7 +160,7 @@ impl Encodable for AlterConfigsResourceResponse {
 impl Decodable for AlterConfigsResourceResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 2 {
-            bail!("AlterConfigsResourceResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let error_code = types::Int16.decode(buf)?;
         let error_message = if version >= 2 {
@@ -264,7 +264,7 @@ impl AlterConfigsResponse {
 impl Encodable for AlterConfigsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 2 {
-            bail!("AlterConfigsResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         if version >= 2 {
@@ -315,7 +315,7 @@ impl Encodable for AlterConfigsResponse {
 impl Decodable for AlterConfigsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 2 {
-            bail!("AlterConfigsResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let responses = if version >= 2 {

--- a/src/messages/alter_configs_response.rs
+++ b/src/messages/alter_configs_response.rs
@@ -97,6 +97,9 @@ impl AlterConfigsResourceResponse {
 #[cfg(feature = "broker")]
 impl Encodable for AlterConfigsResourceResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 2 {
+            bail!("AlterConfigsResourceResponse v{} is not supported", version);
+        }
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 2 {
             types::CompactString.encode(buf, &self.error_message)?;
@@ -156,6 +159,9 @@ impl Encodable for AlterConfigsResourceResponse {
 #[cfg(feature = "client")]
 impl Decodable for AlterConfigsResourceResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 2 {
+            bail!("AlterConfigsResourceResponse v{} is not supported", version);
+        }
         let error_code = types::Int16.decode(buf)?;
         let error_message = if version >= 2 {
             types::CompactString.decode(buf)?
@@ -257,6 +263,9 @@ impl AlterConfigsResponse {
 #[cfg(feature = "broker")]
 impl Encodable for AlterConfigsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 2 {
+            bail!("AlterConfigsResponse v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         if version >= 2 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.responses)?;
@@ -305,6 +314,9 @@ impl Encodable for AlterConfigsResponse {
 #[cfg(feature = "client")]
 impl Decodable for AlterConfigsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 2 {
+            bail!("AlterConfigsResponse v{} is not supported", version);
+        }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let responses = if version >= 2 {
             types::CompactArray(types::Struct { version }).decode(buf)?

--- a/src/messages/alter_partition_reassignments_request.rs
+++ b/src/messages/alter_partition_reassignments_request.rs
@@ -69,6 +69,12 @@ impl AlterPartitionReassignmentsRequest {
 #[cfg(feature = "client")]
 impl Encodable for AlterPartitionReassignmentsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!(
+                "AlterPartitionReassignmentsRequest v{} is not supported",
+                version
+            );
+        }
         types::Int32.encode(buf, &self.timeout_ms)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -104,6 +110,12 @@ impl Encodable for AlterPartitionReassignmentsRequest {
 #[cfg(feature = "broker")]
 impl Decodable for AlterPartitionReassignmentsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!(
+                "AlterPartitionReassignmentsRequest v{} is not supported",
+                version
+            );
+        }
         let timeout_ms = types::Int32.decode(buf)?;
         let topics = types::CompactArray(types::Struct { version }).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
@@ -189,6 +201,9 @@ impl ReassignablePartition {
 #[cfg(feature = "client")]
 impl Encodable for ReassignablePartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("ReassignablePartition v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.partition_index)?;
         types::CompactArray(types::Int32).encode(buf, &self.replicas)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -224,6 +239,9 @@ impl Encodable for ReassignablePartition {
 #[cfg(feature = "broker")]
 impl Decodable for ReassignablePartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("ReassignablePartition v{} is not supported", version);
+        }
         let partition_index = types::Int32.decode(buf)?;
         let replicas = types::CompactArray(types::Int32).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
@@ -309,6 +327,9 @@ impl ReassignableTopic {
 #[cfg(feature = "client")]
 impl Encodable for ReassignableTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("ReassignableTopic v{} is not supported", version);
+        }
         types::CompactString.encode(buf, &self.name)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.partitions)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -345,6 +366,9 @@ impl Encodable for ReassignableTopic {
 #[cfg(feature = "broker")]
 impl Decodable for ReassignableTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("ReassignableTopic v{} is not supported", version);
+        }
         let name = types::CompactString.decode(buf)?;
         let partitions = types::CompactArray(types::Struct { version }).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();

--- a/src/messages/alter_partition_reassignments_request.rs
+++ b/src/messages/alter_partition_reassignments_request.rs
@@ -70,10 +70,7 @@ impl AlterPartitionReassignmentsRequest {
 impl Encodable for AlterPartitionReassignmentsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!(
-                "AlterPartitionReassignmentsRequest v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.timeout_ms)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
@@ -111,10 +108,7 @@ impl Encodable for AlterPartitionReassignmentsRequest {
 impl Decodable for AlterPartitionReassignmentsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!(
-                "AlterPartitionReassignmentsRequest v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         let timeout_ms = types::Int32.decode(buf)?;
         let topics = types::CompactArray(types::Struct { version }).decode(buf)?;
@@ -202,7 +196,7 @@ impl ReassignablePartition {
 impl Encodable for ReassignablePartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("ReassignablePartition v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.partition_index)?;
         types::CompactArray(types::Int32).encode(buf, &self.replicas)?;
@@ -240,7 +234,7 @@ impl Encodable for ReassignablePartition {
 impl Decodable for ReassignablePartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("ReassignablePartition v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let partition_index = types::Int32.decode(buf)?;
         let replicas = types::CompactArray(types::Int32).decode(buf)?;
@@ -328,7 +322,7 @@ impl ReassignableTopic {
 impl Encodable for ReassignableTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("ReassignableTopic v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::CompactString.encode(buf, &self.name)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.partitions)?;
@@ -367,7 +361,7 @@ impl Encodable for ReassignableTopic {
 impl Decodable for ReassignableTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("ReassignableTopic v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = types::CompactString.decode(buf)?;
         let partitions = types::CompactArray(types::Struct { version }).decode(buf)?;

--- a/src/messages/alter_partition_reassignments_response.rs
+++ b/src/messages/alter_partition_reassignments_response.rs
@@ -97,6 +97,12 @@ impl AlterPartitionReassignmentsResponse {
 #[cfg(feature = "broker")]
 impl Encodable for AlterPartitionReassignmentsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!(
+                "AlterPartitionReassignmentsResponse v{} is not supported",
+                version
+            );
+        }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
         types::CompactString.encode(buf, &self.error_message)?;
@@ -137,6 +143,12 @@ impl Encodable for AlterPartitionReassignmentsResponse {
 #[cfg(feature = "client")]
 impl Decodable for AlterPartitionReassignmentsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!(
+                "AlterPartitionReassignmentsResponse v{} is not supported",
+                version
+            );
+        }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let error_message = types::CompactString.decode(buf)?;
@@ -242,6 +254,12 @@ impl ReassignablePartitionResponse {
 #[cfg(feature = "broker")]
 impl Encodable for ReassignablePartitionResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!(
+                "ReassignablePartitionResponse v{} is not supported",
+                version
+            );
+        }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int16.encode(buf, &self.error_code)?;
         types::CompactString.encode(buf, &self.error_message)?;
@@ -279,6 +297,12 @@ impl Encodable for ReassignablePartitionResponse {
 #[cfg(feature = "client")]
 impl Decodable for ReassignablePartitionResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!(
+                "ReassignablePartitionResponse v{} is not supported",
+                version
+            );
+        }
         let partition_index = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let error_message = types::CompactString.decode(buf)?;
@@ -367,6 +391,9 @@ impl ReassignableTopicResponse {
 #[cfg(feature = "broker")]
 impl Encodable for ReassignableTopicResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("ReassignableTopicResponse v{} is not supported", version);
+        }
         types::CompactString.encode(buf, &self.name)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.partitions)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -403,6 +430,9 @@ impl Encodable for ReassignableTopicResponse {
 #[cfg(feature = "client")]
 impl Decodable for ReassignableTopicResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("ReassignableTopicResponse v{} is not supported", version);
+        }
         let name = types::CompactString.decode(buf)?;
         let partitions = types::CompactArray(types::Struct { version }).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();

--- a/src/messages/alter_partition_reassignments_response.rs
+++ b/src/messages/alter_partition_reassignments_response.rs
@@ -98,10 +98,7 @@ impl AlterPartitionReassignmentsResponse {
 impl Encodable for AlterPartitionReassignmentsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!(
-                "AlterPartitionReassignmentsResponse v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -144,10 +141,7 @@ impl Encodable for AlterPartitionReassignmentsResponse {
 impl Decodable for AlterPartitionReassignmentsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!(
-                "AlterPartitionReassignmentsResponse v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
@@ -255,10 +249,7 @@ impl ReassignablePartitionResponse {
 impl Encodable for ReassignablePartitionResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!(
-                "ReassignablePartitionResponse v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -298,10 +289,7 @@ impl Encodable for ReassignablePartitionResponse {
 impl Decodable for ReassignablePartitionResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!(
-                "ReassignablePartitionResponse v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         let partition_index = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
@@ -392,7 +380,7 @@ impl ReassignableTopicResponse {
 impl Encodable for ReassignableTopicResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("ReassignableTopicResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::CompactString.encode(buf, &self.name)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.partitions)?;
@@ -431,7 +419,7 @@ impl Encodable for ReassignableTopicResponse {
 impl Decodable for ReassignableTopicResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("ReassignableTopicResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = types::CompactString.decode(buf)?;
         let partitions = types::CompactArray(types::Struct { version }).decode(buf)?;

--- a/src/messages/alter_partition_request.rs
+++ b/src/messages/alter_partition_request.rs
@@ -83,6 +83,9 @@ impl AlterPartitionRequest {
 #[cfg(feature = "client")]
 impl Encodable for AlterPartitionRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 3 {
+            bail!("AlterPartitionRequest v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.broker_id)?;
         types::Int64.encode(buf, &self.broker_epoch)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
@@ -120,6 +123,9 @@ impl Encodable for AlterPartitionRequest {
 #[cfg(feature = "broker")]
 impl Decodable for AlterPartitionRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 3 {
+            bail!("AlterPartitionRequest v{} is not supported", version);
+        }
         let broker_id = types::Int32.decode(buf)?;
         let broker_epoch = types::Int64.decode(buf)?;
         let topics = types::CompactArray(types::Struct { version }).decode(buf)?;
@@ -208,6 +214,9 @@ impl BrokerState {
 #[cfg(feature = "client")]
 impl Encodable for BrokerState {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 3 {
+            bail!("BrokerState v{} is not supported", version);
+        }
         if version >= 3 {
             types::Int32.encode(buf, &self.broker_id)?;
         } else {
@@ -267,6 +276,9 @@ impl Encodable for BrokerState {
 #[cfg(feature = "broker")]
 impl Decodable for BrokerState {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 3 {
+            bail!("BrokerState v{} is not supported", version);
+        }
         let broker_id = if version >= 3 {
             types::Int32.decode(buf)?
         } else {
@@ -416,6 +428,9 @@ impl PartitionData {
 #[cfg(feature = "client")]
 impl Encodable for PartitionData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 3 {
+            bail!("PartitionData v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int32.encode(buf, &self.leader_epoch)?;
         if version <= 2 {
@@ -497,6 +512,9 @@ impl Encodable for PartitionData {
 #[cfg(feature = "broker")]
 impl Decodable for PartitionData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 3 {
+            bail!("PartitionData v{} is not supported", version);
+        }
         let partition_index = types::Int32.decode(buf)?;
         let leader_epoch = types::Int32.decode(buf)?;
         let new_isr = if version <= 2 {
@@ -620,6 +638,9 @@ impl TopicData {
 #[cfg(feature = "client")]
 impl Encodable for TopicData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 3 {
+            bail!("TopicData v{} is not supported", version);
+        }
         if version <= 1 {
             types::CompactString.encode(buf, &self.topic_name)?;
         }
@@ -666,6 +687,9 @@ impl Encodable for TopicData {
 #[cfg(feature = "broker")]
 impl Decodable for TopicData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 3 {
+            bail!("TopicData v{} is not supported", version);
+        }
         let topic_name = if version <= 1 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/alter_partition_request.rs
+++ b/src/messages/alter_partition_request.rs
@@ -84,7 +84,7 @@ impl AlterPartitionRequest {
 impl Encodable for AlterPartitionRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 3 {
-            bail!("AlterPartitionRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.broker_id)?;
         types::Int64.encode(buf, &self.broker_epoch)?;
@@ -124,7 +124,7 @@ impl Encodable for AlterPartitionRequest {
 impl Decodable for AlterPartitionRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 3 {
-            bail!("AlterPartitionRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let broker_id = types::Int32.decode(buf)?;
         let broker_epoch = types::Int64.decode(buf)?;
@@ -215,7 +215,7 @@ impl BrokerState {
 impl Encodable for BrokerState {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 3 {
-            bail!("BrokerState v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 3 {
             types::Int32.encode(buf, &self.broker_id)?;
@@ -277,7 +277,7 @@ impl Encodable for BrokerState {
 impl Decodable for BrokerState {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 3 {
-            bail!("BrokerState v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let broker_id = if version >= 3 {
             types::Int32.decode(buf)?
@@ -429,7 +429,7 @@ impl PartitionData {
 impl Encodable for PartitionData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 3 {
-            bail!("PartitionData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int32.encode(buf, &self.leader_epoch)?;
@@ -513,7 +513,7 @@ impl Encodable for PartitionData {
 impl Decodable for PartitionData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 3 {
-            bail!("PartitionData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let partition_index = types::Int32.decode(buf)?;
         let leader_epoch = types::Int32.decode(buf)?;
@@ -639,7 +639,7 @@ impl TopicData {
 impl Encodable for TopicData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 3 {
-            bail!("TopicData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version <= 1 {
             types::CompactString.encode(buf, &self.topic_name)?;
@@ -688,7 +688,7 @@ impl Encodable for TopicData {
 impl Decodable for TopicData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 3 {
-            bail!("TopicData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topic_name = if version <= 1 {
             types::CompactString.decode(buf)?

--- a/src/messages/alter_partition_response.rs
+++ b/src/messages/alter_partition_response.rs
@@ -84,7 +84,7 @@ impl AlterPartitionResponse {
 impl Encodable for AlterPartitionResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 3 {
-            bail!("AlterPartitionResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -124,7 +124,7 @@ impl Encodable for AlterPartitionResponse {
 impl Decodable for AlterPartitionResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 3 {
-            bail!("AlterPartitionResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
@@ -285,7 +285,7 @@ impl PartitionData {
 impl Encodable for PartitionData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 3 {
-            bail!("PartitionData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -337,7 +337,7 @@ impl Encodable for PartitionData {
 impl Decodable for PartitionData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 3 {
-            bail!("PartitionData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let partition_index = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
@@ -458,7 +458,7 @@ impl TopicData {
 impl Encodable for TopicData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 3 {
-            bail!("TopicData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version <= 1 {
             types::CompactString.encode(buf, &self.topic_name)?;
@@ -507,7 +507,7 @@ impl Encodable for TopicData {
 impl Decodable for TopicData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 3 {
-            bail!("TopicData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topic_name = if version <= 1 {
             types::CompactString.decode(buf)?

--- a/src/messages/alter_partition_response.rs
+++ b/src/messages/alter_partition_response.rs
@@ -83,6 +83,9 @@ impl AlterPartitionResponse {
 #[cfg(feature = "broker")]
 impl Encodable for AlterPartitionResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 3 {
+            bail!("AlterPartitionResponse v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
@@ -120,6 +123,9 @@ impl Encodable for AlterPartitionResponse {
 #[cfg(feature = "client")]
 impl Decodable for AlterPartitionResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 3 {
+            bail!("AlterPartitionResponse v{} is not supported", version);
+        }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let topics = types::CompactArray(types::Struct { version }).decode(buf)?;
@@ -278,6 +284,9 @@ impl PartitionData {
 #[cfg(feature = "broker")]
 impl Encodable for PartitionData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 3 {
+            bail!("PartitionData v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int16.encode(buf, &self.error_code)?;
         types::Int32.encode(buf, &self.leader_id)?;
@@ -327,6 +336,9 @@ impl Encodable for PartitionData {
 #[cfg(feature = "client")]
 impl Decodable for PartitionData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 3 {
+            bail!("PartitionData v{} is not supported", version);
+        }
         let partition_index = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let leader_id = types::Int32.decode(buf)?;
@@ -445,6 +457,9 @@ impl TopicData {
 #[cfg(feature = "broker")]
 impl Encodable for TopicData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 3 {
+            bail!("TopicData v{} is not supported", version);
+        }
         if version <= 1 {
             types::CompactString.encode(buf, &self.topic_name)?;
         }
@@ -491,6 +506,9 @@ impl Encodable for TopicData {
 #[cfg(feature = "client")]
 impl Decodable for TopicData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 3 {
+            bail!("TopicData v{} is not supported", version);
+        }
         let topic_name = if version <= 1 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/alter_replica_log_dirs_request.rs
+++ b/src/messages/alter_replica_log_dirs_request.rs
@@ -70,7 +70,7 @@ impl AlterReplicaLogDir {
 impl Encodable for AlterReplicaLogDir {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 2 {
-            bail!("AlterReplicaLogDir v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 2 {
             types::CompactString.encode(buf, &self.path)?;
@@ -129,7 +129,7 @@ impl Encodable for AlterReplicaLogDir {
 impl Decodable for AlterReplicaLogDir {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 2 {
-            bail!("AlterReplicaLogDir v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let path = if version >= 2 {
             types::CompactString.decode(buf)?
@@ -227,7 +227,7 @@ impl AlterReplicaLogDirTopic {
 impl Encodable for AlterReplicaLogDirTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 2 {
-            bail!("AlterReplicaLogDirTopic v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 2 {
             types::CompactString.encode(buf, &self.name)?;
@@ -285,7 +285,7 @@ impl Encodable for AlterReplicaLogDirTopic {
 impl Decodable for AlterReplicaLogDirTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 2 {
-            bail!("AlterReplicaLogDirTopic v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = if version >= 2 {
             types::CompactString.decode(buf)?
@@ -369,7 +369,7 @@ impl AlterReplicaLogDirsRequest {
 impl Encodable for AlterReplicaLogDirsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 2 {
-            bail!("AlterReplicaLogDirsRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 2 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.dirs)?;
@@ -418,7 +418,7 @@ impl Encodable for AlterReplicaLogDirsRequest {
 impl Decodable for AlterReplicaLogDirsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 2 {
-            bail!("AlterReplicaLogDirsRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let dirs = if version >= 2 {
             types::CompactArray(types::Struct { version }).decode(buf)?

--- a/src/messages/alter_replica_log_dirs_request.rs
+++ b/src/messages/alter_replica_log_dirs_request.rs
@@ -69,6 +69,9 @@ impl AlterReplicaLogDir {
 #[cfg(feature = "client")]
 impl Encodable for AlterReplicaLogDir {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 2 {
+            bail!("AlterReplicaLogDir v{} is not supported", version);
+        }
         if version >= 2 {
             types::CompactString.encode(buf, &self.path)?;
         } else {
@@ -125,6 +128,9 @@ impl Encodable for AlterReplicaLogDir {
 #[cfg(feature = "broker")]
 impl Decodable for AlterReplicaLogDir {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 2 {
+            bail!("AlterReplicaLogDir v{} is not supported", version);
+        }
         let path = if version >= 2 {
             types::CompactString.decode(buf)?
         } else {
@@ -220,6 +226,9 @@ impl AlterReplicaLogDirTopic {
 #[cfg(feature = "client")]
 impl Encodable for AlterReplicaLogDirTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 2 {
+            bail!("AlterReplicaLogDirTopic v{} is not supported", version);
+        }
         if version >= 2 {
             types::CompactString.encode(buf, &self.name)?;
         } else {
@@ -275,6 +284,9 @@ impl Encodable for AlterReplicaLogDirTopic {
 #[cfg(feature = "broker")]
 impl Decodable for AlterReplicaLogDirTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 2 {
+            bail!("AlterReplicaLogDirTopic v{} is not supported", version);
+        }
         let name = if version >= 2 {
             types::CompactString.decode(buf)?
         } else {
@@ -356,6 +368,9 @@ impl AlterReplicaLogDirsRequest {
 #[cfg(feature = "client")]
 impl Encodable for AlterReplicaLogDirsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 2 {
+            bail!("AlterReplicaLogDirsRequest v{} is not supported", version);
+        }
         if version >= 2 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.dirs)?;
         } else {
@@ -402,6 +417,9 @@ impl Encodable for AlterReplicaLogDirsRequest {
 #[cfg(feature = "broker")]
 impl Decodable for AlterReplicaLogDirsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 2 {
+            bail!("AlterReplicaLogDirsRequest v{} is not supported", version);
+        }
         let dirs = if version >= 2 {
             types::CompactArray(types::Struct { version }).decode(buf)?
         } else {

--- a/src/messages/alter_replica_log_dirs_response.rs
+++ b/src/messages/alter_replica_log_dirs_response.rs
@@ -69,6 +69,12 @@ impl AlterReplicaLogDirPartitionResult {
 #[cfg(feature = "broker")]
 impl Encodable for AlterReplicaLogDirPartitionResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 2 {
+            bail!(
+                "AlterReplicaLogDirPartitionResult v{} is not supported",
+                version
+            );
+        }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 2 {
@@ -108,6 +114,12 @@ impl Encodable for AlterReplicaLogDirPartitionResult {
 #[cfg(feature = "client")]
 impl Decodable for AlterReplicaLogDirPartitionResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 2 {
+            bail!(
+                "AlterReplicaLogDirPartitionResult v{} is not supported",
+                version
+            );
+        }
         let partition_index = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
@@ -195,6 +207,12 @@ impl AlterReplicaLogDirTopicResult {
 #[cfg(feature = "broker")]
 impl Encodable for AlterReplicaLogDirTopicResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 2 {
+            bail!(
+                "AlterReplicaLogDirTopicResult v{} is not supported",
+                version
+            );
+        }
         if version >= 2 {
             types::CompactString.encode(buf, &self.topic_name)?;
         } else {
@@ -251,6 +269,12 @@ impl Encodable for AlterReplicaLogDirTopicResult {
 #[cfg(feature = "client")]
 impl Decodable for AlterReplicaLogDirTopicResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 2 {
+            bail!(
+                "AlterReplicaLogDirTopicResult v{} is not supported",
+                version
+            );
+        }
         let topic_name = if version >= 2 {
             types::CompactString.decode(buf)?
         } else {
@@ -346,6 +370,9 @@ impl AlterReplicaLogDirsResponse {
 #[cfg(feature = "broker")]
 impl Encodable for AlterReplicaLogDirsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 2 {
+            bail!("AlterReplicaLogDirsResponse v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         if version >= 2 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.results)?;
@@ -394,6 +421,9 @@ impl Encodable for AlterReplicaLogDirsResponse {
 #[cfg(feature = "client")]
 impl Decodable for AlterReplicaLogDirsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 2 {
+            bail!("AlterReplicaLogDirsResponse v{} is not supported", version);
+        }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let results = if version >= 2 {
             types::CompactArray(types::Struct { version }).decode(buf)?

--- a/src/messages/alter_replica_log_dirs_response.rs
+++ b/src/messages/alter_replica_log_dirs_response.rs
@@ -70,10 +70,7 @@ impl AlterReplicaLogDirPartitionResult {
 impl Encodable for AlterReplicaLogDirPartitionResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 2 {
-            bail!(
-                "AlterReplicaLogDirPartitionResult v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -115,10 +112,7 @@ impl Encodable for AlterReplicaLogDirPartitionResult {
 impl Decodable for AlterReplicaLogDirPartitionResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 2 {
-            bail!(
-                "AlterReplicaLogDirPartitionResult v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         let partition_index = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
@@ -208,10 +202,7 @@ impl AlterReplicaLogDirTopicResult {
 impl Encodable for AlterReplicaLogDirTopicResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 2 {
-            bail!(
-                "AlterReplicaLogDirTopicResult v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         if version >= 2 {
             types::CompactString.encode(buf, &self.topic_name)?;
@@ -270,10 +261,7 @@ impl Encodable for AlterReplicaLogDirTopicResult {
 impl Decodable for AlterReplicaLogDirTopicResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 2 {
-            bail!(
-                "AlterReplicaLogDirTopicResult v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         let topic_name = if version >= 2 {
             types::CompactString.decode(buf)?
@@ -371,7 +359,7 @@ impl AlterReplicaLogDirsResponse {
 impl Encodable for AlterReplicaLogDirsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 2 {
-            bail!("AlterReplicaLogDirsResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         if version >= 2 {
@@ -422,7 +410,7 @@ impl Encodable for AlterReplicaLogDirsResponse {
 impl Decodable for AlterReplicaLogDirsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 2 {
-            bail!("AlterReplicaLogDirsResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let results = if version >= 2 {

--- a/src/messages/alter_user_scram_credentials_request.rs
+++ b/src/messages/alter_user_scram_credentials_request.rs
@@ -70,10 +70,7 @@ impl AlterUserScramCredentialsRequest {
 impl Encodable for AlterUserScramCredentialsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!(
-                "AlterUserScramCredentialsRequest v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         types::CompactArray(types::Struct { version }).encode(buf, &self.deletions)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.upsertions)?;
@@ -113,10 +110,7 @@ impl Encodable for AlterUserScramCredentialsRequest {
 impl Decodable for AlterUserScramCredentialsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!(
-                "AlterUserScramCredentialsRequest v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         let deletions = types::CompactArray(types::Struct { version }).decode(buf)?;
         let upsertions = types::CompactArray(types::Struct { version }).decode(buf)?;
@@ -204,7 +198,7 @@ impl ScramCredentialDeletion {
 impl Encodable for ScramCredentialDeletion {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("ScramCredentialDeletion v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::CompactString.encode(buf, &self.name)?;
         types::Int8.encode(buf, &self.mechanism)?;
@@ -242,7 +236,7 @@ impl Encodable for ScramCredentialDeletion {
 impl Decodable for ScramCredentialDeletion {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("ScramCredentialDeletion v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = types::CompactString.decode(buf)?;
         let mechanism = types::Int8.decode(buf)?;
@@ -372,7 +366,7 @@ impl ScramCredentialUpsertion {
 impl Encodable for ScramCredentialUpsertion {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("ScramCredentialUpsertion v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::CompactString.encode(buf, &self.name)?;
         types::Int8.encode(buf, &self.mechanism)?;
@@ -416,7 +410,7 @@ impl Encodable for ScramCredentialUpsertion {
 impl Decodable for ScramCredentialUpsertion {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("ScramCredentialUpsertion v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = types::CompactString.decode(buf)?;
         let mechanism = types::Int8.decode(buf)?;

--- a/src/messages/alter_user_scram_credentials_request.rs
+++ b/src/messages/alter_user_scram_credentials_request.rs
@@ -69,6 +69,12 @@ impl AlterUserScramCredentialsRequest {
 #[cfg(feature = "client")]
 impl Encodable for AlterUserScramCredentialsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!(
+                "AlterUserScramCredentialsRequest v{} is not supported",
+                version
+            );
+        }
         types::CompactArray(types::Struct { version }).encode(buf, &self.deletions)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.upsertions)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -106,6 +112,12 @@ impl Encodable for AlterUserScramCredentialsRequest {
 #[cfg(feature = "broker")]
 impl Decodable for AlterUserScramCredentialsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!(
+                "AlterUserScramCredentialsRequest v{} is not supported",
+                version
+            );
+        }
         let deletions = types::CompactArray(types::Struct { version }).decode(buf)?;
         let upsertions = types::CompactArray(types::Struct { version }).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
@@ -191,6 +203,9 @@ impl ScramCredentialDeletion {
 #[cfg(feature = "client")]
 impl Encodable for ScramCredentialDeletion {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("ScramCredentialDeletion v{} is not supported", version);
+        }
         types::CompactString.encode(buf, &self.name)?;
         types::Int8.encode(buf, &self.mechanism)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -226,6 +241,9 @@ impl Encodable for ScramCredentialDeletion {
 #[cfg(feature = "broker")]
 impl Decodable for ScramCredentialDeletion {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("ScramCredentialDeletion v{} is not supported", version);
+        }
         let name = types::CompactString.decode(buf)?;
         let mechanism = types::Int8.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
@@ -353,6 +371,9 @@ impl ScramCredentialUpsertion {
 #[cfg(feature = "client")]
 impl Encodable for ScramCredentialUpsertion {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("ScramCredentialUpsertion v{} is not supported", version);
+        }
         types::CompactString.encode(buf, &self.name)?;
         types::Int8.encode(buf, &self.mechanism)?;
         types::Int32.encode(buf, &self.iterations)?;
@@ -394,6 +415,9 @@ impl Encodable for ScramCredentialUpsertion {
 #[cfg(feature = "broker")]
 impl Decodable for ScramCredentialUpsertion {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("ScramCredentialUpsertion v{} is not supported", version);
+        }
         let name = types::CompactString.decode(buf)?;
         let mechanism = types::Int8.decode(buf)?;
         let iterations = types::Int32.decode(buf)?;

--- a/src/messages/alter_user_scram_credentials_response.rs
+++ b/src/messages/alter_user_scram_credentials_response.rs
@@ -69,6 +69,12 @@ impl AlterUserScramCredentialsResponse {
 #[cfg(feature = "broker")]
 impl Encodable for AlterUserScramCredentialsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!(
+                "AlterUserScramCredentialsResponse v{} is not supported",
+                version
+            );
+        }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.results)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -104,6 +110,12 @@ impl Encodable for AlterUserScramCredentialsResponse {
 #[cfg(feature = "client")]
 impl Decodable for AlterUserScramCredentialsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!(
+                "AlterUserScramCredentialsResponse v{} is not supported",
+                version
+            );
+        }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let results = types::CompactArray(types::Struct { version }).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
@@ -203,6 +215,12 @@ impl AlterUserScramCredentialsResult {
 #[cfg(feature = "broker")]
 impl Encodable for AlterUserScramCredentialsResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!(
+                "AlterUserScramCredentialsResult v{} is not supported",
+                version
+            );
+        }
         types::CompactString.encode(buf, &self.user)?;
         types::Int16.encode(buf, &self.error_code)?;
         types::CompactString.encode(buf, &self.error_message)?;
@@ -240,6 +258,12 @@ impl Encodable for AlterUserScramCredentialsResult {
 #[cfg(feature = "client")]
 impl Decodable for AlterUserScramCredentialsResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!(
+                "AlterUserScramCredentialsResult v{} is not supported",
+                version
+            );
+        }
         let user = types::CompactString.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let error_message = types::CompactString.decode(buf)?;

--- a/src/messages/alter_user_scram_credentials_response.rs
+++ b/src/messages/alter_user_scram_credentials_response.rs
@@ -70,10 +70,7 @@ impl AlterUserScramCredentialsResponse {
 impl Encodable for AlterUserScramCredentialsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!(
-                "AlterUserScramCredentialsResponse v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.results)?;
@@ -111,10 +108,7 @@ impl Encodable for AlterUserScramCredentialsResponse {
 impl Decodable for AlterUserScramCredentialsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!(
-                "AlterUserScramCredentialsResponse v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let results = types::CompactArray(types::Struct { version }).decode(buf)?;
@@ -216,10 +210,7 @@ impl AlterUserScramCredentialsResult {
 impl Encodable for AlterUserScramCredentialsResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!(
-                "AlterUserScramCredentialsResult v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         types::CompactString.encode(buf, &self.user)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -259,10 +250,7 @@ impl Encodable for AlterUserScramCredentialsResult {
 impl Decodable for AlterUserScramCredentialsResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!(
-                "AlterUserScramCredentialsResult v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         let user = types::CompactString.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;

--- a/src/messages/api_versions_request.rs
+++ b/src/messages/api_versions_request.rs
@@ -69,6 +69,9 @@ impl ApiVersionsRequest {
 #[cfg(feature = "client")]
 impl Encodable for ApiVersionsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 4 {
+            bail!("ApiVersionsRequest v{} is not supported", version);
+        }
         if version >= 3 {
             types::CompactString.encode(buf, &self.client_software_name)?;
         }
@@ -116,6 +119,9 @@ impl Encodable for ApiVersionsRequest {
 #[cfg(feature = "broker")]
 impl Decodable for ApiVersionsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 4 {
+            bail!("ApiVersionsRequest v{} is not supported", version);
+        }
         let client_software_name = if version >= 3 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/api_versions_request.rs
+++ b/src/messages/api_versions_request.rs
@@ -70,7 +70,7 @@ impl ApiVersionsRequest {
 impl Encodable for ApiVersionsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 4 {
-            bail!("ApiVersionsRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 3 {
             types::CompactString.encode(buf, &self.client_software_name)?;
@@ -120,7 +120,7 @@ impl Encodable for ApiVersionsRequest {
 impl Decodable for ApiVersionsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 4 {
-            bail!("ApiVersionsRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let client_software_name = if version >= 3 {
             types::CompactString.decode(buf)?

--- a/src/messages/api_versions_response.rs
+++ b/src/messages/api_versions_response.rs
@@ -83,6 +83,9 @@ impl ApiVersion {
 #[cfg(feature = "broker")]
 impl Encodable for ApiVersion {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 4 {
+            bail!("ApiVersion v{} is not supported", version);
+        }
         types::Int16.encode(buf, &self.api_key)?;
         types::Int16.encode(buf, &self.min_version)?;
         types::Int16.encode(buf, &self.max_version)?;
@@ -124,6 +127,9 @@ impl Encodable for ApiVersion {
 #[cfg(feature = "client")]
 impl Decodable for ApiVersion {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 4 {
+            bail!("ApiVersion v{} is not supported", version);
+        }
         let api_key = types::Int16.decode(buf)?;
         let min_version = types::Int16.decode(buf)?;
         let max_version = types::Int16.decode(buf)?;
@@ -284,6 +290,9 @@ impl ApiVersionsResponse {
 #[cfg(feature = "broker")]
 impl Encodable for ApiVersionsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 4 {
+            bail!("ApiVersionsResponse v{} is not supported", version);
+        }
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 3 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.api_keys)?;
@@ -464,6 +473,9 @@ impl Encodable for ApiVersionsResponse {
 #[cfg(feature = "client")]
 impl Decodable for ApiVersionsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 4 {
+            bail!("ApiVersionsResponse v{} is not supported", version);
+        }
         let error_code = types::Int16.decode(buf)?;
         let api_keys = if version >= 3 {
             types::CompactArray(types::Struct { version }).decode(buf)?
@@ -606,6 +618,9 @@ impl FinalizedFeatureKey {
 #[cfg(feature = "broker")]
 impl Encodable for FinalizedFeatureKey {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 4 {
+            bail!("FinalizedFeatureKey v{} is not supported", version);
+        }
         if version >= 3 {
             types::CompactString.encode(buf, &self.name)?;
         } else {
@@ -683,6 +698,9 @@ impl Encodable for FinalizedFeatureKey {
 #[cfg(feature = "client")]
 impl Decodable for FinalizedFeatureKey {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 4 {
+            bail!("FinalizedFeatureKey v{} is not supported", version);
+        }
         let name = if version >= 3 {
             types::CompactString.decode(buf)?
         } else {
@@ -799,6 +817,9 @@ impl SupportedFeatureKey {
 #[cfg(feature = "broker")]
 impl Encodable for SupportedFeatureKey {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 4 {
+            bail!("SupportedFeatureKey v{} is not supported", version);
+        }
         if version >= 3 {
             types::CompactString.encode(buf, &self.name)?;
         } else {
@@ -876,6 +897,9 @@ impl Encodable for SupportedFeatureKey {
 #[cfg(feature = "client")]
 impl Decodable for SupportedFeatureKey {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 4 {
+            bail!("SupportedFeatureKey v{} is not supported", version);
+        }
         let name = if version >= 3 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/api_versions_response.rs
+++ b/src/messages/api_versions_response.rs
@@ -84,7 +84,7 @@ impl ApiVersion {
 impl Encodable for ApiVersion {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 4 {
-            bail!("ApiVersion v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int16.encode(buf, &self.api_key)?;
         types::Int16.encode(buf, &self.min_version)?;
@@ -128,7 +128,7 @@ impl Encodable for ApiVersion {
 impl Decodable for ApiVersion {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 4 {
-            bail!("ApiVersion v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let api_key = types::Int16.decode(buf)?;
         let min_version = types::Int16.decode(buf)?;
@@ -291,7 +291,7 @@ impl ApiVersionsResponse {
 impl Encodable for ApiVersionsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 4 {
-            bail!("ApiVersionsResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 3 {
@@ -474,7 +474,7 @@ impl Encodable for ApiVersionsResponse {
 impl Decodable for ApiVersionsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 4 {
-            bail!("ApiVersionsResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let error_code = types::Int16.decode(buf)?;
         let api_keys = if version >= 3 {
@@ -619,7 +619,7 @@ impl FinalizedFeatureKey {
 impl Encodable for FinalizedFeatureKey {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 4 {
-            bail!("FinalizedFeatureKey v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 3 {
             types::CompactString.encode(buf, &self.name)?;
@@ -699,7 +699,7 @@ impl Encodable for FinalizedFeatureKey {
 impl Decodable for FinalizedFeatureKey {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 4 {
-            bail!("FinalizedFeatureKey v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = if version >= 3 {
             types::CompactString.decode(buf)?
@@ -818,7 +818,7 @@ impl SupportedFeatureKey {
 impl Encodable for SupportedFeatureKey {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 4 {
-            bail!("SupportedFeatureKey v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 3 {
             types::CompactString.encode(buf, &self.name)?;
@@ -898,7 +898,7 @@ impl Encodable for SupportedFeatureKey {
 impl Decodable for SupportedFeatureKey {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 4 {
-            bail!("SupportedFeatureKey v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = if version >= 3 {
             types::CompactString.decode(buf)?

--- a/src/messages/assign_replicas_to_dirs_request.rs
+++ b/src/messages/assign_replicas_to_dirs_request.rs
@@ -83,6 +83,9 @@ impl AssignReplicasToDirsRequest {
 #[cfg(feature = "client")]
 impl Encodable for AssignReplicasToDirsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("AssignReplicasToDirsRequest v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.broker_id)?;
         types::Int64.encode(buf, &self.broker_epoch)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.directories)?;
@@ -121,6 +124,9 @@ impl Encodable for AssignReplicasToDirsRequest {
 #[cfg(feature = "broker")]
 impl Decodable for AssignReplicasToDirsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("AssignReplicasToDirsRequest v{} is not supported", version);
+        }
         let broker_id = types::Int32.decode(buf)?;
         let broker_epoch = types::Int64.decode(buf)?;
         let directories = types::CompactArray(types::Struct { version }).decode(buf)?;
@@ -209,6 +215,9 @@ impl DirectoryData {
 #[cfg(feature = "client")]
 impl Encodable for DirectoryData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("DirectoryData v{} is not supported", version);
+        }
         types::Uuid.encode(buf, &self.id)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -244,6 +253,9 @@ impl Encodable for DirectoryData {
 #[cfg(feature = "broker")]
 impl Decodable for DirectoryData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("DirectoryData v{} is not supported", version);
+        }
         let id = types::Uuid.decode(buf)?;
         let topics = types::CompactArray(types::Struct { version }).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
@@ -315,6 +327,9 @@ impl PartitionData {
 #[cfg(feature = "client")]
 impl Encodable for PartitionData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("PartitionData v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.partition_index)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
@@ -348,6 +363,9 @@ impl Encodable for PartitionData {
 #[cfg(feature = "broker")]
 impl Decodable for PartitionData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("PartitionData v{} is not supported", version);
+        }
         let partition_index = types::Int32.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
         let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
@@ -430,6 +448,9 @@ impl TopicData {
 #[cfg(feature = "client")]
 impl Encodable for TopicData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("TopicData v{} is not supported", version);
+        }
         types::Uuid.encode(buf, &self.topic_id)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.partitions)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -466,6 +487,9 @@ impl Encodable for TopicData {
 #[cfg(feature = "broker")]
 impl Decodable for TopicData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("TopicData v{} is not supported", version);
+        }
         let topic_id = types::Uuid.decode(buf)?;
         let partitions = types::CompactArray(types::Struct { version }).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();

--- a/src/messages/assign_replicas_to_dirs_request.rs
+++ b/src/messages/assign_replicas_to_dirs_request.rs
@@ -84,7 +84,7 @@ impl AssignReplicasToDirsRequest {
 impl Encodable for AssignReplicasToDirsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("AssignReplicasToDirsRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.broker_id)?;
         types::Int64.encode(buf, &self.broker_epoch)?;
@@ -125,7 +125,7 @@ impl Encodable for AssignReplicasToDirsRequest {
 impl Decodable for AssignReplicasToDirsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("AssignReplicasToDirsRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let broker_id = types::Int32.decode(buf)?;
         let broker_epoch = types::Int64.decode(buf)?;
@@ -216,7 +216,7 @@ impl DirectoryData {
 impl Encodable for DirectoryData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("DirectoryData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Uuid.encode(buf, &self.id)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
@@ -254,7 +254,7 @@ impl Encodable for DirectoryData {
 impl Decodable for DirectoryData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("DirectoryData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let id = types::Uuid.decode(buf)?;
         let topics = types::CompactArray(types::Struct { version }).decode(buf)?;
@@ -328,7 +328,7 @@ impl PartitionData {
 impl Encodable for PartitionData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("PartitionData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.partition_index)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -364,7 +364,7 @@ impl Encodable for PartitionData {
 impl Decodable for PartitionData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("PartitionData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let partition_index = types::Int32.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
@@ -449,7 +449,7 @@ impl TopicData {
 impl Encodable for TopicData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("TopicData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Uuid.encode(buf, &self.topic_id)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.partitions)?;
@@ -488,7 +488,7 @@ impl Encodable for TopicData {
 impl Decodable for TopicData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("TopicData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topic_id = types::Uuid.decode(buf)?;
         let partitions = types::CompactArray(types::Struct { version }).decode(buf)?;

--- a/src/messages/assign_replicas_to_dirs_response.rs
+++ b/src/messages/assign_replicas_to_dirs_response.rs
@@ -83,6 +83,9 @@ impl AssignReplicasToDirsResponse {
 #[cfg(feature = "broker")]
 impl Encodable for AssignReplicasToDirsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("AssignReplicasToDirsResponse v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.directories)?;
@@ -121,6 +124,9 @@ impl Encodable for AssignReplicasToDirsResponse {
 #[cfg(feature = "client")]
 impl Decodable for AssignReplicasToDirsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("AssignReplicasToDirsResponse v{} is not supported", version);
+        }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let directories = types::CompactArray(types::Struct { version }).decode(buf)?;
@@ -209,6 +215,9 @@ impl DirectoryData {
 #[cfg(feature = "broker")]
 impl Encodable for DirectoryData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("DirectoryData v{} is not supported", version);
+        }
         types::Uuid.encode(buf, &self.id)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -244,6 +253,9 @@ impl Encodable for DirectoryData {
 #[cfg(feature = "client")]
 impl Decodable for DirectoryData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("DirectoryData v{} is not supported", version);
+        }
         let id = types::Uuid.decode(buf)?;
         let topics = types::CompactArray(types::Struct { version }).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
@@ -329,6 +341,9 @@ impl PartitionData {
 #[cfg(feature = "broker")]
 impl Encodable for PartitionData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("PartitionData v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int16.encode(buf, &self.error_code)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -364,6 +379,9 @@ impl Encodable for PartitionData {
 #[cfg(feature = "client")]
 impl Decodable for PartitionData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("PartitionData v{} is not supported", version);
+        }
         let partition_index = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
@@ -449,6 +467,9 @@ impl TopicData {
 #[cfg(feature = "broker")]
 impl Encodable for TopicData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("TopicData v{} is not supported", version);
+        }
         types::Uuid.encode(buf, &self.topic_id)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.partitions)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -485,6 +506,9 @@ impl Encodable for TopicData {
 #[cfg(feature = "client")]
 impl Decodable for TopicData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("TopicData v{} is not supported", version);
+        }
         let topic_id = types::Uuid.decode(buf)?;
         let partitions = types::CompactArray(types::Struct { version }).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();

--- a/src/messages/assign_replicas_to_dirs_response.rs
+++ b/src/messages/assign_replicas_to_dirs_response.rs
@@ -84,7 +84,7 @@ impl AssignReplicasToDirsResponse {
 impl Encodable for AssignReplicasToDirsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("AssignReplicasToDirsResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -125,7 +125,7 @@ impl Encodable for AssignReplicasToDirsResponse {
 impl Decodable for AssignReplicasToDirsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("AssignReplicasToDirsResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
@@ -216,7 +216,7 @@ impl DirectoryData {
 impl Encodable for DirectoryData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("DirectoryData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Uuid.encode(buf, &self.id)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
@@ -254,7 +254,7 @@ impl Encodable for DirectoryData {
 impl Decodable for DirectoryData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("DirectoryData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let id = types::Uuid.decode(buf)?;
         let topics = types::CompactArray(types::Struct { version }).decode(buf)?;
@@ -342,7 +342,7 @@ impl PartitionData {
 impl Encodable for PartitionData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("PartitionData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -380,7 +380,7 @@ impl Encodable for PartitionData {
 impl Decodable for PartitionData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("PartitionData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let partition_index = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
@@ -468,7 +468,7 @@ impl TopicData {
 impl Encodable for TopicData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("TopicData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Uuid.encode(buf, &self.topic_id)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.partitions)?;
@@ -507,7 +507,7 @@ impl Encodable for TopicData {
 impl Decodable for TopicData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("TopicData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topic_id = types::Uuid.decode(buf)?;
         let partitions = types::CompactArray(types::Struct { version }).decode(buf)?;

--- a/src/messages/begin_quorum_epoch_request.rs
+++ b/src/messages/begin_quorum_epoch_request.rs
@@ -98,7 +98,7 @@ impl BeginQuorumEpochRequest {
 impl Encodable for BeginQuorumEpochRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("BeginQuorumEpochRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 1 {
             types::CompactString.encode(buf, &self.cluster_id)?;
@@ -170,7 +170,7 @@ impl Encodable for BeginQuorumEpochRequest {
 impl Decodable for BeginQuorumEpochRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("BeginQuorumEpochRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let cluster_id = if version >= 1 {
             types::CompactString.decode(buf)?
@@ -296,7 +296,7 @@ impl LeaderEndpoint {
 impl Encodable for LeaderEndpoint {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("LeaderEndpoint v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 1 {
             types::CompactString.encode(buf, &self.name)?;
@@ -376,7 +376,7 @@ impl Encodable for LeaderEndpoint {
 impl Decodable for LeaderEndpoint {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("LeaderEndpoint v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = if version >= 1 {
             types::CompactString.decode(buf)?
@@ -509,7 +509,7 @@ impl PartitionData {
 impl Encodable for PartitionData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("PartitionData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.partition_index)?;
         if version >= 1 {
@@ -559,7 +559,7 @@ impl Encodable for PartitionData {
 impl Decodable for PartitionData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("PartitionData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let partition_index = types::Int32.decode(buf)?;
         let voter_directory_id = if version >= 1 {
@@ -659,7 +659,7 @@ impl TopicData {
 impl Encodable for TopicData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("TopicData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 1 {
             types::CompactString.encode(buf, &self.topic_name)?;
@@ -718,7 +718,7 @@ impl Encodable for TopicData {
 impl Decodable for TopicData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("TopicData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topic_name = if version >= 1 {
             types::CompactString.decode(buf)?

--- a/src/messages/begin_quorum_epoch_request.rs
+++ b/src/messages/begin_quorum_epoch_request.rs
@@ -97,6 +97,9 @@ impl BeginQuorumEpochRequest {
 #[cfg(feature = "client")]
 impl Encodable for BeginQuorumEpochRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("BeginQuorumEpochRequest v{} is not supported", version);
+        }
         if version >= 1 {
             types::CompactString.encode(buf, &self.cluster_id)?;
         } else {
@@ -166,6 +169,9 @@ impl Encodable for BeginQuorumEpochRequest {
 #[cfg(feature = "broker")]
 impl Decodable for BeginQuorumEpochRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("BeginQuorumEpochRequest v{} is not supported", version);
+        }
         let cluster_id = if version >= 1 {
             types::CompactString.decode(buf)?
         } else {
@@ -289,6 +295,9 @@ impl LeaderEndpoint {
 #[cfg(feature = "client")]
 impl Encodable for LeaderEndpoint {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("LeaderEndpoint v{} is not supported", version);
+        }
         if version >= 1 {
             types::CompactString.encode(buf, &self.name)?;
         } else {
@@ -366,6 +375,9 @@ impl Encodable for LeaderEndpoint {
 #[cfg(feature = "broker")]
 impl Decodable for LeaderEndpoint {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("LeaderEndpoint v{} is not supported", version);
+        }
         let name = if version >= 1 {
             types::CompactString.decode(buf)?
         } else {
@@ -496,6 +508,9 @@ impl PartitionData {
 #[cfg(feature = "client")]
 impl Encodable for PartitionData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("PartitionData v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.partition_index)?;
         if version >= 1 {
             types::Uuid.encode(buf, &self.voter_directory_id)?;
@@ -543,6 +558,9 @@ impl Encodable for PartitionData {
 #[cfg(feature = "broker")]
 impl Decodable for PartitionData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("PartitionData v{} is not supported", version);
+        }
         let partition_index = types::Int32.decode(buf)?;
         let voter_directory_id = if version >= 1 {
             types::Uuid.decode(buf)?
@@ -640,6 +658,9 @@ impl TopicData {
 #[cfg(feature = "client")]
 impl Encodable for TopicData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("TopicData v{} is not supported", version);
+        }
         if version >= 1 {
             types::CompactString.encode(buf, &self.topic_name)?;
         } else {
@@ -696,6 +717,9 @@ impl Encodable for TopicData {
 #[cfg(feature = "broker")]
 impl Decodable for TopicData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("TopicData v{} is not supported", version);
+        }
         let topic_name = if version >= 1 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/begin_quorum_epoch_response.rs
+++ b/src/messages/begin_quorum_epoch_response.rs
@@ -84,7 +84,7 @@ impl BeginQuorumEpochResponse {
 impl Encodable for BeginQuorumEpochResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("BeginQuorumEpochResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 1 {
@@ -167,7 +167,7 @@ impl Encodable for BeginQuorumEpochResponse {
 impl Decodable for BeginQuorumEpochResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("BeginQuorumEpochResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let error_code = types::Int16.decode(buf)?;
         let topics = if version >= 1 {
@@ -286,7 +286,7 @@ impl NodeEndpoint {
 impl Encodable for NodeEndpoint {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("NodeEndpoint v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 1 {
             types::Int32.encode(buf, &self.node_id)?;
@@ -366,7 +366,7 @@ impl Encodable for NodeEndpoint {
 impl Decodable for NodeEndpoint {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("NodeEndpoint v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let node_id = if version >= 1 {
             types::Int32.decode(buf)?
@@ -499,7 +499,7 @@ impl PartitionData {
 impl Encodable for PartitionData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("PartitionData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -545,7 +545,7 @@ impl Encodable for PartitionData {
 impl Decodable for PartitionData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("PartitionData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let partition_index = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
@@ -641,7 +641,7 @@ impl TopicData {
 impl Encodable for TopicData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("TopicData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 1 {
             types::CompactString.encode(buf, &self.topic_name)?;
@@ -700,7 +700,7 @@ impl Encodable for TopicData {
 impl Decodable for TopicData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("TopicData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topic_name = if version >= 1 {
             types::CompactString.decode(buf)?

--- a/src/messages/begin_quorum_epoch_response.rs
+++ b/src/messages/begin_quorum_epoch_response.rs
@@ -83,6 +83,9 @@ impl BeginQuorumEpochResponse {
 #[cfg(feature = "broker")]
 impl Encodable for BeginQuorumEpochResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("BeginQuorumEpochResponse v{} is not supported", version);
+        }
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 1 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
@@ -163,6 +166,9 @@ impl Encodable for BeginQuorumEpochResponse {
 #[cfg(feature = "client")]
 impl Decodable for BeginQuorumEpochResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("BeginQuorumEpochResponse v{} is not supported", version);
+        }
         let error_code = types::Int16.decode(buf)?;
         let topics = if version >= 1 {
             types::CompactArray(types::Struct { version }).decode(buf)?
@@ -279,6 +285,9 @@ impl NodeEndpoint {
 #[cfg(feature = "broker")]
 impl Encodable for NodeEndpoint {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("NodeEndpoint v{} is not supported", version);
+        }
         if version >= 1 {
             types::Int32.encode(buf, &self.node_id)?;
         } else {
@@ -356,6 +365,9 @@ impl Encodable for NodeEndpoint {
 #[cfg(feature = "client")]
 impl Decodable for NodeEndpoint {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("NodeEndpoint v{} is not supported", version);
+        }
         let node_id = if version >= 1 {
             types::Int32.decode(buf)?
         } else {
@@ -486,6 +498,9 @@ impl PartitionData {
 #[cfg(feature = "broker")]
 impl Encodable for PartitionData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("PartitionData v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int16.encode(buf, &self.error_code)?;
         types::Int32.encode(buf, &self.leader_id)?;
@@ -529,6 +544,9 @@ impl Encodable for PartitionData {
 #[cfg(feature = "client")]
 impl Decodable for PartitionData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("PartitionData v{} is not supported", version);
+        }
         let partition_index = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let leader_id = types::Int32.decode(buf)?;
@@ -622,6 +640,9 @@ impl TopicData {
 #[cfg(feature = "broker")]
 impl Encodable for TopicData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("TopicData v{} is not supported", version);
+        }
         if version >= 1 {
             types::CompactString.encode(buf, &self.topic_name)?;
         } else {
@@ -678,6 +699,9 @@ impl Encodable for TopicData {
 #[cfg(feature = "client")]
 impl Decodable for TopicData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("TopicData v{} is not supported", version);
+        }
         let topic_name = if version >= 1 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/broker_heartbeat_request.rs
+++ b/src/messages/broker_heartbeat_request.rs
@@ -126,7 +126,7 @@ impl BrokerHeartbeatRequest {
 impl Encodable for BrokerHeartbeatRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("BrokerHeartbeatRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.broker_id)?;
         types::Int64.encode(buf, &self.broker_epoch)?;
@@ -208,7 +208,7 @@ impl Encodable for BrokerHeartbeatRequest {
 impl Decodable for BrokerHeartbeatRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("BrokerHeartbeatRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let broker_id = types::Int32.decode(buf)?;
         let broker_epoch = types::Int64.decode(buf)?;

--- a/src/messages/broker_heartbeat_request.rs
+++ b/src/messages/broker_heartbeat_request.rs
@@ -125,6 +125,9 @@ impl BrokerHeartbeatRequest {
 #[cfg(feature = "client")]
 impl Encodable for BrokerHeartbeatRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("BrokerHeartbeatRequest v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.broker_id)?;
         types::Int64.encode(buf, &self.broker_epoch)?;
         types::Int64.encode(buf, &self.current_metadata_offset)?;
@@ -204,6 +207,9 @@ impl Encodable for BrokerHeartbeatRequest {
 #[cfg(feature = "broker")]
 impl Decodable for BrokerHeartbeatRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("BrokerHeartbeatRequest v{} is not supported", version);
+        }
         let broker_id = types::Int32.decode(buf)?;
         let broker_epoch = types::Int64.decode(buf)?;
         let current_metadata_offset = types::Int64.decode(buf)?;

--- a/src/messages/broker_heartbeat_response.rs
+++ b/src/messages/broker_heartbeat_response.rs
@@ -112,7 +112,7 @@ impl BrokerHeartbeatResponse {
 impl Encodable for BrokerHeartbeatResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("BrokerHeartbeatResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -156,7 +156,7 @@ impl Encodable for BrokerHeartbeatResponse {
 impl Decodable for BrokerHeartbeatResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("BrokerHeartbeatResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;

--- a/src/messages/broker_heartbeat_response.rs
+++ b/src/messages/broker_heartbeat_response.rs
@@ -111,6 +111,9 @@ impl BrokerHeartbeatResponse {
 #[cfg(feature = "broker")]
 impl Encodable for BrokerHeartbeatResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("BrokerHeartbeatResponse v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
         types::Boolean.encode(buf, &self.is_caught_up)?;
@@ -152,6 +155,9 @@ impl Encodable for BrokerHeartbeatResponse {
 #[cfg(feature = "client")]
 impl Decodable for BrokerHeartbeatResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("BrokerHeartbeatResponse v{} is not supported", version);
+        }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let is_caught_up = types::Boolean.decode(buf)?;

--- a/src/messages/broker_registration_request.rs
+++ b/src/messages/broker_registration_request.rs
@@ -168,7 +168,7 @@ impl BrokerRegistrationRequest {
 impl Encodable for BrokerRegistrationRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 4 {
-            bail!("BrokerRegistrationRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.broker_id)?;
         types::CompactString.encode(buf, &self.cluster_id)?;
@@ -242,7 +242,7 @@ impl Encodable for BrokerRegistrationRequest {
 impl Decodable for BrokerRegistrationRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 4 {
-            bail!("BrokerRegistrationRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let broker_id = types::Int32.decode(buf)?;
         let cluster_id = types::CompactString.decode(buf)?;
@@ -377,7 +377,7 @@ impl Feature {
 impl Encodable for Feature {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 4 {
-            bail!("Feature v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::CompactString.encode(buf, &self.name)?;
         types::Int16.encode(buf, &self.min_supported_version)?;
@@ -417,7 +417,7 @@ impl Encodable for Feature {
 impl Decodable for Feature {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 4 {
-            bail!("Feature v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = types::CompactString.decode(buf)?;
         let min_supported_version = types::Int16.decode(buf)?;
@@ -536,7 +536,7 @@ impl Listener {
 impl Encodable for Listener {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 4 {
-            bail!("Listener v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::CompactString.encode(buf, &self.name)?;
         types::CompactString.encode(buf, &self.host)?;
@@ -578,7 +578,7 @@ impl Encodable for Listener {
 impl Decodable for Listener {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 4 {
-            bail!("Listener v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = types::CompactString.decode(buf)?;
         let host = types::CompactString.decode(buf)?;

--- a/src/messages/broker_registration_request.rs
+++ b/src/messages/broker_registration_request.rs
@@ -167,6 +167,9 @@ impl BrokerRegistrationRequest {
 #[cfg(feature = "client")]
 impl Encodable for BrokerRegistrationRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 4 {
+            bail!("BrokerRegistrationRequest v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.broker_id)?;
         types::CompactString.encode(buf, &self.cluster_id)?;
         types::Uuid.encode(buf, &self.incarnation_id)?;
@@ -238,6 +241,9 @@ impl Encodable for BrokerRegistrationRequest {
 #[cfg(feature = "broker")]
 impl Decodable for BrokerRegistrationRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 4 {
+            bail!("BrokerRegistrationRequest v{} is not supported", version);
+        }
         let broker_id = types::Int32.decode(buf)?;
         let cluster_id = types::CompactString.decode(buf)?;
         let incarnation_id = types::Uuid.decode(buf)?;
@@ -370,6 +376,9 @@ impl Feature {
 #[cfg(feature = "client")]
 impl Encodable for Feature {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 4 {
+            bail!("Feature v{} is not supported", version);
+        }
         types::CompactString.encode(buf, &self.name)?;
         types::Int16.encode(buf, &self.min_supported_version)?;
         types::Int16.encode(buf, &self.max_supported_version)?;
@@ -407,6 +416,9 @@ impl Encodable for Feature {
 #[cfg(feature = "broker")]
 impl Decodable for Feature {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 4 {
+            bail!("Feature v{} is not supported", version);
+        }
         let name = types::CompactString.decode(buf)?;
         let min_supported_version = types::Int16.decode(buf)?;
         let max_supported_version = types::Int16.decode(buf)?;
@@ -523,6 +535,9 @@ impl Listener {
 #[cfg(feature = "client")]
 impl Encodable for Listener {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 4 {
+            bail!("Listener v{} is not supported", version);
+        }
         types::CompactString.encode(buf, &self.name)?;
         types::CompactString.encode(buf, &self.host)?;
         types::UInt16.encode(buf, &self.port)?;
@@ -562,6 +577,9 @@ impl Encodable for Listener {
 #[cfg(feature = "broker")]
 impl Decodable for Listener {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 4 {
+            bail!("Listener v{} is not supported", version);
+        }
         let name = types::CompactString.decode(buf)?;
         let host = types::CompactString.decode(buf)?;
         let port = types::UInt16.decode(buf)?;

--- a/src/messages/broker_registration_response.rs
+++ b/src/messages/broker_registration_response.rs
@@ -84,7 +84,7 @@ impl BrokerRegistrationResponse {
 impl Encodable for BrokerRegistrationResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 4 {
-            bail!("BrokerRegistrationResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -124,7 +124,7 @@ impl Encodable for BrokerRegistrationResponse {
 impl Decodable for BrokerRegistrationResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 4 {
-            bail!("BrokerRegistrationResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;

--- a/src/messages/broker_registration_response.rs
+++ b/src/messages/broker_registration_response.rs
@@ -83,6 +83,9 @@ impl BrokerRegistrationResponse {
 #[cfg(feature = "broker")]
 impl Encodable for BrokerRegistrationResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 4 {
+            bail!("BrokerRegistrationResponse v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
         types::Int64.encode(buf, &self.broker_epoch)?;
@@ -120,6 +123,9 @@ impl Encodable for BrokerRegistrationResponse {
 #[cfg(feature = "client")]
 impl Decodable for BrokerRegistrationResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 4 {
+            bail!("BrokerRegistrationResponse v{} is not supported", version);
+        }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let broker_epoch = types::Int64.decode(buf)?;

--- a/src/messages/consumer_group_describe_request.rs
+++ b/src/messages/consumer_group_describe_request.rs
@@ -69,6 +69,9 @@ impl ConsumerGroupDescribeRequest {
 #[cfg(feature = "client")]
 impl Encodable for ConsumerGroupDescribeRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("ConsumerGroupDescribeRequest v{} is not supported", version);
+        }
         types::CompactArray(types::CompactString).encode(buf, &self.group_ids)?;
         types::Boolean.encode(buf, &self.include_authorized_operations)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -104,6 +107,9 @@ impl Encodable for ConsumerGroupDescribeRequest {
 #[cfg(feature = "broker")]
 impl Decodable for ConsumerGroupDescribeRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("ConsumerGroupDescribeRequest v{} is not supported", version);
+        }
         let group_ids = types::CompactArray(types::CompactString).decode(buf)?;
         let include_authorized_operations = types::Boolean.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();

--- a/src/messages/consumer_group_describe_request.rs
+++ b/src/messages/consumer_group_describe_request.rs
@@ -70,7 +70,7 @@ impl ConsumerGroupDescribeRequest {
 impl Encodable for ConsumerGroupDescribeRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("ConsumerGroupDescribeRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::CompactArray(types::CompactString).encode(buf, &self.group_ids)?;
         types::Boolean.encode(buf, &self.include_authorized_operations)?;
@@ -108,7 +108,7 @@ impl Encodable for ConsumerGroupDescribeRequest {
 impl Decodable for ConsumerGroupDescribeRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("ConsumerGroupDescribeRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let group_ids = types::CompactArray(types::CompactString).decode(buf)?;
         let include_authorized_operations = types::Boolean.decode(buf)?;

--- a/src/messages/consumer_group_describe_response.rs
+++ b/src/messages/consumer_group_describe_response.rs
@@ -55,6 +55,9 @@ impl Assignment {
 #[cfg(feature = "broker")]
 impl Encodable for Assignment {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("Assignment v{} is not supported", version);
+        }
         types::CompactArray(types::Struct { version }).encode(buf, &self.topic_partitions)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
@@ -89,6 +92,9 @@ impl Encodable for Assignment {
 #[cfg(feature = "client")]
 impl Decodable for Assignment {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("Assignment v{} is not supported", version);
+        }
         let topic_partitions = types::CompactArray(types::Struct { version }).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
         let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
@@ -171,6 +177,12 @@ impl ConsumerGroupDescribeResponse {
 #[cfg(feature = "broker")]
 impl Encodable for ConsumerGroupDescribeResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!(
+                "ConsumerGroupDescribeResponse v{} is not supported",
+                version
+            );
+        }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.groups)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -206,6 +218,12 @@ impl Encodable for ConsumerGroupDescribeResponse {
 #[cfg(feature = "client")]
 impl Decodable for ConsumerGroupDescribeResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!(
+                "ConsumerGroupDescribeResponse v{} is not supported",
+                version
+            );
+        }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let groups = types::CompactArray(types::Struct { version }).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
@@ -389,6 +407,9 @@ impl DescribedGroup {
 #[cfg(feature = "broker")]
 impl Encodable for DescribedGroup {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("DescribedGroup v{} is not supported", version);
+        }
         types::Int16.encode(buf, &self.error_code)?;
         types::CompactString.encode(buf, &self.error_message)?;
         types::CompactString.encode(buf, &self.group_id)?;
@@ -438,6 +459,9 @@ impl Encodable for DescribedGroup {
 #[cfg(feature = "client")]
 impl Decodable for DescribedGroup {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("DescribedGroup v{} is not supported", version);
+        }
         let error_code = types::Int16.decode(buf)?;
         let error_message = types::CompactString.decode(buf)?;
         let group_id = types::CompactString.decode(buf)?;
@@ -656,6 +680,9 @@ impl Member {
 #[cfg(feature = "broker")]
 impl Encodable for Member {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("Member v{} is not supported", version);
+        }
         types::CompactString.encode(buf, &self.member_id)?;
         types::CompactString.encode(buf, &self.instance_id)?;
         types::CompactString.encode(buf, &self.rack_id)?;
@@ -708,6 +735,9 @@ impl Encodable for Member {
 #[cfg(feature = "client")]
 impl Decodable for Member {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("Member v{} is not supported", version);
+        }
         let member_id = types::CompactString.decode(buf)?;
         let instance_id = types::CompactString.decode(buf)?;
         let rack_id = types::CompactString.decode(buf)?;
@@ -831,6 +861,9 @@ impl TopicPartitions {
 #[cfg(feature = "broker")]
 impl Encodable for TopicPartitions {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("TopicPartitions v{} is not supported", version);
+        }
         types::Uuid.encode(buf, &self.topic_id)?;
         types::CompactString.encode(buf, &self.topic_name)?;
         types::CompactArray(types::Int32).encode(buf, &self.partitions)?;
@@ -868,6 +901,9 @@ impl Encodable for TopicPartitions {
 #[cfg(feature = "client")]
 impl Decodable for TopicPartitions {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("TopicPartitions v{} is not supported", version);
+        }
         let topic_id = types::Uuid.decode(buf)?;
         let topic_name = types::CompactString.decode(buf)?;
         let partitions = types::CompactArray(types::Int32).decode(buf)?;

--- a/src/messages/consumer_group_describe_response.rs
+++ b/src/messages/consumer_group_describe_response.rs
@@ -56,7 +56,7 @@ impl Assignment {
 impl Encodable for Assignment {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("Assignment v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::CompactArray(types::Struct { version }).encode(buf, &self.topic_partitions)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -93,7 +93,7 @@ impl Encodable for Assignment {
 impl Decodable for Assignment {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("Assignment v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topic_partitions = types::CompactArray(types::Struct { version }).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
@@ -178,10 +178,7 @@ impl ConsumerGroupDescribeResponse {
 impl Encodable for ConsumerGroupDescribeResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!(
-                "ConsumerGroupDescribeResponse v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.groups)?;
@@ -219,10 +216,7 @@ impl Encodable for ConsumerGroupDescribeResponse {
 impl Decodable for ConsumerGroupDescribeResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!(
-                "ConsumerGroupDescribeResponse v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let groups = types::CompactArray(types::Struct { version }).decode(buf)?;
@@ -408,7 +402,7 @@ impl DescribedGroup {
 impl Encodable for DescribedGroup {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("DescribedGroup v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int16.encode(buf, &self.error_code)?;
         types::CompactString.encode(buf, &self.error_message)?;
@@ -460,7 +454,7 @@ impl Encodable for DescribedGroup {
 impl Decodable for DescribedGroup {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("DescribedGroup v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let error_code = types::Int16.decode(buf)?;
         let error_message = types::CompactString.decode(buf)?;
@@ -681,7 +675,7 @@ impl Member {
 impl Encodable for Member {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("Member v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::CompactString.encode(buf, &self.member_id)?;
         types::CompactString.encode(buf, &self.instance_id)?;
@@ -736,7 +730,7 @@ impl Encodable for Member {
 impl Decodable for Member {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("Member v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let member_id = types::CompactString.decode(buf)?;
         let instance_id = types::CompactString.decode(buf)?;
@@ -862,7 +856,7 @@ impl TopicPartitions {
 impl Encodable for TopicPartitions {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("TopicPartitions v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Uuid.encode(buf, &self.topic_id)?;
         types::CompactString.encode(buf, &self.topic_name)?;
@@ -902,7 +896,7 @@ impl Encodable for TopicPartitions {
 impl Decodable for TopicPartitions {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("TopicPartitions v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topic_id = types::Uuid.decode(buf)?;
         let topic_name = types::CompactString.decode(buf)?;

--- a/src/messages/consumer_group_heartbeat_request.rs
+++ b/src/messages/consumer_group_heartbeat_request.rs
@@ -167,6 +167,12 @@ impl ConsumerGroupHeartbeatRequest {
 #[cfg(feature = "client")]
 impl Encodable for ConsumerGroupHeartbeatRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!(
+                "ConsumerGroupHeartbeatRequest v{} is not supported",
+                version
+            );
+        }
         types::CompactString.encode(buf, &self.group_id)?;
         types::CompactString.encode(buf, &self.member_id)?;
         types::Int32.encode(buf, &self.member_epoch)?;
@@ -218,6 +224,12 @@ impl Encodable for ConsumerGroupHeartbeatRequest {
 #[cfg(feature = "broker")]
 impl Decodable for ConsumerGroupHeartbeatRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!(
+                "ConsumerGroupHeartbeatRequest v{} is not supported",
+                version
+            );
+        }
         let group_id = types::CompactString.decode(buf)?;
         let member_id = types::CompactString.decode(buf)?;
         let member_epoch = types::Int32.decode(buf)?;
@@ -324,6 +336,9 @@ impl TopicPartitions {
 #[cfg(feature = "client")]
 impl Encodable for TopicPartitions {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("TopicPartitions v{} is not supported", version);
+        }
         types::Uuid.encode(buf, &self.topic_id)?;
         types::CompactArray(types::Int32).encode(buf, &self.partitions)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -359,6 +374,9 @@ impl Encodable for TopicPartitions {
 #[cfg(feature = "broker")]
 impl Decodable for TopicPartitions {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("TopicPartitions v{} is not supported", version);
+        }
         let topic_id = types::Uuid.decode(buf)?;
         let partitions = types::CompactArray(types::Int32).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();

--- a/src/messages/consumer_group_heartbeat_request.rs
+++ b/src/messages/consumer_group_heartbeat_request.rs
@@ -168,10 +168,7 @@ impl ConsumerGroupHeartbeatRequest {
 impl Encodable for ConsumerGroupHeartbeatRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!(
-                "ConsumerGroupHeartbeatRequest v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         types::CompactString.encode(buf, &self.group_id)?;
         types::CompactString.encode(buf, &self.member_id)?;
@@ -225,10 +222,7 @@ impl Encodable for ConsumerGroupHeartbeatRequest {
 impl Decodable for ConsumerGroupHeartbeatRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!(
-                "ConsumerGroupHeartbeatRequest v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         let group_id = types::CompactString.decode(buf)?;
         let member_id = types::CompactString.decode(buf)?;
@@ -337,7 +331,7 @@ impl TopicPartitions {
 impl Encodable for TopicPartitions {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("TopicPartitions v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Uuid.encode(buf, &self.topic_id)?;
         types::CompactArray(types::Int32).encode(buf, &self.partitions)?;
@@ -375,7 +369,7 @@ impl Encodable for TopicPartitions {
 impl Decodable for TopicPartitions {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("TopicPartitions v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topic_id = types::Uuid.decode(buf)?;
         let partitions = types::CompactArray(types::Int32).decode(buf)?;

--- a/src/messages/consumer_group_heartbeat_response.rs
+++ b/src/messages/consumer_group_heartbeat_response.rs
@@ -55,6 +55,9 @@ impl Assignment {
 #[cfg(feature = "broker")]
 impl Encodable for Assignment {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("Assignment v{} is not supported", version);
+        }
         types::CompactArray(types::Struct { version }).encode(buf, &self.topic_partitions)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
@@ -89,6 +92,9 @@ impl Encodable for Assignment {
 #[cfg(feature = "client")]
 impl Decodable for Assignment {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("Assignment v{} is not supported", version);
+        }
         let topic_partitions = types::CompactArray(types::Struct { version }).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
         let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
@@ -241,6 +247,12 @@ impl ConsumerGroupHeartbeatResponse {
 #[cfg(feature = "broker")]
 impl Encodable for ConsumerGroupHeartbeatResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!(
+                "ConsumerGroupHeartbeatResponse v{} is not supported",
+                version
+            );
+        }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
         types::CompactString.encode(buf, &self.error_message)?;
@@ -286,6 +298,12 @@ impl Encodable for ConsumerGroupHeartbeatResponse {
 #[cfg(feature = "client")]
 impl Decodable for ConsumerGroupHeartbeatResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!(
+                "ConsumerGroupHeartbeatResponse v{} is not supported",
+                version
+            );
+        }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let error_message = types::CompactString.decode(buf)?;
@@ -386,6 +404,9 @@ impl TopicPartitions {
 #[cfg(feature = "broker")]
 impl Encodable for TopicPartitions {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("TopicPartitions v{} is not supported", version);
+        }
         types::Uuid.encode(buf, &self.topic_id)?;
         types::CompactArray(types::Int32).encode(buf, &self.partitions)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -421,6 +442,9 @@ impl Encodable for TopicPartitions {
 #[cfg(feature = "client")]
 impl Decodable for TopicPartitions {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("TopicPartitions v{} is not supported", version);
+        }
         let topic_id = types::Uuid.decode(buf)?;
         let partitions = types::CompactArray(types::Int32).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();

--- a/src/messages/consumer_group_heartbeat_response.rs
+++ b/src/messages/consumer_group_heartbeat_response.rs
@@ -56,7 +56,7 @@ impl Assignment {
 impl Encodable for Assignment {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("Assignment v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::CompactArray(types::Struct { version }).encode(buf, &self.topic_partitions)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -93,7 +93,7 @@ impl Encodable for Assignment {
 impl Decodable for Assignment {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("Assignment v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topic_partitions = types::CompactArray(types::Struct { version }).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
@@ -248,10 +248,7 @@ impl ConsumerGroupHeartbeatResponse {
 impl Encodable for ConsumerGroupHeartbeatResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!(
-                "ConsumerGroupHeartbeatResponse v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -299,10 +296,7 @@ impl Encodable for ConsumerGroupHeartbeatResponse {
 impl Decodable for ConsumerGroupHeartbeatResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!(
-                "ConsumerGroupHeartbeatResponse v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
@@ -405,7 +399,7 @@ impl TopicPartitions {
 impl Encodable for TopicPartitions {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("TopicPartitions v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Uuid.encode(buf, &self.topic_id)?;
         types::CompactArray(types::Int32).encode(buf, &self.partitions)?;
@@ -443,7 +437,7 @@ impl Encodable for TopicPartitions {
 impl Decodable for TopicPartitions {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("TopicPartitions v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topic_id = types::Uuid.decode(buf)?;
         let partitions = types::CompactArray(types::Int32).decode(buf)?;

--- a/src/messages/consumer_protocol_assignment.rs
+++ b/src/messages/consumer_protocol_assignment.rs
@@ -55,6 +55,9 @@ impl ConsumerProtocolAssignment {
 
 impl Encodable for ConsumerProtocolAssignment {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 3 {
+            bail!("ConsumerProtocolAssignment v{} is not supported", version);
+        }
         types::Array(types::Struct { version }).encode(buf, &self.assigned_partitions)?;
         types::Bytes.encode(buf, &self.user_data)?;
 
@@ -72,6 +75,9 @@ impl Encodable for ConsumerProtocolAssignment {
 
 impl Decodable for ConsumerProtocolAssignment {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 3 {
+            bail!("ConsumerProtocolAssignment v{} is not supported", version);
+        }
         let assigned_partitions = types::Array(types::Struct { version }).decode(buf)?;
         let user_data = types::Bytes.decode(buf)?;
         Ok(Self {
@@ -133,6 +139,9 @@ impl TopicPartition {
 
 impl Encodable for TopicPartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 3 {
+            bail!("TopicPartition v{} is not supported", version);
+        }
         types::String.encode(buf, &self.topic)?;
         types::Array(types::Int32).encode(buf, &self.partitions)?;
 
@@ -149,6 +158,9 @@ impl Encodable for TopicPartition {
 
 impl Decodable for TopicPartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 3 {
+            bail!("TopicPartition v{} is not supported", version);
+        }
         let topic = types::String.decode(buf)?;
         let partitions = types::Array(types::Int32).decode(buf)?;
         Ok(Self { topic, partitions })

--- a/src/messages/consumer_protocol_assignment.rs
+++ b/src/messages/consumer_protocol_assignment.rs
@@ -56,7 +56,7 @@ impl ConsumerProtocolAssignment {
 impl Encodable for ConsumerProtocolAssignment {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 3 {
-            bail!("ConsumerProtocolAssignment v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Array(types::Struct { version }).encode(buf, &self.assigned_partitions)?;
         types::Bytes.encode(buf, &self.user_data)?;
@@ -76,7 +76,7 @@ impl Encodable for ConsumerProtocolAssignment {
 impl Decodable for ConsumerProtocolAssignment {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 3 {
-            bail!("ConsumerProtocolAssignment v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let assigned_partitions = types::Array(types::Struct { version }).decode(buf)?;
         let user_data = types::Bytes.decode(buf)?;
@@ -140,7 +140,7 @@ impl TopicPartition {
 impl Encodable for TopicPartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 3 {
-            bail!("TopicPartition v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::String.encode(buf, &self.topic)?;
         types::Array(types::Int32).encode(buf, &self.partitions)?;
@@ -159,7 +159,7 @@ impl Encodable for TopicPartition {
 impl Decodable for TopicPartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 3 {
-            bail!("TopicPartition v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topic = types::String.decode(buf)?;
         let partitions = types::Array(types::Int32).decode(buf)?;

--- a/src/messages/consumer_protocol_subscription.rs
+++ b/src/messages/consumer_protocol_subscription.rs
@@ -97,6 +97,9 @@ impl ConsumerProtocolSubscription {
 
 impl Encodable for ConsumerProtocolSubscription {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 3 {
+            bail!("ConsumerProtocolSubscription v{} is not supported", version);
+        }
         types::Array(types::String).encode(buf, &self.topics)?;
         types::Bytes.encode(buf, &self.user_data)?;
         if version >= 1 {
@@ -132,6 +135,9 @@ impl Encodable for ConsumerProtocolSubscription {
 
 impl Decodable for ConsumerProtocolSubscription {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 3 {
+            bail!("ConsumerProtocolSubscription v{} is not supported", version);
+        }
         let topics = types::Array(types::String).decode(buf)?;
         let user_data = types::Bytes.decode(buf)?;
         let owned_partitions = if version >= 1 {
@@ -214,6 +220,9 @@ impl TopicPartition {
 
 impl Encodable for TopicPartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 3 {
+            bail!("TopicPartition v{} is not supported", version);
+        }
         if version >= 1 {
             types::String.encode(buf, &self.topic)?;
         } else {
@@ -254,6 +263,9 @@ impl Encodable for TopicPartition {
 
 impl Decodable for TopicPartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 3 {
+            bail!("TopicPartition v{} is not supported", version);
+        }
         let topic = if version >= 1 {
             types::String.decode(buf)?
         } else {

--- a/src/messages/consumer_protocol_subscription.rs
+++ b/src/messages/consumer_protocol_subscription.rs
@@ -98,7 +98,7 @@ impl ConsumerProtocolSubscription {
 impl Encodable for ConsumerProtocolSubscription {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 3 {
-            bail!("ConsumerProtocolSubscription v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Array(types::String).encode(buf, &self.topics)?;
         types::Bytes.encode(buf, &self.user_data)?;
@@ -136,7 +136,7 @@ impl Encodable for ConsumerProtocolSubscription {
 impl Decodable for ConsumerProtocolSubscription {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 3 {
-            bail!("ConsumerProtocolSubscription v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topics = types::Array(types::String).decode(buf)?;
         let user_data = types::Bytes.decode(buf)?;
@@ -221,7 +221,7 @@ impl TopicPartition {
 impl Encodable for TopicPartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 3 {
-            bail!("TopicPartition v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 1 {
             types::String.encode(buf, &self.topic)?;
@@ -264,7 +264,7 @@ impl Encodable for TopicPartition {
 impl Decodable for TopicPartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 3 {
-            bail!("TopicPartition v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topic = if version >= 1 {
             types::String.decode(buf)?

--- a/src/messages/controlled_shutdown_request.rs
+++ b/src/messages/controlled_shutdown_request.rs
@@ -69,6 +69,9 @@ impl ControlledShutdownRequest {
 #[cfg(feature = "client")]
 impl Encodable for ControlledShutdownRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 3 {
+            bail!("ControlledShutdownRequest v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.broker_id)?;
         if version >= 2 {
             types::Int64.encode(buf, &self.broker_epoch)?;
@@ -112,6 +115,9 @@ impl Encodable for ControlledShutdownRequest {
 #[cfg(feature = "broker")]
 impl Decodable for ControlledShutdownRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 3 {
+            bail!("ControlledShutdownRequest v{} is not supported", version);
+        }
         let broker_id = types::Int32.decode(buf)?;
         let broker_epoch = if version >= 2 {
             types::Int64.decode(buf)?

--- a/src/messages/controlled_shutdown_request.rs
+++ b/src/messages/controlled_shutdown_request.rs
@@ -70,7 +70,7 @@ impl ControlledShutdownRequest {
 impl Encodable for ControlledShutdownRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 3 {
-            bail!("ControlledShutdownRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.broker_id)?;
         if version >= 2 {
@@ -116,7 +116,7 @@ impl Encodable for ControlledShutdownRequest {
 impl Decodable for ControlledShutdownRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 3 {
-            bail!("ControlledShutdownRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let broker_id = types::Int32.decode(buf)?;
         let broker_epoch = if version >= 2 {

--- a/src/messages/controlled_shutdown_response.rs
+++ b/src/messages/controlled_shutdown_response.rs
@@ -69,6 +69,9 @@ impl ControlledShutdownResponse {
 #[cfg(feature = "broker")]
 impl Encodable for ControlledShutdownResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 3 {
+            bail!("ControlledShutdownResponse v{} is not supported", version);
+        }
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 3 {
             types::CompactArray(types::Struct { version })
@@ -119,6 +122,9 @@ impl Encodable for ControlledShutdownResponse {
 #[cfg(feature = "client")]
 impl Decodable for ControlledShutdownResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 3 {
+            bail!("ControlledShutdownResponse v{} is not supported", version);
+        }
         let error_code = types::Int16.decode(buf)?;
         let remaining_partitions = if version >= 3 {
             types::CompactArray(types::Struct { version }).decode(buf)?
@@ -210,6 +216,9 @@ impl RemainingPartition {
 #[cfg(feature = "broker")]
 impl Encodable for RemainingPartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 3 {
+            bail!("RemainingPartition v{} is not supported", version);
+        }
         if version >= 3 {
             types::CompactString.encode(buf, &self.topic_name)?;
         } else {
@@ -257,6 +266,9 @@ impl Encodable for RemainingPartition {
 #[cfg(feature = "client")]
 impl Decodable for RemainingPartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 3 {
+            bail!("RemainingPartition v{} is not supported", version);
+        }
         let topic_name = if version >= 3 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/controlled_shutdown_response.rs
+++ b/src/messages/controlled_shutdown_response.rs
@@ -70,7 +70,7 @@ impl ControlledShutdownResponse {
 impl Encodable for ControlledShutdownResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 3 {
-            bail!("ControlledShutdownResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 3 {
@@ -123,7 +123,7 @@ impl Encodable for ControlledShutdownResponse {
 impl Decodable for ControlledShutdownResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 3 {
-            bail!("ControlledShutdownResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let error_code = types::Int16.decode(buf)?;
         let remaining_partitions = if version >= 3 {
@@ -217,7 +217,7 @@ impl RemainingPartition {
 impl Encodable for RemainingPartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 3 {
-            bail!("RemainingPartition v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 3 {
             types::CompactString.encode(buf, &self.topic_name)?;
@@ -267,7 +267,7 @@ impl Encodable for RemainingPartition {
 impl Decodable for RemainingPartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 3 {
-            bail!("RemainingPartition v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topic_name = if version >= 3 {
             types::CompactString.decode(buf)?

--- a/src/messages/controller_registration_request.rs
+++ b/src/messages/controller_registration_request.rs
@@ -112,10 +112,7 @@ impl ControllerRegistrationRequest {
 impl Encodable for ControllerRegistrationRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!(
-                "ControllerRegistrationRequest v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.controller_id)?;
         types::Uuid.encode(buf, &self.incarnation_id)?;
@@ -161,10 +158,7 @@ impl Encodable for ControllerRegistrationRequest {
 impl Decodable for ControllerRegistrationRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!(
-                "ControllerRegistrationRequest v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         let controller_id = types::Int32.decode(buf)?;
         let incarnation_id = types::Uuid.decode(buf)?;
@@ -275,7 +269,7 @@ impl Feature {
 impl Encodable for Feature {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("Feature v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::CompactString.encode(buf, &self.name)?;
         types::Int16.encode(buf, &self.min_supported_version)?;
@@ -315,7 +309,7 @@ impl Encodable for Feature {
 impl Decodable for Feature {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("Feature v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = types::CompactString.decode(buf)?;
         let min_supported_version = types::Int16.decode(buf)?;
@@ -434,7 +428,7 @@ impl Listener {
 impl Encodable for Listener {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("Listener v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::CompactString.encode(buf, &self.name)?;
         types::CompactString.encode(buf, &self.host)?;
@@ -476,7 +470,7 @@ impl Encodable for Listener {
 impl Decodable for Listener {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("Listener v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = types::CompactString.decode(buf)?;
         let host = types::CompactString.decode(buf)?;

--- a/src/messages/controller_registration_request.rs
+++ b/src/messages/controller_registration_request.rs
@@ -111,6 +111,12 @@ impl ControllerRegistrationRequest {
 #[cfg(feature = "client")]
 impl Encodable for ControllerRegistrationRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!(
+                "ControllerRegistrationRequest v{} is not supported",
+                version
+            );
+        }
         types::Int32.encode(buf, &self.controller_id)?;
         types::Uuid.encode(buf, &self.incarnation_id)?;
         types::Boolean.encode(buf, &self.zk_migration_ready)?;
@@ -154,6 +160,12 @@ impl Encodable for ControllerRegistrationRequest {
 #[cfg(feature = "broker")]
 impl Decodable for ControllerRegistrationRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!(
+                "ControllerRegistrationRequest v{} is not supported",
+                version
+            );
+        }
         let controller_id = types::Int32.decode(buf)?;
         let incarnation_id = types::Uuid.decode(buf)?;
         let zk_migration_ready = types::Boolean.decode(buf)?;
@@ -262,6 +274,9 @@ impl Feature {
 #[cfg(feature = "client")]
 impl Encodable for Feature {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("Feature v{} is not supported", version);
+        }
         types::CompactString.encode(buf, &self.name)?;
         types::Int16.encode(buf, &self.min_supported_version)?;
         types::Int16.encode(buf, &self.max_supported_version)?;
@@ -299,6 +314,9 @@ impl Encodable for Feature {
 #[cfg(feature = "broker")]
 impl Decodable for Feature {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("Feature v{} is not supported", version);
+        }
         let name = types::CompactString.decode(buf)?;
         let min_supported_version = types::Int16.decode(buf)?;
         let max_supported_version = types::Int16.decode(buf)?;
@@ -415,6 +433,9 @@ impl Listener {
 #[cfg(feature = "client")]
 impl Encodable for Listener {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("Listener v{} is not supported", version);
+        }
         types::CompactString.encode(buf, &self.name)?;
         types::CompactString.encode(buf, &self.host)?;
         types::UInt16.encode(buf, &self.port)?;
@@ -454,6 +475,9 @@ impl Encodable for Listener {
 #[cfg(feature = "broker")]
 impl Decodable for Listener {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("Listener v{} is not supported", version);
+        }
         let name = types::CompactString.decode(buf)?;
         let host = types::CompactString.decode(buf)?;
         let port = types::UInt16.decode(buf)?;

--- a/src/messages/controller_registration_response.rs
+++ b/src/messages/controller_registration_response.rs
@@ -83,6 +83,12 @@ impl ControllerRegistrationResponse {
 #[cfg(feature = "broker")]
 impl Encodable for ControllerRegistrationResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!(
+                "ControllerRegistrationResponse v{} is not supported",
+                version
+            );
+        }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
         types::CompactString.encode(buf, &self.error_message)?;
@@ -120,6 +126,12 @@ impl Encodable for ControllerRegistrationResponse {
 #[cfg(feature = "client")]
 impl Decodable for ControllerRegistrationResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!(
+                "ControllerRegistrationResponse v{} is not supported",
+                version
+            );
+        }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let error_message = types::CompactString.decode(buf)?;

--- a/src/messages/controller_registration_response.rs
+++ b/src/messages/controller_registration_response.rs
@@ -84,10 +84,7 @@ impl ControllerRegistrationResponse {
 impl Encodable for ControllerRegistrationResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!(
-                "ControllerRegistrationResponse v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -127,10 +124,7 @@ impl Encodable for ControllerRegistrationResponse {
 impl Decodable for ControllerRegistrationResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!(
-                "ControllerRegistrationResponse v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;

--- a/src/messages/create_acls_request.rs
+++ b/src/messages/create_acls_request.rs
@@ -140,7 +140,7 @@ impl AclCreation {
 impl Encodable for AclCreation {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 3 {
-            bail!("AclCreation v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int8.encode(buf, &self.resource_type)?;
         if version >= 2 {
@@ -228,7 +228,7 @@ impl Encodable for AclCreation {
 impl Decodable for AclCreation {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 3 {
-            bail!("AclCreation v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let resource_type = types::Int8.decode(buf)?;
         let resource_name = if version >= 2 {
@@ -335,7 +335,7 @@ impl CreateAclsRequest {
 impl Encodable for CreateAclsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 3 {
-            bail!("CreateAclsRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 2 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.creations)?;
@@ -384,7 +384,7 @@ impl Encodable for CreateAclsRequest {
 impl Decodable for CreateAclsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 3 {
-            bail!("CreateAclsRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let creations = if version >= 2 {
             types::CompactArray(types::Struct { version }).decode(buf)?

--- a/src/messages/create_acls_request.rs
+++ b/src/messages/create_acls_request.rs
@@ -139,6 +139,9 @@ impl AclCreation {
 #[cfg(feature = "client")]
 impl Encodable for AclCreation {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 3 {
+            bail!("AclCreation v{} is not supported", version);
+        }
         types::Int8.encode(buf, &self.resource_type)?;
         if version >= 2 {
             types::CompactString.encode(buf, &self.resource_name)?;
@@ -224,6 +227,9 @@ impl Encodable for AclCreation {
 #[cfg(feature = "broker")]
 impl Decodable for AclCreation {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 3 {
+            bail!("AclCreation v{} is not supported", version);
+        }
         let resource_type = types::Int8.decode(buf)?;
         let resource_name = if version >= 2 {
             types::CompactString.decode(buf)?
@@ -328,6 +334,9 @@ impl CreateAclsRequest {
 #[cfg(feature = "client")]
 impl Encodable for CreateAclsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 3 {
+            bail!("CreateAclsRequest v{} is not supported", version);
+        }
         if version >= 2 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.creations)?;
         } else {
@@ -374,6 +383,9 @@ impl Encodable for CreateAclsRequest {
 #[cfg(feature = "broker")]
 impl Decodable for CreateAclsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 3 {
+            bail!("CreateAclsRequest v{} is not supported", version);
+        }
         let creations = if version >= 2 {
             types::CompactArray(types::Struct { version }).decode(buf)?
         } else {

--- a/src/messages/create_acls_response.rs
+++ b/src/messages/create_acls_response.rs
@@ -69,6 +69,9 @@ impl AclCreationResult {
 #[cfg(feature = "broker")]
 impl Encodable for AclCreationResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 3 {
+            bail!("AclCreationResult v{} is not supported", version);
+        }
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 2 {
             types::CompactString.encode(buf, &self.error_message)?;
@@ -116,6 +119,9 @@ impl Encodable for AclCreationResult {
 #[cfg(feature = "client")]
 impl Decodable for AclCreationResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 3 {
+            bail!("AclCreationResult v{} is not supported", version);
+        }
         let error_code = types::Int16.decode(buf)?;
         let error_message = if version >= 2 {
             types::CompactString.decode(buf)?
@@ -207,6 +213,9 @@ impl CreateAclsResponse {
 #[cfg(feature = "broker")]
 impl Encodable for CreateAclsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 3 {
+            bail!("CreateAclsResponse v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         if version >= 2 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.results)?;
@@ -255,6 +264,9 @@ impl Encodable for CreateAclsResponse {
 #[cfg(feature = "client")]
 impl Decodable for CreateAclsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 3 {
+            bail!("CreateAclsResponse v{} is not supported", version);
+        }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let results = if version >= 2 {
             types::CompactArray(types::Struct { version }).decode(buf)?

--- a/src/messages/create_acls_response.rs
+++ b/src/messages/create_acls_response.rs
@@ -70,7 +70,7 @@ impl AclCreationResult {
 impl Encodable for AclCreationResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 3 {
-            bail!("AclCreationResult v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 2 {
@@ -120,7 +120,7 @@ impl Encodable for AclCreationResult {
 impl Decodable for AclCreationResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 3 {
-            bail!("AclCreationResult v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let error_code = types::Int16.decode(buf)?;
         let error_message = if version >= 2 {
@@ -214,7 +214,7 @@ impl CreateAclsResponse {
 impl Encodable for CreateAclsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 3 {
-            bail!("CreateAclsResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         if version >= 2 {
@@ -265,7 +265,7 @@ impl Encodable for CreateAclsResponse {
 impl Decodable for CreateAclsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 3 {
-            bail!("CreateAclsResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let results = if version >= 2 {

--- a/src/messages/create_delegation_token_request.rs
+++ b/src/messages/create_delegation_token_request.rs
@@ -69,6 +69,9 @@ impl CreatableRenewers {
 #[cfg(feature = "client")]
 impl Encodable for CreatableRenewers {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 3 {
+            bail!("CreatableRenewers v{} is not supported", version);
+        }
         if version >= 2 {
             types::CompactString.encode(buf, &self.principal_type)?;
         } else {
@@ -124,6 +127,9 @@ impl Encodable for CreatableRenewers {
 #[cfg(feature = "broker")]
 impl Decodable for CreatableRenewers {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 3 {
+            bail!("CreatableRenewers v{} is not supported", version);
+        }
         let principal_type = if version >= 2 {
             types::CompactString.decode(buf)?
         } else {
@@ -247,6 +253,9 @@ impl CreateDelegationTokenRequest {
 #[cfg(feature = "client")]
 impl Encodable for CreateDelegationTokenRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 3 {
+            bail!("CreateDelegationTokenRequest v{} is not supported", version);
+        }
         if version >= 3 {
             types::CompactString.encode(buf, &self.owner_principal_type)?;
         } else {
@@ -343,6 +352,9 @@ impl Encodable for CreateDelegationTokenRequest {
 #[cfg(feature = "broker")]
 impl Decodable for CreateDelegationTokenRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 3 {
+            bail!("CreateDelegationTokenRequest v{} is not supported", version);
+        }
         let owner_principal_type = if version >= 3 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/create_delegation_token_request.rs
+++ b/src/messages/create_delegation_token_request.rs
@@ -70,7 +70,7 @@ impl CreatableRenewers {
 impl Encodable for CreatableRenewers {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 3 {
-            bail!("CreatableRenewers v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 2 {
             types::CompactString.encode(buf, &self.principal_type)?;
@@ -128,7 +128,7 @@ impl Encodable for CreatableRenewers {
 impl Decodable for CreatableRenewers {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 3 {
-            bail!("CreatableRenewers v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let principal_type = if version >= 2 {
             types::CompactString.decode(buf)?
@@ -254,7 +254,7 @@ impl CreateDelegationTokenRequest {
 impl Encodable for CreateDelegationTokenRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 3 {
-            bail!("CreateDelegationTokenRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 3 {
             types::CompactString.encode(buf, &self.owner_principal_type)?;
@@ -353,7 +353,7 @@ impl Encodable for CreateDelegationTokenRequest {
 impl Decodable for CreateDelegationTokenRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 3 {
-            bail!("CreateDelegationTokenRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let owner_principal_type = if version >= 3 {
             types::CompactString.decode(buf)?

--- a/src/messages/create_delegation_token_response.rs
+++ b/src/messages/create_delegation_token_response.rs
@@ -196,10 +196,7 @@ impl CreateDelegationTokenResponse {
 impl Encodable for CreateDelegationTokenResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 3 {
-            bail!(
-                "CreateDelegationTokenResponse v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 2 {
@@ -317,10 +314,7 @@ impl Encodable for CreateDelegationTokenResponse {
 impl Decodable for CreateDelegationTokenResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 3 {
-            bail!(
-                "CreateDelegationTokenResponse v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         let error_code = types::Int16.decode(buf)?;
         let principal_type = if version >= 2 {

--- a/src/messages/create_delegation_token_response.rs
+++ b/src/messages/create_delegation_token_response.rs
@@ -195,6 +195,12 @@ impl CreateDelegationTokenResponse {
 #[cfg(feature = "broker")]
 impl Encodable for CreateDelegationTokenResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 3 {
+            bail!(
+                "CreateDelegationTokenResponse v{} is not supported",
+                version
+            );
+        }
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 2 {
             types::CompactString.encode(buf, &self.principal_type)?;
@@ -310,6 +316,12 @@ impl Encodable for CreateDelegationTokenResponse {
 #[cfg(feature = "client")]
 impl Decodable for CreateDelegationTokenResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 3 {
+            bail!(
+                "CreateDelegationTokenResponse v{} is not supported",
+                version
+            );
+        }
         let error_code = types::Int16.decode(buf)?;
         let principal_type = if version >= 2 {
             types::CompactString.decode(buf)?

--- a/src/messages/create_partitions_request.rs
+++ b/src/messages/create_partitions_request.rs
@@ -56,7 +56,7 @@ impl CreatePartitionsAssignment {
 impl Encodable for CreatePartitionsAssignment {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 3 {
-            bail!("CreatePartitionsAssignment v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 2 {
             types::CompactArray(types::Int32).encode(buf, &self.broker_ids)?;
@@ -104,7 +104,7 @@ impl Encodable for CreatePartitionsAssignment {
 impl Decodable for CreatePartitionsAssignment {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 3 {
-            bail!("CreatePartitionsAssignment v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let broker_ids = if version >= 2 {
             types::CompactArray(types::Int32).decode(buf)?
@@ -209,7 +209,7 @@ impl CreatePartitionsRequest {
 impl Encodable for CreatePartitionsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 3 {
-            bail!("CreatePartitionsRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 2 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
@@ -262,7 +262,7 @@ impl Encodable for CreatePartitionsRequest {
 impl Decodable for CreatePartitionsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 3 {
-            bail!("CreatePartitionsRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topics = if version >= 2 {
             types::CompactArray(types::Struct { version }).decode(buf)?
@@ -373,7 +373,7 @@ impl CreatePartitionsTopic {
 impl Encodable for CreatePartitionsTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 3 {
-            bail!("CreatePartitionsTopic v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 2 {
             types::CompactString.encode(buf, &self.name)?;
@@ -435,7 +435,7 @@ impl Encodable for CreatePartitionsTopic {
 impl Decodable for CreatePartitionsTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 3 {
-            bail!("CreatePartitionsTopic v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = if version >= 2 {
             types::CompactString.decode(buf)?

--- a/src/messages/create_partitions_request.rs
+++ b/src/messages/create_partitions_request.rs
@@ -55,6 +55,9 @@ impl CreatePartitionsAssignment {
 #[cfg(feature = "client")]
 impl Encodable for CreatePartitionsAssignment {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 3 {
+            bail!("CreatePartitionsAssignment v{} is not supported", version);
+        }
         if version >= 2 {
             types::CompactArray(types::Int32).encode(buf, &self.broker_ids)?;
         } else {
@@ -100,6 +103,9 @@ impl Encodable for CreatePartitionsAssignment {
 #[cfg(feature = "broker")]
 impl Decodable for CreatePartitionsAssignment {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 3 {
+            bail!("CreatePartitionsAssignment v{} is not supported", version);
+        }
         let broker_ids = if version >= 2 {
             types::CompactArray(types::Int32).decode(buf)?
         } else {
@@ -202,6 +208,9 @@ impl CreatePartitionsRequest {
 #[cfg(feature = "client")]
 impl Encodable for CreatePartitionsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 3 {
+            bail!("CreatePartitionsRequest v{} is not supported", version);
+        }
         if version >= 2 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
         } else {
@@ -252,6 +261,9 @@ impl Encodable for CreatePartitionsRequest {
 #[cfg(feature = "broker")]
 impl Decodable for CreatePartitionsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 3 {
+            bail!("CreatePartitionsRequest v{} is not supported", version);
+        }
         let topics = if version >= 2 {
             types::CompactArray(types::Struct { version }).decode(buf)?
         } else {
@@ -360,6 +372,9 @@ impl CreatePartitionsTopic {
 #[cfg(feature = "client")]
 impl Encodable for CreatePartitionsTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 3 {
+            bail!("CreatePartitionsTopic v{} is not supported", version);
+        }
         if version >= 2 {
             types::CompactString.encode(buf, &self.name)?;
         } else {
@@ -419,6 +434,9 @@ impl Encodable for CreatePartitionsTopic {
 #[cfg(feature = "broker")]
 impl Decodable for CreatePartitionsTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 3 {
+            bail!("CreatePartitionsTopic v{} is not supported", version);
+        }
         let name = if version >= 2 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/create_partitions_response.rs
+++ b/src/messages/create_partitions_response.rs
@@ -69,6 +69,9 @@ impl CreatePartitionsResponse {
 #[cfg(feature = "broker")]
 impl Encodable for CreatePartitionsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 3 {
+            bail!("CreatePartitionsResponse v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         if version >= 2 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.results)?;
@@ -117,6 +120,9 @@ impl Encodable for CreatePartitionsResponse {
 #[cfg(feature = "client")]
 impl Decodable for CreatePartitionsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 3 {
+            bail!("CreatePartitionsResponse v{} is not supported", version);
+        }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let results = if version >= 2 {
             types::CompactArray(types::Struct { version }).decode(buf)?
@@ -222,6 +228,9 @@ impl CreatePartitionsTopicResult {
 #[cfg(feature = "broker")]
 impl Encodable for CreatePartitionsTopicResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 3 {
+            bail!("CreatePartitionsTopicResult v{} is not supported", version);
+        }
         if version >= 2 {
             types::CompactString.encode(buf, &self.name)?;
         } else {
@@ -279,6 +288,9 @@ impl Encodable for CreatePartitionsTopicResult {
 #[cfg(feature = "client")]
 impl Decodable for CreatePartitionsTopicResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 3 {
+            bail!("CreatePartitionsTopicResult v{} is not supported", version);
+        }
         let name = if version >= 2 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/create_partitions_response.rs
+++ b/src/messages/create_partitions_response.rs
@@ -70,7 +70,7 @@ impl CreatePartitionsResponse {
 impl Encodable for CreatePartitionsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 3 {
-            bail!("CreatePartitionsResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         if version >= 2 {
@@ -121,7 +121,7 @@ impl Encodable for CreatePartitionsResponse {
 impl Decodable for CreatePartitionsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 3 {
-            bail!("CreatePartitionsResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let results = if version >= 2 {
@@ -229,7 +229,7 @@ impl CreatePartitionsTopicResult {
 impl Encodable for CreatePartitionsTopicResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 3 {
-            bail!("CreatePartitionsTopicResult v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 2 {
             types::CompactString.encode(buf, &self.name)?;
@@ -289,7 +289,7 @@ impl Encodable for CreatePartitionsTopicResult {
 impl Decodable for CreatePartitionsTopicResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 3 {
-            bail!("CreatePartitionsTopicResult v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = if version >= 2 {
             types::CompactString.decode(buf)?

--- a/src/messages/create_topics_request.rs
+++ b/src/messages/create_topics_request.rs
@@ -70,7 +70,7 @@ impl CreatableReplicaAssignment {
 impl Encodable for CreatableReplicaAssignment {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 7 {
-            bail!("CreatableReplicaAssignment v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.partition_index)?;
         if version >= 5 {
@@ -120,7 +120,7 @@ impl Encodable for CreatableReplicaAssignment {
 impl Decodable for CreatableReplicaAssignment {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 7 {
-            bail!("CreatableReplicaAssignment v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let partition_index = types::Int32.decode(buf)?;
         let broker_ids = if version >= 5 {
@@ -256,7 +256,7 @@ impl CreatableTopic {
 impl Encodable for CreatableTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 7 {
-            bail!("CreatableTopic v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 5 {
             types::CompactString.encode(buf, &self.name)?;
@@ -331,7 +331,7 @@ impl Encodable for CreatableTopic {
 impl Decodable for CreatableTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 7 {
-            bail!("CreatableTopic v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = if version >= 5 {
             types::CompactString.decode(buf)?
@@ -442,7 +442,7 @@ impl CreatableTopicConfig {
 impl Encodable for CreatableTopicConfig {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 7 {
-            bail!("CreatableTopicConfig v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 5 {
             types::CompactString.encode(buf, &self.name)?;
@@ -500,7 +500,7 @@ impl Encodable for CreatableTopicConfig {
 impl Decodable for CreatableTopicConfig {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 7 {
-            bail!("CreatableTopicConfig v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = if version >= 5 {
             types::CompactString.decode(buf)?
@@ -612,7 +612,7 @@ impl CreateTopicsRequest {
 impl Encodable for CreateTopicsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 7 {
-            bail!("CreateTopicsRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 5 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
@@ -677,7 +677,7 @@ impl Encodable for CreateTopicsRequest {
 impl Decodable for CreateTopicsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 7 {
-            bail!("CreateTopicsRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topics = if version >= 5 {
             types::CompactArray(types::Struct { version }).decode(buf)?

--- a/src/messages/create_topics_request.rs
+++ b/src/messages/create_topics_request.rs
@@ -69,6 +69,9 @@ impl CreatableReplicaAssignment {
 #[cfg(feature = "client")]
 impl Encodable for CreatableReplicaAssignment {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 7 {
+            bail!("CreatableReplicaAssignment v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.partition_index)?;
         if version >= 5 {
             types::CompactArray(types::Int32).encode(buf, &self.broker_ids)?;
@@ -116,6 +119,9 @@ impl Encodable for CreatableReplicaAssignment {
 #[cfg(feature = "broker")]
 impl Decodable for CreatableReplicaAssignment {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 7 {
+            bail!("CreatableReplicaAssignment v{} is not supported", version);
+        }
         let partition_index = types::Int32.decode(buf)?;
         let broker_ids = if version >= 5 {
             types::CompactArray(types::Int32).decode(buf)?
@@ -249,6 +255,9 @@ impl CreatableTopic {
 #[cfg(feature = "client")]
 impl Encodable for CreatableTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 7 {
+            bail!("CreatableTopic v{} is not supported", version);
+        }
         if version >= 5 {
             types::CompactString.encode(buf, &self.name)?;
         } else {
@@ -321,6 +330,9 @@ impl Encodable for CreatableTopic {
 #[cfg(feature = "broker")]
 impl Decodable for CreatableTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 7 {
+            bail!("CreatableTopic v{} is not supported", version);
+        }
         let name = if version >= 5 {
             types::CompactString.decode(buf)?
         } else {
@@ -429,6 +441,9 @@ impl CreatableTopicConfig {
 #[cfg(feature = "client")]
 impl Encodable for CreatableTopicConfig {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 7 {
+            bail!("CreatableTopicConfig v{} is not supported", version);
+        }
         if version >= 5 {
             types::CompactString.encode(buf, &self.name)?;
         } else {
@@ -484,6 +499,9 @@ impl Encodable for CreatableTopicConfig {
 #[cfg(feature = "broker")]
 impl Decodable for CreatableTopicConfig {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 7 {
+            bail!("CreatableTopicConfig v{} is not supported", version);
+        }
         let name = if version >= 5 {
             types::CompactString.decode(buf)?
         } else {
@@ -593,6 +611,9 @@ impl CreateTopicsRequest {
 #[cfg(feature = "client")]
 impl Encodable for CreateTopicsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 7 {
+            bail!("CreateTopicsRequest v{} is not supported", version);
+        }
         if version >= 5 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
         } else {
@@ -655,6 +676,9 @@ impl Encodable for CreateTopicsRequest {
 #[cfg(feature = "broker")]
 impl Decodable for CreateTopicsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 7 {
+            bail!("CreateTopicsRequest v{} is not supported", version);
+        }
         let topics = if version >= 5 {
             types::CompactArray(types::Struct { version }).decode(buf)?
         } else {

--- a/src/messages/create_topics_response.rs
+++ b/src/messages/create_topics_response.rs
@@ -112,7 +112,7 @@ impl CreatableTopicConfigs {
 impl Encodable for CreatableTopicConfigs {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 7 {
-            bail!("CreatableTopicConfigs v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 5 {
             types::CompactString.encode(buf, &self.name)?;
@@ -222,7 +222,7 @@ impl Encodable for CreatableTopicConfigs {
 impl Decodable for CreatableTopicConfigs {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 7 {
-            bail!("CreatableTopicConfigs v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = if version >= 5 {
             types::CompactString.decode(buf)?
@@ -425,7 +425,7 @@ impl CreatableTopicResult {
 impl Encodable for CreatableTopicResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 7 {
-            bail!("CreatableTopicResult v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 5 {
             types::CompactString.encode(buf, &self.name)?;
@@ -544,7 +544,7 @@ impl Encodable for CreatableTopicResult {
 impl Decodable for CreatableTopicResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 7 {
-            bail!("CreatableTopicResult v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = if version >= 5 {
             types::CompactString.decode(buf)?
@@ -687,7 +687,7 @@ impl CreateTopicsResponse {
 impl Encodable for CreateTopicsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 7 {
-            bail!("CreateTopicsResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 2 {
             types::Int32.encode(buf, &self.throttle_time_ms)?;
@@ -742,7 +742,7 @@ impl Encodable for CreateTopicsResponse {
 impl Decodable for CreateTopicsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 7 {
-            bail!("CreateTopicsResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = if version >= 2 {
             types::Int32.decode(buf)?

--- a/src/messages/create_topics_response.rs
+++ b/src/messages/create_topics_response.rs
@@ -111,6 +111,9 @@ impl CreatableTopicConfigs {
 #[cfg(feature = "broker")]
 impl Encodable for CreatableTopicConfigs {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 7 {
+            bail!("CreatableTopicConfigs v{} is not supported", version);
+        }
         if version >= 5 {
             types::CompactString.encode(buf, &self.name)?;
         } else {
@@ -218,6 +221,9 @@ impl Encodable for CreatableTopicConfigs {
 #[cfg(feature = "client")]
 impl Decodable for CreatableTopicConfigs {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 7 {
+            bail!("CreatableTopicConfigs v{} is not supported", version);
+        }
         let name = if version >= 5 {
             types::CompactString.decode(buf)?
         } else {
@@ -418,6 +424,9 @@ impl CreatableTopicResult {
 #[cfg(feature = "broker")]
 impl Encodable for CreatableTopicResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 7 {
+            bail!("CreatableTopicResult v{} is not supported", version);
+        }
         if version >= 5 {
             types::CompactString.encode(buf, &self.name)?;
         } else {
@@ -534,6 +543,9 @@ impl Encodable for CreatableTopicResult {
 #[cfg(feature = "client")]
 impl Decodable for CreatableTopicResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 7 {
+            bail!("CreatableTopicResult v{} is not supported", version);
+        }
         let name = if version >= 5 {
             types::CompactString.decode(buf)?
         } else {
@@ -674,6 +686,9 @@ impl CreateTopicsResponse {
 #[cfg(feature = "broker")]
 impl Encodable for CreateTopicsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 7 {
+            bail!("CreateTopicsResponse v{} is not supported", version);
+        }
         if version >= 2 {
             types::Int32.encode(buf, &self.throttle_time_ms)?;
         }
@@ -726,6 +741,9 @@ impl Encodable for CreateTopicsResponse {
 #[cfg(feature = "client")]
 impl Decodable for CreateTopicsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 7 {
+            bail!("CreateTopicsResponse v{} is not supported", version);
+        }
         let throttle_time_ms = if version >= 2 {
             types::Int32.decode(buf)?
         } else {

--- a/src/messages/default_principal_data.rs
+++ b/src/messages/default_principal_data.rs
@@ -83,7 +83,7 @@ impl DefaultPrincipalData {
 impl Encodable for DefaultPrincipalData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("DefaultPrincipalData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::CompactString.encode(buf, &self._type)?;
         types::CompactString.encode(buf, &self.name)?;
@@ -122,7 +122,7 @@ impl Encodable for DefaultPrincipalData {
 impl Decodable for DefaultPrincipalData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("DefaultPrincipalData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let _type = types::CompactString.decode(buf)?;
         let name = types::CompactString.decode(buf)?;

--- a/src/messages/default_principal_data.rs
+++ b/src/messages/default_principal_data.rs
@@ -82,6 +82,9 @@ impl DefaultPrincipalData {
 
 impl Encodable for DefaultPrincipalData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("DefaultPrincipalData v{} is not supported", version);
+        }
         types::CompactString.encode(buf, &self._type)?;
         types::CompactString.encode(buf, &self.name)?;
         types::Boolean.encode(buf, &self.token_authenticated)?;
@@ -118,6 +121,9 @@ impl Encodable for DefaultPrincipalData {
 
 impl Decodable for DefaultPrincipalData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("DefaultPrincipalData v{} is not supported", version);
+        }
         let _type = types::CompactString.decode(buf)?;
         let name = types::CompactString.decode(buf)?;
         let token_authenticated = types::Boolean.decode(buf)?;

--- a/src/messages/delete_acls_request.rs
+++ b/src/messages/delete_acls_request.rs
@@ -140,7 +140,7 @@ impl DeleteAclsFilter {
 impl Encodable for DeleteAclsFilter {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 3 {
-            bail!("DeleteAclsFilter v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int8.encode(buf, &self.resource_type_filter)?;
         if version >= 2 {
@@ -228,7 +228,7 @@ impl Encodable for DeleteAclsFilter {
 impl Decodable for DeleteAclsFilter {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 3 {
-            bail!("DeleteAclsFilter v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let resource_type_filter = types::Int8.decode(buf)?;
         let resource_name_filter = if version >= 2 {
@@ -335,7 +335,7 @@ impl DeleteAclsRequest {
 impl Encodable for DeleteAclsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 3 {
-            bail!("DeleteAclsRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 2 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.filters)?;
@@ -384,7 +384,7 @@ impl Encodable for DeleteAclsRequest {
 impl Decodable for DeleteAclsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 3 {
-            bail!("DeleteAclsRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let filters = if version >= 2 {
             types::CompactArray(types::Struct { version }).decode(buf)?

--- a/src/messages/delete_acls_request.rs
+++ b/src/messages/delete_acls_request.rs
@@ -139,6 +139,9 @@ impl DeleteAclsFilter {
 #[cfg(feature = "client")]
 impl Encodable for DeleteAclsFilter {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 3 {
+            bail!("DeleteAclsFilter v{} is not supported", version);
+        }
         types::Int8.encode(buf, &self.resource_type_filter)?;
         if version >= 2 {
             types::CompactString.encode(buf, &self.resource_name_filter)?;
@@ -224,6 +227,9 @@ impl Encodable for DeleteAclsFilter {
 #[cfg(feature = "broker")]
 impl Decodable for DeleteAclsFilter {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 3 {
+            bail!("DeleteAclsFilter v{} is not supported", version);
+        }
         let resource_type_filter = types::Int8.decode(buf)?;
         let resource_name_filter = if version >= 2 {
             types::CompactString.decode(buf)?
@@ -328,6 +334,9 @@ impl DeleteAclsRequest {
 #[cfg(feature = "client")]
 impl Encodable for DeleteAclsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 3 {
+            bail!("DeleteAclsRequest v{} is not supported", version);
+        }
         if version >= 2 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.filters)?;
         } else {
@@ -374,6 +383,9 @@ impl Encodable for DeleteAclsRequest {
 #[cfg(feature = "broker")]
 impl Decodable for DeleteAclsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 3 {
+            bail!("DeleteAclsRequest v{} is not supported", version);
+        }
         let filters = if version >= 2 {
             types::CompactArray(types::Struct { version }).decode(buf)?
         } else {

--- a/src/messages/delete_acls_response.rs
+++ b/src/messages/delete_acls_response.rs
@@ -84,7 +84,7 @@ impl DeleteAclsFilterResult {
 impl Encodable for DeleteAclsFilterResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 3 {
-            bail!("DeleteAclsFilterResult v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 2 {
@@ -146,7 +146,7 @@ impl Encodable for DeleteAclsFilterResult {
 impl Decodable for DeleteAclsFilterResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 3 {
-            bail!("DeleteAclsFilterResult v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let error_code = types::Int16.decode(buf)?;
         let error_message = if version >= 2 {
@@ -345,7 +345,7 @@ impl DeleteAclsMatchingAcl {
 impl Encodable for DeleteAclsMatchingAcl {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 3 {
-            bail!("DeleteAclsMatchingAcl v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 2 {
@@ -445,7 +445,7 @@ impl Encodable for DeleteAclsMatchingAcl {
 impl Decodable for DeleteAclsMatchingAcl {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 3 {
-            bail!("DeleteAclsMatchingAcl v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let error_code = types::Int16.decode(buf)?;
         let error_message = if version >= 2 {
@@ -576,7 +576,7 @@ impl DeleteAclsResponse {
 impl Encodable for DeleteAclsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 3 {
-            bail!("DeleteAclsResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         if version >= 2 {
@@ -628,7 +628,7 @@ impl Encodable for DeleteAclsResponse {
 impl Decodable for DeleteAclsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 3 {
-            bail!("DeleteAclsResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let filter_results = if version >= 2 {

--- a/src/messages/delete_acls_response.rs
+++ b/src/messages/delete_acls_response.rs
@@ -83,6 +83,9 @@ impl DeleteAclsFilterResult {
 #[cfg(feature = "broker")]
 impl Encodable for DeleteAclsFilterResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 3 {
+            bail!("DeleteAclsFilterResult v{} is not supported", version);
+        }
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 2 {
             types::CompactString.encode(buf, &self.error_message)?;
@@ -142,6 +145,9 @@ impl Encodable for DeleteAclsFilterResult {
 #[cfg(feature = "client")]
 impl Decodable for DeleteAclsFilterResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 3 {
+            bail!("DeleteAclsFilterResult v{} is not supported", version);
+        }
         let error_code = types::Int16.decode(buf)?;
         let error_message = if version >= 2 {
             types::CompactString.decode(buf)?
@@ -338,6 +344,9 @@ impl DeleteAclsMatchingAcl {
 #[cfg(feature = "broker")]
 impl Encodable for DeleteAclsMatchingAcl {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 3 {
+            bail!("DeleteAclsMatchingAcl v{} is not supported", version);
+        }
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 2 {
             types::CompactString.encode(buf, &self.error_message)?;
@@ -435,6 +444,9 @@ impl Encodable for DeleteAclsMatchingAcl {
 #[cfg(feature = "client")]
 impl Decodable for DeleteAclsMatchingAcl {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 3 {
+            bail!("DeleteAclsMatchingAcl v{} is not supported", version);
+        }
         let error_code = types::Int16.decode(buf)?;
         let error_message = if version >= 2 {
             types::CompactString.decode(buf)?
@@ -563,6 +575,9 @@ impl DeleteAclsResponse {
 #[cfg(feature = "broker")]
 impl Encodable for DeleteAclsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 3 {
+            bail!("DeleteAclsResponse v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         if version >= 2 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.filter_results)?;
@@ -612,6 +627,9 @@ impl Encodable for DeleteAclsResponse {
 #[cfg(feature = "client")]
 impl Decodable for DeleteAclsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 3 {
+            bail!("DeleteAclsResponse v{} is not supported", version);
+        }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let filter_results = if version >= 2 {
             types::CompactArray(types::Struct { version }).decode(buf)?

--- a/src/messages/delete_groups_request.rs
+++ b/src/messages/delete_groups_request.rs
@@ -55,6 +55,9 @@ impl DeleteGroupsRequest {
 #[cfg(feature = "client")]
 impl Encodable for DeleteGroupsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 2 {
+            bail!("DeleteGroupsRequest v{} is not supported", version);
+        }
         if version >= 2 {
             types::CompactArray(types::CompactString).encode(buf, &self.groups_names)?;
         } else {
@@ -101,6 +104,9 @@ impl Encodable for DeleteGroupsRequest {
 #[cfg(feature = "broker")]
 impl Decodable for DeleteGroupsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 2 {
+            bail!("DeleteGroupsRequest v{} is not supported", version);
+        }
         let groups_names = if version >= 2 {
             types::CompactArray(types::CompactString).decode(buf)?
         } else {

--- a/src/messages/delete_groups_request.rs
+++ b/src/messages/delete_groups_request.rs
@@ -56,7 +56,7 @@ impl DeleteGroupsRequest {
 impl Encodable for DeleteGroupsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 2 {
-            bail!("DeleteGroupsRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 2 {
             types::CompactArray(types::CompactString).encode(buf, &self.groups_names)?;
@@ -105,7 +105,7 @@ impl Encodable for DeleteGroupsRequest {
 impl Decodable for DeleteGroupsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 2 {
-            bail!("DeleteGroupsRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let groups_names = if version >= 2 {
             types::CompactArray(types::CompactString).decode(buf)?

--- a/src/messages/delete_groups_response.rs
+++ b/src/messages/delete_groups_response.rs
@@ -69,6 +69,9 @@ impl DeletableGroupResult {
 #[cfg(feature = "broker")]
 impl Encodable for DeletableGroupResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 2 {
+            bail!("DeletableGroupResult v{} is not supported", version);
+        }
         if version >= 2 {
             types::CompactString.encode(buf, &self.group_id)?;
         } else {
@@ -116,6 +119,9 @@ impl Encodable for DeletableGroupResult {
 #[cfg(feature = "client")]
 impl Decodable for DeletableGroupResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 2 {
+            bail!("DeletableGroupResult v{} is not supported", version);
+        }
         let group_id = if version >= 2 {
             types::CompactString.decode(buf)?
         } else {
@@ -207,6 +213,9 @@ impl DeleteGroupsResponse {
 #[cfg(feature = "broker")]
 impl Encodable for DeleteGroupsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 2 {
+            bail!("DeleteGroupsResponse v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         if version >= 2 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.results)?;
@@ -255,6 +264,9 @@ impl Encodable for DeleteGroupsResponse {
 #[cfg(feature = "client")]
 impl Decodable for DeleteGroupsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 2 {
+            bail!("DeleteGroupsResponse v{} is not supported", version);
+        }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let results = if version >= 2 {
             types::CompactArray(types::Struct { version }).decode(buf)?

--- a/src/messages/delete_groups_response.rs
+++ b/src/messages/delete_groups_response.rs
@@ -70,7 +70,7 @@ impl DeletableGroupResult {
 impl Encodable for DeletableGroupResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 2 {
-            bail!("DeletableGroupResult v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 2 {
             types::CompactString.encode(buf, &self.group_id)?;
@@ -120,7 +120,7 @@ impl Encodable for DeletableGroupResult {
 impl Decodable for DeletableGroupResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 2 {
-            bail!("DeletableGroupResult v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let group_id = if version >= 2 {
             types::CompactString.decode(buf)?
@@ -214,7 +214,7 @@ impl DeleteGroupsResponse {
 impl Encodable for DeleteGroupsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 2 {
-            bail!("DeleteGroupsResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         if version >= 2 {
@@ -265,7 +265,7 @@ impl Encodable for DeleteGroupsResponse {
 impl Decodable for DeleteGroupsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 2 {
-            bail!("DeleteGroupsResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let results = if version >= 2 {

--- a/src/messages/delete_records_request.rs
+++ b/src/messages/delete_records_request.rs
@@ -69,6 +69,9 @@ impl DeleteRecordsPartition {
 #[cfg(feature = "client")]
 impl Encodable for DeleteRecordsPartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 2 {
+            bail!("DeleteRecordsPartition v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int64.encode(buf, &self.offset)?;
         if version >= 2 {
@@ -108,6 +111,9 @@ impl Encodable for DeleteRecordsPartition {
 #[cfg(feature = "broker")]
 impl Decodable for DeleteRecordsPartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 2 {
+            bail!("DeleteRecordsPartition v{} is not supported", version);
+        }
         let partition_index = types::Int32.decode(buf)?;
         let offset = types::Int64.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
@@ -195,6 +201,9 @@ impl DeleteRecordsRequest {
 #[cfg(feature = "client")]
 impl Encodable for DeleteRecordsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 2 {
+            bail!("DeleteRecordsRequest v{} is not supported", version);
+        }
         if version >= 2 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
         } else {
@@ -243,6 +252,9 @@ impl Encodable for DeleteRecordsRequest {
 #[cfg(feature = "broker")]
 impl Decodable for DeleteRecordsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 2 {
+            bail!("DeleteRecordsRequest v{} is not supported", version);
+        }
         let topics = if version >= 2 {
             types::CompactArray(types::Struct { version }).decode(buf)?
         } else {
@@ -334,6 +346,9 @@ impl DeleteRecordsTopic {
 #[cfg(feature = "client")]
 impl Encodable for DeleteRecordsTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 2 {
+            bail!("DeleteRecordsTopic v{} is not supported", version);
+        }
         if version >= 2 {
             types::CompactString.encode(buf, &self.name)?;
         } else {
@@ -390,6 +405,9 @@ impl Encodable for DeleteRecordsTopic {
 #[cfg(feature = "broker")]
 impl Decodable for DeleteRecordsTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 2 {
+            bail!("DeleteRecordsTopic v{} is not supported", version);
+        }
         let name = if version >= 2 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/delete_records_request.rs
+++ b/src/messages/delete_records_request.rs
@@ -70,7 +70,7 @@ impl DeleteRecordsPartition {
 impl Encodable for DeleteRecordsPartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 2 {
-            bail!("DeleteRecordsPartition v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int64.encode(buf, &self.offset)?;
@@ -112,7 +112,7 @@ impl Encodable for DeleteRecordsPartition {
 impl Decodable for DeleteRecordsPartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 2 {
-            bail!("DeleteRecordsPartition v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let partition_index = types::Int32.decode(buf)?;
         let offset = types::Int64.decode(buf)?;
@@ -202,7 +202,7 @@ impl DeleteRecordsRequest {
 impl Encodable for DeleteRecordsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 2 {
-            bail!("DeleteRecordsRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 2 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
@@ -253,7 +253,7 @@ impl Encodable for DeleteRecordsRequest {
 impl Decodable for DeleteRecordsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 2 {
-            bail!("DeleteRecordsRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topics = if version >= 2 {
             types::CompactArray(types::Struct { version }).decode(buf)?
@@ -347,7 +347,7 @@ impl DeleteRecordsTopic {
 impl Encodable for DeleteRecordsTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 2 {
-            bail!("DeleteRecordsTopic v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 2 {
             types::CompactString.encode(buf, &self.name)?;
@@ -406,7 +406,7 @@ impl Encodable for DeleteRecordsTopic {
 impl Decodable for DeleteRecordsTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 2 {
-            bail!("DeleteRecordsTopic v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = if version >= 2 {
             types::CompactString.decode(buf)?

--- a/src/messages/delete_records_response.rs
+++ b/src/messages/delete_records_response.rs
@@ -83,6 +83,9 @@ impl DeleteRecordsPartitionResult {
 #[cfg(feature = "broker")]
 impl Encodable for DeleteRecordsPartitionResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 2 {
+            bail!("DeleteRecordsPartitionResult v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int64.encode(buf, &self.low_watermark)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -124,6 +127,9 @@ impl Encodable for DeleteRecordsPartitionResult {
 #[cfg(feature = "client")]
 impl Decodable for DeleteRecordsPartitionResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 2 {
+            bail!("DeleteRecordsPartitionResult v{} is not supported", version);
+        }
         let partition_index = types::Int32.decode(buf)?;
         let low_watermark = types::Int64.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
@@ -214,6 +220,9 @@ impl DeleteRecordsResponse {
 #[cfg(feature = "broker")]
 impl Encodable for DeleteRecordsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 2 {
+            bail!("DeleteRecordsResponse v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         if version >= 2 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
@@ -262,6 +271,9 @@ impl Encodable for DeleteRecordsResponse {
 #[cfg(feature = "client")]
 impl Decodable for DeleteRecordsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 2 {
+            bail!("DeleteRecordsResponse v{} is not supported", version);
+        }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let topics = if version >= 2 {
             types::CompactArray(types::Struct { version }).decode(buf)?
@@ -353,6 +365,9 @@ impl DeleteRecordsTopicResult {
 #[cfg(feature = "broker")]
 impl Encodable for DeleteRecordsTopicResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 2 {
+            bail!("DeleteRecordsTopicResult v{} is not supported", version);
+        }
         if version >= 2 {
             types::CompactString.encode(buf, &self.name)?;
         } else {
@@ -409,6 +424,9 @@ impl Encodable for DeleteRecordsTopicResult {
 #[cfg(feature = "client")]
 impl Decodable for DeleteRecordsTopicResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 2 {
+            bail!("DeleteRecordsTopicResult v{} is not supported", version);
+        }
         let name = if version >= 2 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/delete_records_response.rs
+++ b/src/messages/delete_records_response.rs
@@ -84,7 +84,7 @@ impl DeleteRecordsPartitionResult {
 impl Encodable for DeleteRecordsPartitionResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 2 {
-            bail!("DeleteRecordsPartitionResult v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int64.encode(buf, &self.low_watermark)?;
@@ -128,7 +128,7 @@ impl Encodable for DeleteRecordsPartitionResult {
 impl Decodable for DeleteRecordsPartitionResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 2 {
-            bail!("DeleteRecordsPartitionResult v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let partition_index = types::Int32.decode(buf)?;
         let low_watermark = types::Int64.decode(buf)?;
@@ -221,7 +221,7 @@ impl DeleteRecordsResponse {
 impl Encodable for DeleteRecordsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 2 {
-            bail!("DeleteRecordsResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         if version >= 2 {
@@ -272,7 +272,7 @@ impl Encodable for DeleteRecordsResponse {
 impl Decodable for DeleteRecordsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 2 {
-            bail!("DeleteRecordsResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let topics = if version >= 2 {
@@ -366,7 +366,7 @@ impl DeleteRecordsTopicResult {
 impl Encodable for DeleteRecordsTopicResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 2 {
-            bail!("DeleteRecordsTopicResult v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 2 {
             types::CompactString.encode(buf, &self.name)?;
@@ -425,7 +425,7 @@ impl Encodable for DeleteRecordsTopicResult {
 impl Decodable for DeleteRecordsTopicResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 2 {
-            bail!("DeleteRecordsTopicResult v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = if version >= 2 {
             types::CompactString.decode(buf)?

--- a/src/messages/delete_topics_request.rs
+++ b/src/messages/delete_topics_request.rs
@@ -69,6 +69,9 @@ impl DeleteTopicState {
 #[cfg(feature = "client")]
 impl Encodable for DeleteTopicState {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 6 {
+            bail!("DeleteTopicState v{} is not supported", version);
+        }
         if version >= 6 {
             types::CompactString.encode(buf, &self.name)?;
         } else {
@@ -132,6 +135,9 @@ impl Encodable for DeleteTopicState {
 #[cfg(feature = "broker")]
 impl Decodable for DeleteTopicState {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 6 {
+            bail!("DeleteTopicState v{} is not supported", version);
+        }
         let name = if version >= 6 {
             types::CompactString.decode(buf)?
         } else {
@@ -241,6 +247,9 @@ impl DeleteTopicsRequest {
 #[cfg(feature = "client")]
 impl Encodable for DeleteTopicsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 6 {
+            bail!("DeleteTopicsRequest v{} is not supported", version);
+        }
         if version >= 6 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
         } else {
@@ -308,6 +317,9 @@ impl Encodable for DeleteTopicsRequest {
 #[cfg(feature = "broker")]
 impl Decodable for DeleteTopicsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 6 {
+            bail!("DeleteTopicsRequest v{} is not supported", version);
+        }
         let topics = if version >= 6 {
             types::CompactArray(types::Struct { version }).decode(buf)?
         } else {

--- a/src/messages/delete_topics_request.rs
+++ b/src/messages/delete_topics_request.rs
@@ -70,7 +70,7 @@ impl DeleteTopicState {
 impl Encodable for DeleteTopicState {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 6 {
-            bail!("DeleteTopicState v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 6 {
             types::CompactString.encode(buf, &self.name)?;
@@ -136,7 +136,7 @@ impl Encodable for DeleteTopicState {
 impl Decodable for DeleteTopicState {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 6 {
-            bail!("DeleteTopicState v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = if version >= 6 {
             types::CompactString.decode(buf)?
@@ -248,7 +248,7 @@ impl DeleteTopicsRequest {
 impl Encodable for DeleteTopicsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 6 {
-            bail!("DeleteTopicsRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 6 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
@@ -318,7 +318,7 @@ impl Encodable for DeleteTopicsRequest {
 impl Decodable for DeleteTopicsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 6 {
-            bail!("DeleteTopicsRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topics = if version >= 6 {
             types::CompactArray(types::Struct { version }).decode(buf)?

--- a/src/messages/delete_topics_response.rs
+++ b/src/messages/delete_topics_response.rs
@@ -97,6 +97,9 @@ impl DeletableTopicResult {
 #[cfg(feature = "broker")]
 impl Encodable for DeletableTopicResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 6 {
+            bail!("DeletableTopicResult v{} is not supported", version);
+        }
         if version >= 4 {
             types::CompactString.encode(buf, &self.name)?;
         } else {
@@ -156,6 +159,9 @@ impl Encodable for DeletableTopicResult {
 #[cfg(feature = "client")]
 impl Decodable for DeletableTopicResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 6 {
+            bail!("DeletableTopicResult v{} is not supported", version);
+        }
         let name = if version >= 4 {
             types::CompactString.decode(buf)?
         } else {
@@ -261,6 +267,9 @@ impl DeleteTopicsResponse {
 #[cfg(feature = "broker")]
 impl Encodable for DeleteTopicsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 6 {
+            bail!("DeleteTopicsResponse v{} is not supported", version);
+        }
         if version >= 1 {
             types::Int32.encode(buf, &self.throttle_time_ms)?;
         }
@@ -313,6 +322,9 @@ impl Encodable for DeleteTopicsResponse {
 #[cfg(feature = "client")]
 impl Decodable for DeleteTopicsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 6 {
+            bail!("DeleteTopicsResponse v{} is not supported", version);
+        }
         let throttle_time_ms = if version >= 1 {
             types::Int32.decode(buf)?
         } else {

--- a/src/messages/delete_topics_response.rs
+++ b/src/messages/delete_topics_response.rs
@@ -98,7 +98,7 @@ impl DeletableTopicResult {
 impl Encodable for DeletableTopicResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 6 {
-            bail!("DeletableTopicResult v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 4 {
             types::CompactString.encode(buf, &self.name)?;
@@ -160,7 +160,7 @@ impl Encodable for DeletableTopicResult {
 impl Decodable for DeletableTopicResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 6 {
-            bail!("DeletableTopicResult v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = if version >= 4 {
             types::CompactString.decode(buf)?
@@ -268,7 +268,7 @@ impl DeleteTopicsResponse {
 impl Encodable for DeleteTopicsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 6 {
-            bail!("DeleteTopicsResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 1 {
             types::Int32.encode(buf, &self.throttle_time_ms)?;
@@ -323,7 +323,7 @@ impl Encodable for DeleteTopicsResponse {
 impl Decodable for DeleteTopicsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 6 {
-            bail!("DeleteTopicsResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = if version >= 1 {
             types::Int32.decode(buf)?

--- a/src/messages/describe_acls_request.rs
+++ b/src/messages/describe_acls_request.rs
@@ -140,7 +140,7 @@ impl DescribeAclsRequest {
 impl Encodable for DescribeAclsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 3 {
-            bail!("DescribeAclsRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int8.encode(buf, &self.resource_type_filter)?;
         if version >= 2 {
@@ -228,7 +228,7 @@ impl Encodable for DescribeAclsRequest {
 impl Decodable for DescribeAclsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 3 {
-            bail!("DescribeAclsRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let resource_type_filter = types::Int8.decode(buf)?;
         let resource_name_filter = if version >= 2 {

--- a/src/messages/describe_acls_request.rs
+++ b/src/messages/describe_acls_request.rs
@@ -139,6 +139,9 @@ impl DescribeAclsRequest {
 #[cfg(feature = "client")]
 impl Encodable for DescribeAclsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 3 {
+            bail!("DescribeAclsRequest v{} is not supported", version);
+        }
         types::Int8.encode(buf, &self.resource_type_filter)?;
         if version >= 2 {
             types::CompactString.encode(buf, &self.resource_name_filter)?;
@@ -224,6 +227,9 @@ impl Encodable for DescribeAclsRequest {
 #[cfg(feature = "broker")]
 impl Decodable for DescribeAclsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 3 {
+            bail!("DescribeAclsRequest v{} is not supported", version);
+        }
         let resource_type_filter = types::Int8.decode(buf)?;
         let resource_name_filter = if version >= 2 {
             types::CompactString.decode(buf)?

--- a/src/messages/describe_acls_response.rs
+++ b/src/messages/describe_acls_response.rs
@@ -98,7 +98,7 @@ impl AclDescription {
 impl Encodable for AclDescription {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 3 {
-            bail!("AclDescription v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 2 {
             types::CompactString.encode(buf, &self.principal)?;
@@ -160,7 +160,7 @@ impl Encodable for AclDescription {
 impl Decodable for AclDescription {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 3 {
-            bail!("AclDescription v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let principal = if version >= 2 {
             types::CompactString.decode(buf)?
@@ -292,7 +292,7 @@ impl DescribeAclsResource {
 impl Encodable for DescribeAclsResource {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 3 {
-            bail!("DescribeAclsResource v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int8.encode(buf, &self.resource_type)?;
         if version >= 2 {
@@ -367,7 +367,7 @@ impl Encodable for DescribeAclsResource {
 impl Decodable for DescribeAclsResource {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 3 {
-            bail!("DescribeAclsResource v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let resource_type = types::Int8.decode(buf)?;
         let resource_name = if version >= 2 {
@@ -503,7 +503,7 @@ impl DescribeAclsResponse {
 impl Encodable for DescribeAclsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 3 {
-            bail!("DescribeAclsResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -566,7 +566,7 @@ impl Encodable for DescribeAclsResponse {
 impl Decodable for DescribeAclsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 3 {
-            bail!("DescribeAclsResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;

--- a/src/messages/describe_acls_response.rs
+++ b/src/messages/describe_acls_response.rs
@@ -97,6 +97,9 @@ impl AclDescription {
 #[cfg(feature = "broker")]
 impl Encodable for AclDescription {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 3 {
+            bail!("AclDescription v{} is not supported", version);
+        }
         if version >= 2 {
             types::CompactString.encode(buf, &self.principal)?;
         } else {
@@ -156,6 +159,9 @@ impl Encodable for AclDescription {
 #[cfg(feature = "client")]
 impl Decodable for AclDescription {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 3 {
+            bail!("AclDescription v{} is not supported", version);
+        }
         let principal = if version >= 2 {
             types::CompactString.decode(buf)?
         } else {
@@ -285,6 +291,9 @@ impl DescribeAclsResource {
 #[cfg(feature = "broker")]
 impl Encodable for DescribeAclsResource {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 3 {
+            bail!("DescribeAclsResource v{} is not supported", version);
+        }
         types::Int8.encode(buf, &self.resource_type)?;
         if version >= 2 {
             types::CompactString.encode(buf, &self.resource_name)?;
@@ -357,6 +366,9 @@ impl Encodable for DescribeAclsResource {
 #[cfg(feature = "client")]
 impl Decodable for DescribeAclsResource {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 3 {
+            bail!("DescribeAclsResource v{} is not supported", version);
+        }
         let resource_type = types::Int8.decode(buf)?;
         let resource_name = if version >= 2 {
             types::CompactString.decode(buf)?
@@ -490,6 +502,9 @@ impl DescribeAclsResponse {
 #[cfg(feature = "broker")]
 impl Encodable for DescribeAclsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 3 {
+            bail!("DescribeAclsResponse v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 2 {
@@ -550,6 +565,9 @@ impl Encodable for DescribeAclsResponse {
 #[cfg(feature = "client")]
 impl Decodable for DescribeAclsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 3 {
+            bail!("DescribeAclsResponse v{} is not supported", version);
+        }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let error_message = if version >= 2 {

--- a/src/messages/describe_client_quotas_request.rs
+++ b/src/messages/describe_client_quotas_request.rs
@@ -84,7 +84,7 @@ impl ComponentData {
 impl Encodable for ComponentData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("ComponentData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 1 {
             types::CompactString.encode(buf, &self.entity_type)?;
@@ -144,7 +144,7 @@ impl Encodable for ComponentData {
 impl Decodable for ComponentData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("ComponentData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let entity_type = if version >= 1 {
             types::CompactString.decode(buf)?
@@ -245,7 +245,7 @@ impl DescribeClientQuotasRequest {
 impl Encodable for DescribeClientQuotasRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("DescribeClientQuotasRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 1 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.components)?;
@@ -296,7 +296,7 @@ impl Encodable for DescribeClientQuotasRequest {
 impl Decodable for DescribeClientQuotasRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("DescribeClientQuotasRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let components = if version >= 1 {
             types::CompactArray(types::Struct { version }).decode(buf)?

--- a/src/messages/describe_client_quotas_request.rs
+++ b/src/messages/describe_client_quotas_request.rs
@@ -83,6 +83,9 @@ impl ComponentData {
 #[cfg(feature = "client")]
 impl Encodable for ComponentData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("ComponentData v{} is not supported", version);
+        }
         if version >= 1 {
             types::CompactString.encode(buf, &self.entity_type)?;
         } else {
@@ -140,6 +143,9 @@ impl Encodable for ComponentData {
 #[cfg(feature = "broker")]
 impl Decodable for ComponentData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("ComponentData v{} is not supported", version);
+        }
         let entity_type = if version >= 1 {
             types::CompactString.decode(buf)?
         } else {
@@ -238,6 +244,9 @@ impl DescribeClientQuotasRequest {
 #[cfg(feature = "client")]
 impl Encodable for DescribeClientQuotasRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("DescribeClientQuotasRequest v{} is not supported", version);
+        }
         if version >= 1 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.components)?;
         } else {
@@ -286,6 +295,9 @@ impl Encodable for DescribeClientQuotasRequest {
 #[cfg(feature = "broker")]
 impl Decodable for DescribeClientQuotasRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("DescribeClientQuotasRequest v{} is not supported", version);
+        }
         let components = if version >= 1 {
             types::CompactArray(types::Struct { version }).decode(buf)?
         } else {

--- a/src/messages/describe_client_quotas_response.rs
+++ b/src/messages/describe_client_quotas_response.rs
@@ -98,7 +98,7 @@ impl DescribeClientQuotasResponse {
 impl Encodable for DescribeClientQuotasResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("DescribeClientQuotasResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -161,7 +161,7 @@ impl Encodable for DescribeClientQuotasResponse {
 impl Decodable for DescribeClientQuotasResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("DescribeClientQuotasResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
@@ -265,7 +265,7 @@ impl EntityData {
 impl Encodable for EntityData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("EntityData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 1 {
             types::CompactString.encode(buf, &self.entity_type)?;
@@ -323,7 +323,7 @@ impl Encodable for EntityData {
 impl Decodable for EntityData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("EntityData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let entity_type = if version >= 1 {
             types::CompactString.decode(buf)?
@@ -421,7 +421,7 @@ impl EntryData {
 impl Encodable for EntryData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("EntryData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 1 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.entity)?;
@@ -481,7 +481,7 @@ impl Encodable for EntryData {
 impl Decodable for EntryData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("EntryData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let entity = if version >= 1 {
             types::CompactArray(types::Struct { version }).decode(buf)?
@@ -579,7 +579,7 @@ impl ValueData {
 impl Encodable for ValueData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("ValueData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 1 {
             types::CompactString.encode(buf, &self.key)?;
@@ -629,7 +629,7 @@ impl Encodable for ValueData {
 impl Decodable for ValueData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("ValueData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let key = if version >= 1 {
             types::CompactString.decode(buf)?

--- a/src/messages/describe_client_quotas_response.rs
+++ b/src/messages/describe_client_quotas_response.rs
@@ -97,6 +97,9 @@ impl DescribeClientQuotasResponse {
 #[cfg(feature = "broker")]
 impl Encodable for DescribeClientQuotasResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("DescribeClientQuotasResponse v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 1 {
@@ -157,6 +160,9 @@ impl Encodable for DescribeClientQuotasResponse {
 #[cfg(feature = "client")]
 impl Decodable for DescribeClientQuotasResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("DescribeClientQuotasResponse v{} is not supported", version);
+        }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let error_message = if version >= 1 {
@@ -258,6 +264,9 @@ impl EntityData {
 #[cfg(feature = "broker")]
 impl Encodable for EntityData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("EntityData v{} is not supported", version);
+        }
         if version >= 1 {
             types::CompactString.encode(buf, &self.entity_type)?;
         } else {
@@ -313,6 +322,9 @@ impl Encodable for EntityData {
 #[cfg(feature = "client")]
 impl Decodable for EntityData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("EntityData v{} is not supported", version);
+        }
         let entity_type = if version >= 1 {
             types::CompactString.decode(buf)?
         } else {
@@ -408,6 +420,9 @@ impl EntryData {
 #[cfg(feature = "broker")]
 impl Encodable for EntryData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("EntryData v{} is not supported", version);
+        }
         if version >= 1 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.entity)?;
         } else {
@@ -465,6 +480,9 @@ impl Encodable for EntryData {
 #[cfg(feature = "client")]
 impl Decodable for EntryData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("EntryData v{} is not supported", version);
+        }
         let entity = if version >= 1 {
             types::CompactArray(types::Struct { version }).decode(buf)?
         } else {
@@ -560,6 +578,9 @@ impl ValueData {
 #[cfg(feature = "broker")]
 impl Encodable for ValueData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("ValueData v{} is not supported", version);
+        }
         if version >= 1 {
             types::CompactString.encode(buf, &self.key)?;
         } else {
@@ -607,6 +628,9 @@ impl Encodable for ValueData {
 #[cfg(feature = "client")]
 impl Decodable for ValueData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("ValueData v{} is not supported", version);
+        }
         let key = if version >= 1 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/describe_cluster_request.rs
+++ b/src/messages/describe_cluster_request.rs
@@ -70,7 +70,7 @@ impl DescribeClusterRequest {
 impl Encodable for DescribeClusterRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("DescribeClusterRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Boolean.encode(buf, &self.include_cluster_authorized_operations)?;
         if version >= 1 {
@@ -120,7 +120,7 @@ impl Encodable for DescribeClusterRequest {
 impl Decodable for DescribeClusterRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("DescribeClusterRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let include_cluster_authorized_operations = types::Boolean.decode(buf)?;
         let endpoint_type = if version >= 1 {

--- a/src/messages/describe_cluster_request.rs
+++ b/src/messages/describe_cluster_request.rs
@@ -69,6 +69,9 @@ impl DescribeClusterRequest {
 #[cfg(feature = "client")]
 impl Encodable for DescribeClusterRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("DescribeClusterRequest v{} is not supported", version);
+        }
         types::Boolean.encode(buf, &self.include_cluster_authorized_operations)?;
         if version >= 1 {
             types::Int8.encode(buf, &self.endpoint_type)?;
@@ -116,6 +119,9 @@ impl Encodable for DescribeClusterRequest {
 #[cfg(feature = "broker")]
 impl Decodable for DescribeClusterRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("DescribeClusterRequest v{} is not supported", version);
+        }
         let include_cluster_authorized_operations = types::Boolean.decode(buf)?;
         let endpoint_type = if version >= 1 {
             types::Int8.decode(buf)?

--- a/src/messages/describe_cluster_response.rs
+++ b/src/messages/describe_cluster_response.rs
@@ -97,6 +97,9 @@ impl DescribeClusterBroker {
 #[cfg(feature = "broker")]
 impl Encodable for DescribeClusterBroker {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("DescribeClusterBroker v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.broker_id)?;
         types::CompactString.encode(buf, &self.host)?;
         types::Int32.encode(buf, &self.port)?;
@@ -136,6 +139,9 @@ impl Encodable for DescribeClusterBroker {
 #[cfg(feature = "client")]
 impl Decodable for DescribeClusterBroker {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("DescribeClusterBroker v{} is not supported", version);
+        }
         let broker_id = types::Int32.decode(buf)?;
         let host = types::CompactString.decode(buf)?;
         let port = types::Int32.decode(buf)?;
@@ -311,6 +317,9 @@ impl DescribeClusterResponse {
 #[cfg(feature = "broker")]
 impl Encodable for DescribeClusterResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("DescribeClusterResponse v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
         types::CompactString.encode(buf, &self.error_message)?;
@@ -370,6 +379,9 @@ impl Encodable for DescribeClusterResponse {
 #[cfg(feature = "client")]
 impl Decodable for DescribeClusterResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("DescribeClusterResponse v{} is not supported", version);
+        }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let error_message = types::CompactString.decode(buf)?;

--- a/src/messages/describe_cluster_response.rs
+++ b/src/messages/describe_cluster_response.rs
@@ -98,7 +98,7 @@ impl DescribeClusterBroker {
 impl Encodable for DescribeClusterBroker {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("DescribeClusterBroker v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.broker_id)?;
         types::CompactString.encode(buf, &self.host)?;
@@ -140,7 +140,7 @@ impl Encodable for DescribeClusterBroker {
 impl Decodable for DescribeClusterBroker {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("DescribeClusterBroker v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let broker_id = types::Int32.decode(buf)?;
         let host = types::CompactString.decode(buf)?;
@@ -318,7 +318,7 @@ impl DescribeClusterResponse {
 impl Encodable for DescribeClusterResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("DescribeClusterResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -380,7 +380,7 @@ impl Encodable for DescribeClusterResponse {
 impl Decodable for DescribeClusterResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("DescribeClusterResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;

--- a/src/messages/describe_configs_request.rs
+++ b/src/messages/describe_configs_request.rs
@@ -83,6 +83,9 @@ impl DescribeConfigsRequest {
 #[cfg(feature = "client")]
 impl Encodable for DescribeConfigsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 4 {
+            bail!("DescribeConfigsRequest v{} is not supported", version);
+        }
         if version >= 4 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.resources)?;
         } else {
@@ -157,6 +160,9 @@ impl Encodable for DescribeConfigsRequest {
 #[cfg(feature = "broker")]
 impl Decodable for DescribeConfigsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 4 {
+            bail!("DescribeConfigsRequest v{} is not supported", version);
+        }
         let resources = if version >= 4 {
             types::CompactArray(types::Struct { version }).decode(buf)?
         } else {
@@ -273,6 +279,9 @@ impl DescribeConfigsResource {
 #[cfg(feature = "client")]
 impl Encodable for DescribeConfigsResource {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 4 {
+            bail!("DescribeConfigsResource v{} is not supported", version);
+        }
         types::Int8.encode(buf, &self.resource_type)?;
         if version >= 4 {
             types::CompactString.encode(buf, &self.resource_name)?;
@@ -331,6 +340,9 @@ impl Encodable for DescribeConfigsResource {
 #[cfg(feature = "broker")]
 impl Decodable for DescribeConfigsResource {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 4 {
+            bail!("DescribeConfigsResource v{} is not supported", version);
+        }
         let resource_type = types::Int8.decode(buf)?;
         let resource_name = if version >= 4 {
             types::CompactString.decode(buf)?

--- a/src/messages/describe_configs_request.rs
+++ b/src/messages/describe_configs_request.rs
@@ -84,7 +84,7 @@ impl DescribeConfigsRequest {
 impl Encodable for DescribeConfigsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 4 {
-            bail!("DescribeConfigsRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 4 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.resources)?;
@@ -161,7 +161,7 @@ impl Encodable for DescribeConfigsRequest {
 impl Decodable for DescribeConfigsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 4 {
-            bail!("DescribeConfigsRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let resources = if version >= 4 {
             types::CompactArray(types::Struct { version }).decode(buf)?
@@ -280,7 +280,7 @@ impl DescribeConfigsResource {
 impl Encodable for DescribeConfigsResource {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 4 {
-            bail!("DescribeConfigsResource v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int8.encode(buf, &self.resource_type)?;
         if version >= 4 {
@@ -341,7 +341,7 @@ impl Encodable for DescribeConfigsResource {
 impl Decodable for DescribeConfigsResource {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 4 {
-            bail!("DescribeConfigsResource v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let resource_type = types::Int8.decode(buf)?;
         let resource_name = if version >= 4 {

--- a/src/messages/describe_configs_response.rs
+++ b/src/messages/describe_configs_response.rs
@@ -167,6 +167,12 @@ impl DescribeConfigsResourceResult {
 #[cfg(feature = "broker")]
 impl Encodable for DescribeConfigsResourceResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 4 {
+            bail!(
+                "DescribeConfigsResourceResult v{} is not supported",
+                version
+            );
+        }
         if version >= 4 {
             types::CompactString.encode(buf, &self.name)?;
         } else {
@@ -282,6 +288,12 @@ impl Encodable for DescribeConfigsResourceResult {
 #[cfg(feature = "client")]
 impl Decodable for DescribeConfigsResourceResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 4 {
+            bail!(
+                "DescribeConfigsResourceResult v{} is not supported",
+                version
+            );
+        }
         let name = if version >= 4 {
             types::CompactString.decode(buf)?
         } else {
@@ -426,6 +438,9 @@ impl DescribeConfigsResponse {
 #[cfg(feature = "broker")]
 impl Encodable for DescribeConfigsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 4 {
+            bail!("DescribeConfigsResponse v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         if version >= 4 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.results)?;
@@ -474,6 +489,9 @@ impl Encodable for DescribeConfigsResponse {
 #[cfg(feature = "client")]
 impl Decodable for DescribeConfigsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 4 {
+            bail!("DescribeConfigsResponse v{} is not supported", version);
+        }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let results = if version >= 4 {
             types::CompactArray(types::Struct { version }).decode(buf)?
@@ -607,6 +625,9 @@ impl DescribeConfigsResult {
 #[cfg(feature = "broker")]
 impl Encodable for DescribeConfigsResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 4 {
+            bail!("DescribeConfigsResult v{} is not supported", version);
+        }
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 4 {
             types::CompactString.encode(buf, &self.error_message)?;
@@ -677,6 +698,9 @@ impl Encodable for DescribeConfigsResult {
 #[cfg(feature = "client")]
 impl Decodable for DescribeConfigsResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 4 {
+            bail!("DescribeConfigsResult v{} is not supported", version);
+        }
         let error_code = types::Int16.decode(buf)?;
         let error_message = if version >= 4 {
             types::CompactString.decode(buf)?
@@ -799,6 +823,9 @@ impl DescribeConfigsSynonym {
 #[cfg(feature = "broker")]
 impl Encodable for DescribeConfigsSynonym {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 4 {
+            bail!("DescribeConfigsSynonym v{} is not supported", version);
+        }
         if version >= 1 {
             if version >= 4 {
                 types::CompactString.encode(buf, &self.name)?;
@@ -902,6 +929,9 @@ impl Encodable for DescribeConfigsSynonym {
 #[cfg(feature = "client")]
 impl Decodable for DescribeConfigsSynonym {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 4 {
+            bail!("DescribeConfigsSynonym v{} is not supported", version);
+        }
         let name = if version >= 1 {
             if version >= 4 {
                 types::CompactString.decode(buf)?

--- a/src/messages/describe_configs_response.rs
+++ b/src/messages/describe_configs_response.rs
@@ -168,10 +168,7 @@ impl DescribeConfigsResourceResult {
 impl Encodable for DescribeConfigsResourceResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 4 {
-            bail!(
-                "DescribeConfigsResourceResult v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         if version >= 4 {
             types::CompactString.encode(buf, &self.name)?;
@@ -289,10 +286,7 @@ impl Encodable for DescribeConfigsResourceResult {
 impl Decodable for DescribeConfigsResourceResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 4 {
-            bail!(
-                "DescribeConfigsResourceResult v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         let name = if version >= 4 {
             types::CompactString.decode(buf)?
@@ -439,7 +433,7 @@ impl DescribeConfigsResponse {
 impl Encodable for DescribeConfigsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 4 {
-            bail!("DescribeConfigsResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         if version >= 4 {
@@ -490,7 +484,7 @@ impl Encodable for DescribeConfigsResponse {
 impl Decodable for DescribeConfigsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 4 {
-            bail!("DescribeConfigsResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let results = if version >= 4 {
@@ -626,7 +620,7 @@ impl DescribeConfigsResult {
 impl Encodable for DescribeConfigsResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 4 {
-            bail!("DescribeConfigsResult v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 4 {
@@ -699,7 +693,7 @@ impl Encodable for DescribeConfigsResult {
 impl Decodable for DescribeConfigsResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 4 {
-            bail!("DescribeConfigsResult v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let error_code = types::Int16.decode(buf)?;
         let error_message = if version >= 4 {
@@ -824,7 +818,7 @@ impl DescribeConfigsSynonym {
 impl Encodable for DescribeConfigsSynonym {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 4 {
-            bail!("DescribeConfigsSynonym v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 1 {
             if version >= 4 {
@@ -930,7 +924,7 @@ impl Encodable for DescribeConfigsSynonym {
 impl Decodable for DescribeConfigsSynonym {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 4 {
-            bail!("DescribeConfigsSynonym v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = if version >= 1 {
             if version >= 4 {

--- a/src/messages/describe_delegation_token_request.rs
+++ b/src/messages/describe_delegation_token_request.rs
@@ -69,6 +69,9 @@ impl DescribeDelegationTokenOwner {
 #[cfg(feature = "client")]
 impl Encodable for DescribeDelegationTokenOwner {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 3 {
+            bail!("DescribeDelegationTokenOwner v{} is not supported", version);
+        }
         if version >= 2 {
             types::CompactString.encode(buf, &self.principal_type)?;
         } else {
@@ -124,6 +127,9 @@ impl Encodable for DescribeDelegationTokenOwner {
 #[cfg(feature = "broker")]
 impl Decodable for DescribeDelegationTokenOwner {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 3 {
+            bail!("DescribeDelegationTokenOwner v{} is not supported", version);
+        }
         let principal_type = if version >= 2 {
             types::CompactString.decode(buf)?
         } else {
@@ -205,6 +211,12 @@ impl DescribeDelegationTokenRequest {
 #[cfg(feature = "client")]
 impl Encodable for DescribeDelegationTokenRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 3 {
+            bail!(
+                "DescribeDelegationTokenRequest v{} is not supported",
+                version
+            );
+        }
         if version >= 2 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.owners)?;
         } else {
@@ -251,6 +263,12 @@ impl Encodable for DescribeDelegationTokenRequest {
 #[cfg(feature = "broker")]
 impl Decodable for DescribeDelegationTokenRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 3 {
+            bail!(
+                "DescribeDelegationTokenRequest v{} is not supported",
+                version
+            );
+        }
         let owners = if version >= 2 {
             types::CompactArray(types::Struct { version }).decode(buf)?
         } else {

--- a/src/messages/describe_delegation_token_request.rs
+++ b/src/messages/describe_delegation_token_request.rs
@@ -70,7 +70,7 @@ impl DescribeDelegationTokenOwner {
 impl Encodable for DescribeDelegationTokenOwner {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 3 {
-            bail!("DescribeDelegationTokenOwner v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 2 {
             types::CompactString.encode(buf, &self.principal_type)?;
@@ -128,7 +128,7 @@ impl Encodable for DescribeDelegationTokenOwner {
 impl Decodable for DescribeDelegationTokenOwner {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 3 {
-            bail!("DescribeDelegationTokenOwner v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let principal_type = if version >= 2 {
             types::CompactString.decode(buf)?
@@ -212,10 +212,7 @@ impl DescribeDelegationTokenRequest {
 impl Encodable for DescribeDelegationTokenRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 3 {
-            bail!(
-                "DescribeDelegationTokenRequest v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         if version >= 2 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.owners)?;
@@ -264,10 +261,7 @@ impl Encodable for DescribeDelegationTokenRequest {
 impl Decodable for DescribeDelegationTokenRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 3 {
-            bail!(
-                "DescribeDelegationTokenRequest v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         let owners = if version >= 2 {
             types::CompactArray(types::Struct { version }).decode(buf)?

--- a/src/messages/describe_delegation_token_response.rs
+++ b/src/messages/describe_delegation_token_response.rs
@@ -83,6 +83,12 @@ impl DescribeDelegationTokenResponse {
 #[cfg(feature = "broker")]
 impl Encodable for DescribeDelegationTokenResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 3 {
+            bail!(
+                "DescribeDelegationTokenResponse v{} is not supported",
+                version
+            );
+        }
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 2 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.tokens)?;
@@ -133,6 +139,12 @@ impl Encodable for DescribeDelegationTokenResponse {
 #[cfg(feature = "client")]
 impl Decodable for DescribeDelegationTokenResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 3 {
+            bail!(
+                "DescribeDelegationTokenResponse v{} is not supported",
+                version
+            );
+        }
         let error_code = types::Int16.decode(buf)?;
         let tokens = if version >= 2 {
             types::CompactArray(types::Struct { version }).decode(buf)?
@@ -339,6 +351,9 @@ impl DescribedDelegationToken {
 #[cfg(feature = "broker")]
 impl Encodable for DescribedDelegationToken {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 3 {
+            bail!("DescribedDelegationToken v{} is not supported", version);
+        }
         if version >= 2 {
             types::CompactString.encode(buf, &self.principal_type)?;
         } else {
@@ -461,6 +476,9 @@ impl Encodable for DescribedDelegationToken {
 #[cfg(feature = "client")]
 impl Decodable for DescribedDelegationToken {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 3 {
+            bail!("DescribedDelegationToken v{} is not supported", version);
+        }
         let principal_type = if version >= 2 {
             types::CompactString.decode(buf)?
         } else {
@@ -600,6 +618,12 @@ impl DescribedDelegationTokenRenewer {
 #[cfg(feature = "broker")]
 impl Encodable for DescribedDelegationTokenRenewer {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 3 {
+            bail!(
+                "DescribedDelegationTokenRenewer v{} is not supported",
+                version
+            );
+        }
         if version >= 2 {
             types::CompactString.encode(buf, &self.principal_type)?;
         } else {
@@ -655,6 +679,12 @@ impl Encodable for DescribedDelegationTokenRenewer {
 #[cfg(feature = "client")]
 impl Decodable for DescribedDelegationTokenRenewer {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 3 {
+            bail!(
+                "DescribedDelegationTokenRenewer v{} is not supported",
+                version
+            );
+        }
         let principal_type = if version >= 2 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/describe_delegation_token_response.rs
+++ b/src/messages/describe_delegation_token_response.rs
@@ -84,10 +84,7 @@ impl DescribeDelegationTokenResponse {
 impl Encodable for DescribeDelegationTokenResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 3 {
-            bail!(
-                "DescribeDelegationTokenResponse v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 2 {
@@ -140,10 +137,7 @@ impl Encodable for DescribeDelegationTokenResponse {
 impl Decodable for DescribeDelegationTokenResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 3 {
-            bail!(
-                "DescribeDelegationTokenResponse v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         let error_code = types::Int16.decode(buf)?;
         let tokens = if version >= 2 {
@@ -352,7 +346,7 @@ impl DescribedDelegationToken {
 impl Encodable for DescribedDelegationToken {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 3 {
-            bail!("DescribedDelegationToken v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 2 {
             types::CompactString.encode(buf, &self.principal_type)?;
@@ -477,7 +471,7 @@ impl Encodable for DescribedDelegationToken {
 impl Decodable for DescribedDelegationToken {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 3 {
-            bail!("DescribedDelegationToken v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let principal_type = if version >= 2 {
             types::CompactString.decode(buf)?
@@ -619,10 +613,7 @@ impl DescribedDelegationTokenRenewer {
 impl Encodable for DescribedDelegationTokenRenewer {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 3 {
-            bail!(
-                "DescribedDelegationTokenRenewer v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         if version >= 2 {
             types::CompactString.encode(buf, &self.principal_type)?;
@@ -680,10 +671,7 @@ impl Encodable for DescribedDelegationTokenRenewer {
 impl Decodable for DescribedDelegationTokenRenewer {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 3 {
-            bail!(
-                "DescribedDelegationTokenRenewer v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         let principal_type = if version >= 2 {
             types::CompactString.decode(buf)?

--- a/src/messages/describe_groups_request.rs
+++ b/src/messages/describe_groups_request.rs
@@ -69,6 +69,9 @@ impl DescribeGroupsRequest {
 #[cfg(feature = "client")]
 impl Encodable for DescribeGroupsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 5 {
+            bail!("DescribeGroupsRequest v{} is not supported", version);
+        }
         if version >= 5 {
             types::CompactArray(types::CompactString).encode(buf, &self.groups)?;
         } else {
@@ -128,6 +131,9 @@ impl Encodable for DescribeGroupsRequest {
 #[cfg(feature = "broker")]
 impl Decodable for DescribeGroupsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 5 {
+            bail!("DescribeGroupsRequest v{} is not supported", version);
+        }
         let groups = if version >= 5 {
             types::CompactArray(types::CompactString).decode(buf)?
         } else {

--- a/src/messages/describe_groups_request.rs
+++ b/src/messages/describe_groups_request.rs
@@ -70,7 +70,7 @@ impl DescribeGroupsRequest {
 impl Encodable for DescribeGroupsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 5 {
-            bail!("DescribeGroupsRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 5 {
             types::CompactArray(types::CompactString).encode(buf, &self.groups)?;
@@ -132,7 +132,7 @@ impl Encodable for DescribeGroupsRequest {
 impl Decodable for DescribeGroupsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 5 {
-            bail!("DescribeGroupsRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let groups = if version >= 5 {
             types::CompactArray(types::CompactString).decode(buf)?

--- a/src/messages/describe_groups_response.rs
+++ b/src/messages/describe_groups_response.rs
@@ -70,7 +70,7 @@ impl DescribeGroupsResponse {
 impl Encodable for DescribeGroupsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 5 {
-            bail!("DescribeGroupsResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 1 {
             types::Int32.encode(buf, &self.throttle_time_ms)?;
@@ -125,7 +125,7 @@ impl Encodable for DescribeGroupsResponse {
 impl Decodable for DescribeGroupsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 5 {
-            bail!("DescribeGroupsResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = if version >= 1 {
             types::Int32.decode(buf)?
@@ -293,7 +293,7 @@ impl DescribedGroup {
 impl Encodable for DescribedGroup {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 5 {
-            bail!("DescribedGroup v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 5 {
@@ -398,7 +398,7 @@ impl Encodable for DescribedGroup {
 impl Decodable for DescribedGroup {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 5 {
-            bail!("DescribedGroup v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let error_code = types::Int16.decode(buf)?;
         let group_id = if version >= 5 {
@@ -583,7 +583,7 @@ impl DescribedGroupMember {
 impl Encodable for DescribedGroupMember {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 5 {
-            bail!("DescribedGroupMember v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 5 {
             types::CompactString.encode(buf, &self.member_id)?;
@@ -685,7 +685,7 @@ impl Encodable for DescribedGroupMember {
 impl Decodable for DescribedGroupMember {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 5 {
-            bail!("DescribedGroupMember v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let member_id = if version >= 5 {
             types::CompactString.decode(buf)?

--- a/src/messages/describe_groups_response.rs
+++ b/src/messages/describe_groups_response.rs
@@ -69,6 +69,9 @@ impl DescribeGroupsResponse {
 #[cfg(feature = "broker")]
 impl Encodable for DescribeGroupsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 5 {
+            bail!("DescribeGroupsResponse v{} is not supported", version);
+        }
         if version >= 1 {
             types::Int32.encode(buf, &self.throttle_time_ms)?;
         }
@@ -121,6 +124,9 @@ impl Encodable for DescribeGroupsResponse {
 #[cfg(feature = "client")]
 impl Decodable for DescribeGroupsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 5 {
+            bail!("DescribeGroupsResponse v{} is not supported", version);
+        }
         let throttle_time_ms = if version >= 1 {
             types::Int32.decode(buf)?
         } else {
@@ -286,6 +292,9 @@ impl DescribedGroup {
 #[cfg(feature = "broker")]
 impl Encodable for DescribedGroup {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 5 {
+            bail!("DescribedGroup v{} is not supported", version);
+        }
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 5 {
             types::CompactString.encode(buf, &self.group_id)?;
@@ -388,6 +397,9 @@ impl Encodable for DescribedGroup {
 #[cfg(feature = "client")]
 impl Decodable for DescribedGroup {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 5 {
+            bail!("DescribedGroup v{} is not supported", version);
+        }
         let error_code = types::Int16.decode(buf)?;
         let group_id = if version >= 5 {
             types::CompactString.decode(buf)?
@@ -570,6 +582,9 @@ impl DescribedGroupMember {
 #[cfg(feature = "broker")]
 impl Encodable for DescribedGroupMember {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 5 {
+            bail!("DescribedGroupMember v{} is not supported", version);
+        }
         if version >= 5 {
             types::CompactString.encode(buf, &self.member_id)?;
         } else {
@@ -669,6 +684,9 @@ impl Encodable for DescribedGroupMember {
 #[cfg(feature = "client")]
 impl Decodable for DescribedGroupMember {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 5 {
+            bail!("DescribedGroupMember v{} is not supported", version);
+        }
         let member_id = if version >= 5 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/describe_log_dirs_request.rs
+++ b/src/messages/describe_log_dirs_request.rs
@@ -70,7 +70,7 @@ impl DescribableLogDirTopic {
 impl Encodable for DescribableLogDirTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 4 {
-            bail!("DescribableLogDirTopic v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 2 {
             types::CompactString.encode(buf, &self.topic)?;
@@ -128,7 +128,7 @@ impl Encodable for DescribableLogDirTopic {
 impl Decodable for DescribableLogDirTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 4 {
-            bail!("DescribableLogDirTopic v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topic = if version >= 2 {
             types::CompactString.decode(buf)?
@@ -212,7 +212,7 @@ impl DescribeLogDirsRequest {
 impl Encodable for DescribeLogDirsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 4 {
-            bail!("DescribeLogDirsRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 2 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
@@ -261,7 +261,7 @@ impl Encodable for DescribeLogDirsRequest {
 impl Decodable for DescribeLogDirsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 4 {
-            bail!("DescribeLogDirsRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topics = if version >= 2 {
             types::CompactArray(types::Struct { version }).decode(buf)?

--- a/src/messages/describe_log_dirs_request.rs
+++ b/src/messages/describe_log_dirs_request.rs
@@ -69,6 +69,9 @@ impl DescribableLogDirTopic {
 #[cfg(feature = "client")]
 impl Encodable for DescribableLogDirTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 4 {
+            bail!("DescribableLogDirTopic v{} is not supported", version);
+        }
         if version >= 2 {
             types::CompactString.encode(buf, &self.topic)?;
         } else {
@@ -124,6 +127,9 @@ impl Encodable for DescribableLogDirTopic {
 #[cfg(feature = "broker")]
 impl Decodable for DescribableLogDirTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 4 {
+            bail!("DescribableLogDirTopic v{} is not supported", version);
+        }
         let topic = if version >= 2 {
             types::CompactString.decode(buf)?
         } else {
@@ -205,6 +211,9 @@ impl DescribeLogDirsRequest {
 #[cfg(feature = "client")]
 impl Encodable for DescribeLogDirsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 4 {
+            bail!("DescribeLogDirsRequest v{} is not supported", version);
+        }
         if version >= 2 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
         } else {
@@ -251,6 +260,9 @@ impl Encodable for DescribeLogDirsRequest {
 #[cfg(feature = "broker")]
 impl Decodable for DescribeLogDirsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 4 {
+            bail!("DescribeLogDirsRequest v{} is not supported", version);
+        }
         let topics = if version >= 2 {
             types::CompactArray(types::Struct { version }).decode(buf)?
         } else {

--- a/src/messages/describe_log_dirs_response.rs
+++ b/src/messages/describe_log_dirs_response.rs
@@ -97,6 +97,9 @@ impl DescribeLogDirsPartition {
 #[cfg(feature = "broker")]
 impl Encodable for DescribeLogDirsPartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 4 {
+            bail!("DescribeLogDirsPartition v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int64.encode(buf, &self.partition_size)?;
         types::Int64.encode(buf, &self.offset_lag)?;
@@ -140,6 +143,9 @@ impl Encodable for DescribeLogDirsPartition {
 #[cfg(feature = "client")]
 impl Decodable for DescribeLogDirsPartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 4 {
+            bail!("DescribeLogDirsPartition v{} is not supported", version);
+        }
         let partition_index = types::Int32.decode(buf)?;
         let partition_size = types::Int64.decode(buf)?;
         let offset_lag = types::Int64.decode(buf)?;
@@ -247,6 +253,9 @@ impl DescribeLogDirsResponse {
 #[cfg(feature = "broker")]
 impl Encodable for DescribeLogDirsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 4 {
+            bail!("DescribeLogDirsResponse v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         if version >= 3 {
             types::Int16.encode(buf, &self.error_code)?;
@@ -301,6 +310,9 @@ impl Encodable for DescribeLogDirsResponse {
 #[cfg(feature = "client")]
 impl Decodable for DescribeLogDirsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 4 {
+            bail!("DescribeLogDirsResponse v{} is not supported", version);
+        }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = if version >= 3 {
             types::Int16.decode(buf)?
@@ -441,6 +453,9 @@ impl DescribeLogDirsResult {
 #[cfg(feature = "broker")]
 impl Encodable for DescribeLogDirsResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 4 {
+            bail!("DescribeLogDirsResult v{} is not supported", version);
+        }
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 2 {
             types::CompactString.encode(buf, &self.log_dir)?;
@@ -511,6 +526,9 @@ impl Encodable for DescribeLogDirsResult {
 #[cfg(feature = "client")]
 impl Decodable for DescribeLogDirsResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 4 {
+            bail!("DescribeLogDirsResult v{} is not supported", version);
+        }
         let error_code = types::Int16.decode(buf)?;
         let log_dir = if version >= 2 {
             types::CompactString.decode(buf)?
@@ -623,6 +641,9 @@ impl DescribeLogDirsTopic {
 #[cfg(feature = "broker")]
 impl Encodable for DescribeLogDirsTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 4 {
+            bail!("DescribeLogDirsTopic v{} is not supported", version);
+        }
         if version >= 2 {
             types::CompactString.encode(buf, &self.name)?;
         } else {
@@ -679,6 +700,9 @@ impl Encodable for DescribeLogDirsTopic {
 #[cfg(feature = "client")]
 impl Decodable for DescribeLogDirsTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 4 {
+            bail!("DescribeLogDirsTopic v{} is not supported", version);
+        }
         let name = if version >= 2 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/describe_log_dirs_response.rs
+++ b/src/messages/describe_log_dirs_response.rs
@@ -98,7 +98,7 @@ impl DescribeLogDirsPartition {
 impl Encodable for DescribeLogDirsPartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 4 {
-            bail!("DescribeLogDirsPartition v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int64.encode(buf, &self.partition_size)?;
@@ -144,7 +144,7 @@ impl Encodable for DescribeLogDirsPartition {
 impl Decodable for DescribeLogDirsPartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 4 {
-            bail!("DescribeLogDirsPartition v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let partition_index = types::Int32.decode(buf)?;
         let partition_size = types::Int64.decode(buf)?;
@@ -254,7 +254,7 @@ impl DescribeLogDirsResponse {
 impl Encodable for DescribeLogDirsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 4 {
-            bail!("DescribeLogDirsResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         if version >= 3 {
@@ -311,7 +311,7 @@ impl Encodable for DescribeLogDirsResponse {
 impl Decodable for DescribeLogDirsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 4 {
-            bail!("DescribeLogDirsResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = if version >= 3 {
@@ -454,7 +454,7 @@ impl DescribeLogDirsResult {
 impl Encodable for DescribeLogDirsResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 4 {
-            bail!("DescribeLogDirsResult v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 2 {
@@ -527,7 +527,7 @@ impl Encodable for DescribeLogDirsResult {
 impl Decodable for DescribeLogDirsResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 4 {
-            bail!("DescribeLogDirsResult v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let error_code = types::Int16.decode(buf)?;
         let log_dir = if version >= 2 {
@@ -642,7 +642,7 @@ impl DescribeLogDirsTopic {
 impl Encodable for DescribeLogDirsTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 4 {
-            bail!("DescribeLogDirsTopic v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 2 {
             types::CompactString.encode(buf, &self.name)?;
@@ -701,7 +701,7 @@ impl Encodable for DescribeLogDirsTopic {
 impl Decodable for DescribeLogDirsTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 4 {
-            bail!("DescribeLogDirsTopic v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = if version >= 2 {
             types::CompactString.decode(buf)?

--- a/src/messages/describe_producers_request.rs
+++ b/src/messages/describe_producers_request.rs
@@ -55,6 +55,9 @@ impl DescribeProducersRequest {
 #[cfg(feature = "client")]
 impl Encodable for DescribeProducersRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("DescribeProducersRequest v{} is not supported", version);
+        }
         types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
@@ -88,6 +91,9 @@ impl Encodable for DescribeProducersRequest {
 #[cfg(feature = "broker")]
 impl Decodable for DescribeProducersRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("DescribeProducersRequest v{} is not supported", version);
+        }
         let topics = types::CompactArray(types::Struct { version }).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
         let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
@@ -170,6 +176,9 @@ impl TopicRequest {
 #[cfg(feature = "client")]
 impl Encodable for TopicRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("TopicRequest v{} is not supported", version);
+        }
         types::CompactString.encode(buf, &self.name)?;
         types::CompactArray(types::Int32).encode(buf, &self.partition_indexes)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -205,6 +214,9 @@ impl Encodable for TopicRequest {
 #[cfg(feature = "broker")]
 impl Decodable for TopicRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("TopicRequest v{} is not supported", version);
+        }
         let name = types::CompactString.decode(buf)?;
         let partition_indexes = types::CompactArray(types::Int32).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();

--- a/src/messages/describe_producers_request.rs
+++ b/src/messages/describe_producers_request.rs
@@ -56,7 +56,7 @@ impl DescribeProducersRequest {
 impl Encodable for DescribeProducersRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("DescribeProducersRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -92,7 +92,7 @@ impl Encodable for DescribeProducersRequest {
 impl Decodable for DescribeProducersRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("DescribeProducersRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topics = types::CompactArray(types::Struct { version }).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
@@ -177,7 +177,7 @@ impl TopicRequest {
 impl Encodable for TopicRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("TopicRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::CompactString.encode(buf, &self.name)?;
         types::CompactArray(types::Int32).encode(buf, &self.partition_indexes)?;
@@ -215,7 +215,7 @@ impl Encodable for TopicRequest {
 impl Decodable for TopicRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("TopicRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = types::CompactString.decode(buf)?;
         let partition_indexes = types::CompactArray(types::Int32).decode(buf)?;

--- a/src/messages/describe_producers_response.rs
+++ b/src/messages/describe_producers_response.rs
@@ -70,7 +70,7 @@ impl DescribeProducersResponse {
 impl Encodable for DescribeProducersResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("DescribeProducersResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
@@ -108,7 +108,7 @@ impl Encodable for DescribeProducersResponse {
 impl Decodable for DescribeProducersResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("DescribeProducersResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let topics = types::CompactArray(types::Struct { version }).decode(buf)?;
@@ -224,7 +224,7 @@ impl PartitionResponse {
 impl Encodable for PartitionResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("PartitionResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -267,7 +267,7 @@ impl Encodable for PartitionResponse {
 impl Decodable for PartitionResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("PartitionResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let partition_index = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
@@ -417,7 +417,7 @@ impl ProducerState {
 impl Encodable for ProducerState {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("ProducerState v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int64.encode(buf, &self.producer_id)?;
         types::Int32.encode(buf, &self.producer_epoch)?;
@@ -463,7 +463,7 @@ impl Encodable for ProducerState {
 impl Decodable for ProducerState {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("ProducerState v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let producer_id = types::Int64.decode(buf)?;
         let producer_epoch = types::Int32.decode(buf)?;
@@ -563,7 +563,7 @@ impl TopicResponse {
 impl Encodable for TopicResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("TopicResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::CompactString.encode(buf, &self.name)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.partitions)?;
@@ -602,7 +602,7 @@ impl Encodable for TopicResponse {
 impl Decodable for TopicResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("TopicResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = types::CompactString.decode(buf)?;
         let partitions = types::CompactArray(types::Struct { version }).decode(buf)?;

--- a/src/messages/describe_producers_response.rs
+++ b/src/messages/describe_producers_response.rs
@@ -69,6 +69,9 @@ impl DescribeProducersResponse {
 #[cfg(feature = "broker")]
 impl Encodable for DescribeProducersResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("DescribeProducersResponse v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -104,6 +107,9 @@ impl Encodable for DescribeProducersResponse {
 #[cfg(feature = "client")]
 impl Decodable for DescribeProducersResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("DescribeProducersResponse v{} is not supported", version);
+        }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let topics = types::CompactArray(types::Struct { version }).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
@@ -217,6 +223,9 @@ impl PartitionResponse {
 #[cfg(feature = "broker")]
 impl Encodable for PartitionResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("PartitionResponse v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int16.encode(buf, &self.error_code)?;
         types::CompactString.encode(buf, &self.error_message)?;
@@ -257,6 +266,9 @@ impl Encodable for PartitionResponse {
 #[cfg(feature = "client")]
 impl Decodable for PartitionResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("PartitionResponse v{} is not supported", version);
+        }
         let partition_index = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let error_message = types::CompactString.decode(buf)?;
@@ -404,6 +416,9 @@ impl ProducerState {
 #[cfg(feature = "broker")]
 impl Encodable for ProducerState {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("ProducerState v{} is not supported", version);
+        }
         types::Int64.encode(buf, &self.producer_id)?;
         types::Int32.encode(buf, &self.producer_epoch)?;
         types::Int32.encode(buf, &self.last_sequence)?;
@@ -447,6 +462,9 @@ impl Encodable for ProducerState {
 #[cfg(feature = "client")]
 impl Decodable for ProducerState {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("ProducerState v{} is not supported", version);
+        }
         let producer_id = types::Int64.decode(buf)?;
         let producer_epoch = types::Int32.decode(buf)?;
         let last_sequence = types::Int32.decode(buf)?;
@@ -544,6 +562,9 @@ impl TopicResponse {
 #[cfg(feature = "broker")]
 impl Encodable for TopicResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("TopicResponse v{} is not supported", version);
+        }
         types::CompactString.encode(buf, &self.name)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.partitions)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -580,6 +601,9 @@ impl Encodable for TopicResponse {
 #[cfg(feature = "client")]
 impl Decodable for TopicResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("TopicResponse v{} is not supported", version);
+        }
         let name = types::CompactString.decode(buf)?;
         let partitions = types::CompactArray(types::Struct { version }).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();

--- a/src/messages/describe_quorum_request.rs
+++ b/src/messages/describe_quorum_request.rs
@@ -56,7 +56,7 @@ impl DescribeQuorumRequest {
 impl Encodable for DescribeQuorumRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 2 {
-            bail!("DescribeQuorumRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -92,7 +92,7 @@ impl Encodable for DescribeQuorumRequest {
 impl Decodable for DescribeQuorumRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 2 {
-            bail!("DescribeQuorumRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topics = types::CompactArray(types::Struct { version }).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
@@ -163,7 +163,7 @@ impl PartitionData {
 impl Encodable for PartitionData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 2 {
-            bail!("PartitionData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.partition_index)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -199,7 +199,7 @@ impl Encodable for PartitionData {
 impl Decodable for PartitionData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 2 {
-            bail!("PartitionData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let partition_index = types::Int32.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
@@ -284,7 +284,7 @@ impl TopicData {
 impl Encodable for TopicData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 2 {
-            bail!("TopicData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::CompactString.encode(buf, &self.topic_name)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.partitions)?;
@@ -323,7 +323,7 @@ impl Encodable for TopicData {
 impl Decodable for TopicData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 2 {
-            bail!("TopicData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topic_name = types::CompactString.decode(buf)?;
         let partitions = types::CompactArray(types::Struct { version }).decode(buf)?;

--- a/src/messages/describe_quorum_request.rs
+++ b/src/messages/describe_quorum_request.rs
@@ -55,6 +55,9 @@ impl DescribeQuorumRequest {
 #[cfg(feature = "client")]
 impl Encodable for DescribeQuorumRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 2 {
+            bail!("DescribeQuorumRequest v{} is not supported", version);
+        }
         types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
@@ -88,6 +91,9 @@ impl Encodable for DescribeQuorumRequest {
 #[cfg(feature = "broker")]
 impl Decodable for DescribeQuorumRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 2 {
+            bail!("DescribeQuorumRequest v{} is not supported", version);
+        }
         let topics = types::CompactArray(types::Struct { version }).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
         let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
@@ -156,6 +162,9 @@ impl PartitionData {
 #[cfg(feature = "client")]
 impl Encodable for PartitionData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 2 {
+            bail!("PartitionData v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.partition_index)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
@@ -189,6 +198,9 @@ impl Encodable for PartitionData {
 #[cfg(feature = "broker")]
 impl Decodable for PartitionData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 2 {
+            bail!("PartitionData v{} is not supported", version);
+        }
         let partition_index = types::Int32.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
         let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
@@ -271,6 +283,9 @@ impl TopicData {
 #[cfg(feature = "client")]
 impl Encodable for TopicData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 2 {
+            bail!("TopicData v{} is not supported", version);
+        }
         types::CompactString.encode(buf, &self.topic_name)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.partitions)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -307,6 +322,9 @@ impl Encodable for TopicData {
 #[cfg(feature = "broker")]
 impl Decodable for TopicData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 2 {
+            bail!("TopicData v{} is not supported", version);
+        }
         let topic_name = types::CompactString.decode(buf)?;
         let partitions = types::CompactArray(types::Struct { version }).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();

--- a/src/messages/describe_quorum_response.rs
+++ b/src/messages/describe_quorum_response.rs
@@ -98,7 +98,7 @@ impl DescribeQuorumResponse {
 impl Encodable for DescribeQuorumResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 2 {
-            bail!("DescribeQuorumResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 2 {
@@ -157,7 +157,7 @@ impl Encodable for DescribeQuorumResponse {
 impl Decodable for DescribeQuorumResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 2 {
-            bail!("DescribeQuorumResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let error_code = types::Int16.decode(buf)?;
         let error_message = if version >= 2 {
@@ -273,7 +273,7 @@ impl Listener {
 impl Encodable for Listener {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 2 {
-            bail!("Listener v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 2 {
             types::CompactString.encode(buf, &self.name)?;
@@ -349,7 +349,7 @@ impl Encodable for Listener {
 impl Decodable for Listener {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 2 {
-            bail!("Listener v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = if version >= 2 {
             types::CompactString.decode(buf)?
@@ -452,7 +452,7 @@ impl Node {
 impl Encodable for Node {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 2 {
-            bail!("Node v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 2 {
             types::Int32.encode(buf, &self.node_id)?;
@@ -515,7 +515,7 @@ impl Encodable for Node {
 impl Decodable for Node {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 2 {
-            bail!("Node v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let node_id = if version >= 2 {
             types::Int32.decode(buf)?
@@ -695,7 +695,7 @@ impl PartitionData {
 impl Encodable for PartitionData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 2 {
-            bail!("PartitionData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -751,7 +751,7 @@ impl Encodable for PartitionData {
 impl Decodable for PartitionData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 2 {
-            bail!("PartitionData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let partition_index = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
@@ -903,7 +903,7 @@ impl ReplicaState {
 impl Encodable for ReplicaState {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 2 {
-            bail!("ReplicaState v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.replica_id)?;
         if version >= 2 {
@@ -967,7 +967,7 @@ impl Encodable for ReplicaState {
 impl Decodable for ReplicaState {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 2 {
-            bail!("ReplicaState v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let replica_id = types::Int32.decode(buf)?;
         let replica_directory_id = if version >= 2 {
@@ -1076,7 +1076,7 @@ impl TopicData {
 impl Encodable for TopicData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 2 {
-            bail!("TopicData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::CompactString.encode(buf, &self.topic_name)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.partitions)?;
@@ -1115,7 +1115,7 @@ impl Encodable for TopicData {
 impl Decodable for TopicData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 2 {
-            bail!("TopicData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topic_name = types::CompactString.decode(buf)?;
         let partitions = types::CompactArray(types::Struct { version }).decode(buf)?;

--- a/src/messages/describe_quorum_response.rs
+++ b/src/messages/describe_quorum_response.rs
@@ -97,6 +97,9 @@ impl DescribeQuorumResponse {
 #[cfg(feature = "broker")]
 impl Encodable for DescribeQuorumResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 2 {
+            bail!("DescribeQuorumResponse v{} is not supported", version);
+        }
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 2 {
             types::CompactString.encode(buf, &self.error_message)?;
@@ -153,6 +156,9 @@ impl Encodable for DescribeQuorumResponse {
 #[cfg(feature = "client")]
 impl Decodable for DescribeQuorumResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 2 {
+            bail!("DescribeQuorumResponse v{} is not supported", version);
+        }
         let error_code = types::Int16.decode(buf)?;
         let error_message = if version >= 2 {
             types::CompactString.decode(buf)?
@@ -266,6 +272,9 @@ impl Listener {
 #[cfg(feature = "broker")]
 impl Encodable for Listener {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 2 {
+            bail!("Listener v{} is not supported", version);
+        }
         if version >= 2 {
             types::CompactString.encode(buf, &self.name)?;
         } else {
@@ -339,6 +348,9 @@ impl Encodable for Listener {
 #[cfg(feature = "client")]
 impl Decodable for Listener {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 2 {
+            bail!("Listener v{} is not supported", version);
+        }
         let name = if version >= 2 {
             types::CompactString.decode(buf)?
         } else {
@@ -439,6 +451,9 @@ impl Node {
 #[cfg(feature = "broker")]
 impl Encodable for Node {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 2 {
+            bail!("Node v{} is not supported", version);
+        }
         if version >= 2 {
             types::Int32.encode(buf, &self.node_id)?;
         } else {
@@ -499,6 +514,9 @@ impl Encodable for Node {
 #[cfg(feature = "client")]
 impl Decodable for Node {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 2 {
+            bail!("Node v{} is not supported", version);
+        }
         let node_id = if version >= 2 {
             types::Int32.decode(buf)?
         } else {
@@ -676,6 +694,9 @@ impl PartitionData {
 #[cfg(feature = "broker")]
 impl Encodable for PartitionData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 2 {
+            bail!("PartitionData v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 2 {
@@ -729,6 +750,9 @@ impl Encodable for PartitionData {
 #[cfg(feature = "client")]
 impl Decodable for PartitionData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 2 {
+            bail!("PartitionData v{} is not supported", version);
+        }
         let partition_index = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let error_message = if version >= 2 {
@@ -878,6 +902,9 @@ impl ReplicaState {
 #[cfg(feature = "broker")]
 impl Encodable for ReplicaState {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 2 {
+            bail!("ReplicaState v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.replica_id)?;
         if version >= 2 {
             types::Uuid.encode(buf, &self.replica_directory_id)?;
@@ -939,6 +966,9 @@ impl Encodable for ReplicaState {
 #[cfg(feature = "client")]
 impl Decodable for ReplicaState {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 2 {
+            bail!("ReplicaState v{} is not supported", version);
+        }
         let replica_id = types::Int32.decode(buf)?;
         let replica_directory_id = if version >= 2 {
             types::Uuid.decode(buf)?
@@ -1045,6 +1075,9 @@ impl TopicData {
 #[cfg(feature = "broker")]
 impl Encodable for TopicData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 2 {
+            bail!("TopicData v{} is not supported", version);
+        }
         types::CompactString.encode(buf, &self.topic_name)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.partitions)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -1081,6 +1114,9 @@ impl Encodable for TopicData {
 #[cfg(feature = "client")]
 impl Decodable for TopicData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 2 {
+            bail!("TopicData v{} is not supported", version);
+        }
         let topic_name = types::CompactString.decode(buf)?;
         let partitions = types::CompactArray(types::Struct { version }).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();

--- a/src/messages/describe_topic_partitions_request.rs
+++ b/src/messages/describe_topic_partitions_request.rs
@@ -69,6 +69,9 @@ impl Cursor {
 #[cfg(feature = "client")]
 impl Encodable for Cursor {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("Cursor v{} is not supported", version);
+        }
         types::CompactString.encode(buf, &self.topic_name)?;
         types::Int32.encode(buf, &self.partition_index)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -104,6 +107,9 @@ impl Encodable for Cursor {
 #[cfg(feature = "broker")]
 impl Decodable for Cursor {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("Cursor v{} is not supported", version);
+        }
         let topic_name = types::CompactString.decode(buf)?;
         let partition_index = types::Int32.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
@@ -203,6 +209,12 @@ impl DescribeTopicPartitionsRequest {
 #[cfg(feature = "client")]
 impl Encodable for DescribeTopicPartitionsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!(
+                "DescribeTopicPartitionsRequest v{} is not supported",
+                version
+            );
+        }
         types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
         types::Int32.encode(buf, &self.response_partition_limit)?;
         types::OptionStruct { version }.encode(buf, &self.cursor)?;
@@ -240,6 +252,12 @@ impl Encodable for DescribeTopicPartitionsRequest {
 #[cfg(feature = "broker")]
 impl Decodable for DescribeTopicPartitionsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!(
+                "DescribeTopicPartitionsRequest v{} is not supported",
+                version
+            );
+        }
         let topics = types::CompactArray(types::Struct { version }).decode(buf)?;
         let response_partition_limit = types::Int32.decode(buf)?;
         let cursor = types::OptionStruct { version }.decode(buf)?;
@@ -314,6 +332,9 @@ impl TopicRequest {
 #[cfg(feature = "client")]
 impl Encodable for TopicRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("TopicRequest v{} is not supported", version);
+        }
         types::CompactString.encode(buf, &self.name)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
@@ -347,6 +368,9 @@ impl Encodable for TopicRequest {
 #[cfg(feature = "broker")]
 impl Decodable for TopicRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("TopicRequest v{} is not supported", version);
+        }
         let name = types::CompactString.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
         let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;

--- a/src/messages/describe_topic_partitions_request.rs
+++ b/src/messages/describe_topic_partitions_request.rs
@@ -70,7 +70,7 @@ impl Cursor {
 impl Encodable for Cursor {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("Cursor v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::CompactString.encode(buf, &self.topic_name)?;
         types::Int32.encode(buf, &self.partition_index)?;
@@ -108,7 +108,7 @@ impl Encodable for Cursor {
 impl Decodable for Cursor {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("Cursor v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topic_name = types::CompactString.decode(buf)?;
         let partition_index = types::Int32.decode(buf)?;
@@ -210,10 +210,7 @@ impl DescribeTopicPartitionsRequest {
 impl Encodable for DescribeTopicPartitionsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!(
-                "DescribeTopicPartitionsRequest v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
         types::Int32.encode(buf, &self.response_partition_limit)?;
@@ -253,10 +250,7 @@ impl Encodable for DescribeTopicPartitionsRequest {
 impl Decodable for DescribeTopicPartitionsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!(
-                "DescribeTopicPartitionsRequest v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         let topics = types::CompactArray(types::Struct { version }).decode(buf)?;
         let response_partition_limit = types::Int32.decode(buf)?;
@@ -333,7 +327,7 @@ impl TopicRequest {
 impl Encodable for TopicRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("TopicRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::CompactString.encode(buf, &self.name)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -369,7 +363,7 @@ impl Encodable for TopicRequest {
 impl Decodable for TopicRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("TopicRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = types::CompactString.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();

--- a/src/messages/describe_topic_partitions_response.rs
+++ b/src/messages/describe_topic_partitions_response.rs
@@ -69,6 +69,9 @@ impl Cursor {
 #[cfg(feature = "broker")]
 impl Encodable for Cursor {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("Cursor v{} is not supported", version);
+        }
         types::CompactString.encode(buf, &self.topic_name)?;
         types::Int32.encode(buf, &self.partition_index)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -104,6 +107,9 @@ impl Encodable for Cursor {
 #[cfg(feature = "client")]
 impl Decodable for Cursor {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("Cursor v{} is not supported", version);
+        }
         let topic_name = types::CompactString.decode(buf)?;
         let partition_index = types::Int32.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
@@ -203,6 +209,12 @@ impl DescribeTopicPartitionsResponse {
 #[cfg(feature = "broker")]
 impl Encodable for DescribeTopicPartitionsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!(
+                "DescribeTopicPartitionsResponse v{} is not supported",
+                version
+            );
+        }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
         types::OptionStruct { version }.encode(buf, &self.next_cursor)?;
@@ -240,6 +252,12 @@ impl Encodable for DescribeTopicPartitionsResponse {
 #[cfg(feature = "client")]
 impl Decodable for DescribeTopicPartitionsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!(
+                "DescribeTopicPartitionsResponse v{} is not supported",
+                version
+            );
+        }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let topics = types::CompactArray(types::Struct { version }).decode(buf)?;
         let next_cursor = types::OptionStruct { version }.decode(buf)?;
@@ -426,6 +444,12 @@ impl DescribeTopicPartitionsResponsePartition {
 #[cfg(feature = "broker")]
 impl Encodable for DescribeTopicPartitionsResponsePartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!(
+                "DescribeTopicPartitionsResponsePartition v{} is not supported",
+                version
+            );
+        }
         types::Int16.encode(buf, &self.error_code)?;
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int32.encode(buf, &self.leader_id)?;
@@ -476,6 +500,12 @@ impl Encodable for DescribeTopicPartitionsResponsePartition {
 #[cfg(feature = "client")]
 impl Decodable for DescribeTopicPartitionsResponsePartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!(
+                "DescribeTopicPartitionsResponsePartition v{} is not supported",
+                version
+            );
+        }
         let error_code = types::Int16.decode(buf)?;
         let partition_index = types::Int32.decode(buf)?;
         let leader_id = types::Int32.decode(buf)?;
@@ -638,6 +668,12 @@ impl DescribeTopicPartitionsResponseTopic {
 #[cfg(feature = "broker")]
 impl Encodable for DescribeTopicPartitionsResponseTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!(
+                "DescribeTopicPartitionsResponseTopic v{} is not supported",
+                version
+            );
+        }
         types::Int16.encode(buf, &self.error_code)?;
         types::CompactString.encode(buf, &self.name)?;
         types::Uuid.encode(buf, &self.topic_id)?;
@@ -682,6 +718,12 @@ impl Encodable for DescribeTopicPartitionsResponseTopic {
 #[cfg(feature = "client")]
 impl Decodable for DescribeTopicPartitionsResponseTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!(
+                "DescribeTopicPartitionsResponseTopic v{} is not supported",
+                version
+            );
+        }
         let error_code = types::Int16.decode(buf)?;
         let name = types::CompactString.decode(buf)?;
         let topic_id = types::Uuid.decode(buf)?;

--- a/src/messages/describe_topic_partitions_response.rs
+++ b/src/messages/describe_topic_partitions_response.rs
@@ -70,7 +70,7 @@ impl Cursor {
 impl Encodable for Cursor {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("Cursor v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::CompactString.encode(buf, &self.topic_name)?;
         types::Int32.encode(buf, &self.partition_index)?;
@@ -108,7 +108,7 @@ impl Encodable for Cursor {
 impl Decodable for Cursor {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("Cursor v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topic_name = types::CompactString.decode(buf)?;
         let partition_index = types::Int32.decode(buf)?;
@@ -210,10 +210,7 @@ impl DescribeTopicPartitionsResponse {
 impl Encodable for DescribeTopicPartitionsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!(
-                "DescribeTopicPartitionsResponse v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
@@ -253,10 +250,7 @@ impl Encodable for DescribeTopicPartitionsResponse {
 impl Decodable for DescribeTopicPartitionsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!(
-                "DescribeTopicPartitionsResponse v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let topics = types::CompactArray(types::Struct { version }).decode(buf)?;
@@ -445,10 +439,7 @@ impl DescribeTopicPartitionsResponsePartition {
 impl Encodable for DescribeTopicPartitionsResponsePartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!(
-                "DescribeTopicPartitionsResponsePartition v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         types::Int16.encode(buf, &self.error_code)?;
         types::Int32.encode(buf, &self.partition_index)?;
@@ -501,10 +492,7 @@ impl Encodable for DescribeTopicPartitionsResponsePartition {
 impl Decodable for DescribeTopicPartitionsResponsePartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!(
-                "DescribeTopicPartitionsResponsePartition v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         let error_code = types::Int16.decode(buf)?;
         let partition_index = types::Int32.decode(buf)?;
@@ -669,10 +657,7 @@ impl DescribeTopicPartitionsResponseTopic {
 impl Encodable for DescribeTopicPartitionsResponseTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!(
-                "DescribeTopicPartitionsResponseTopic v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         types::Int16.encode(buf, &self.error_code)?;
         types::CompactString.encode(buf, &self.name)?;
@@ -719,10 +704,7 @@ impl Encodable for DescribeTopicPartitionsResponseTopic {
 impl Decodable for DescribeTopicPartitionsResponseTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!(
-                "DescribeTopicPartitionsResponseTopic v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         let error_code = types::Int16.decode(buf)?;
         let name = types::CompactString.decode(buf)?;

--- a/src/messages/describe_transactions_request.rs
+++ b/src/messages/describe_transactions_request.rs
@@ -55,6 +55,9 @@ impl DescribeTransactionsRequest {
 #[cfg(feature = "client")]
 impl Encodable for DescribeTransactionsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("DescribeTransactionsRequest v{} is not supported", version);
+        }
         types::CompactArray(types::CompactString).encode(buf, &self.transactional_ids)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
@@ -89,6 +92,9 @@ impl Encodable for DescribeTransactionsRequest {
 #[cfg(feature = "broker")]
 impl Decodable for DescribeTransactionsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("DescribeTransactionsRequest v{} is not supported", version);
+        }
         let transactional_ids = types::CompactArray(types::CompactString).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
         let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;

--- a/src/messages/describe_transactions_request.rs
+++ b/src/messages/describe_transactions_request.rs
@@ -56,7 +56,7 @@ impl DescribeTransactionsRequest {
 impl Encodable for DescribeTransactionsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("DescribeTransactionsRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::CompactArray(types::CompactString).encode(buf, &self.transactional_ids)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -93,7 +93,7 @@ impl Encodable for DescribeTransactionsRequest {
 impl Decodable for DescribeTransactionsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("DescribeTransactionsRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let transactional_ids = types::CompactArray(types::CompactString).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();

--- a/src/messages/describe_transactions_response.rs
+++ b/src/messages/describe_transactions_response.rs
@@ -69,6 +69,9 @@ impl DescribeTransactionsResponse {
 #[cfg(feature = "broker")]
 impl Encodable for DescribeTransactionsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("DescribeTransactionsResponse v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.transaction_states)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -105,6 +108,9 @@ impl Encodable for DescribeTransactionsResponse {
 #[cfg(feature = "client")]
 impl Decodable for DescribeTransactionsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("DescribeTransactionsResponse v{} is not supported", version);
+        }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let transaction_states = types::CompactArray(types::Struct { version }).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
@@ -190,6 +196,9 @@ impl TopicData {
 #[cfg(feature = "broker")]
 impl Encodable for TopicData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("TopicData v{} is not supported", version);
+        }
         types::CompactString.encode(buf, &self.topic)?;
         types::CompactArray(types::Int32).encode(buf, &self.partitions)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -225,6 +234,9 @@ impl Encodable for TopicData {
 #[cfg(feature = "client")]
 impl Decodable for TopicData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("TopicData v{} is not supported", version);
+        }
         let topic = types::CompactString.decode(buf)?;
         let partitions = types::CompactArray(types::Int32).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
@@ -394,6 +406,9 @@ impl TransactionState {
 #[cfg(feature = "broker")]
 impl Encodable for TransactionState {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("TransactionState v{} is not supported", version);
+        }
         types::Int16.encode(buf, &self.error_code)?;
         types::CompactString.encode(buf, &self.transactional_id)?;
         types::CompactString.encode(buf, &self.transaction_state)?;
@@ -441,6 +456,9 @@ impl Encodable for TransactionState {
 #[cfg(feature = "client")]
 impl Decodable for TransactionState {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("TransactionState v{} is not supported", version);
+        }
         let error_code = types::Int16.decode(buf)?;
         let transactional_id = types::CompactString.decode(buf)?;
         let transaction_state = types::CompactString.decode(buf)?;

--- a/src/messages/describe_transactions_response.rs
+++ b/src/messages/describe_transactions_response.rs
@@ -70,7 +70,7 @@ impl DescribeTransactionsResponse {
 impl Encodable for DescribeTransactionsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("DescribeTransactionsResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.transaction_states)?;
@@ -109,7 +109,7 @@ impl Encodable for DescribeTransactionsResponse {
 impl Decodable for DescribeTransactionsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("DescribeTransactionsResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let transaction_states = types::CompactArray(types::Struct { version }).decode(buf)?;
@@ -197,7 +197,7 @@ impl TopicData {
 impl Encodable for TopicData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("TopicData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::CompactString.encode(buf, &self.topic)?;
         types::CompactArray(types::Int32).encode(buf, &self.partitions)?;
@@ -235,7 +235,7 @@ impl Encodable for TopicData {
 impl Decodable for TopicData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("TopicData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topic = types::CompactString.decode(buf)?;
         let partitions = types::CompactArray(types::Int32).decode(buf)?;
@@ -407,7 +407,7 @@ impl TransactionState {
 impl Encodable for TransactionState {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("TransactionState v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int16.encode(buf, &self.error_code)?;
         types::CompactString.encode(buf, &self.transactional_id)?;
@@ -457,7 +457,7 @@ impl Encodable for TransactionState {
 impl Decodable for TransactionState {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("TransactionState v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let error_code = types::Int16.decode(buf)?;
         let transactional_id = types::CompactString.decode(buf)?;

--- a/src/messages/describe_user_scram_credentials_request.rs
+++ b/src/messages/describe_user_scram_credentials_request.rs
@@ -56,10 +56,7 @@ impl DescribeUserScramCredentialsRequest {
 impl Encodable for DescribeUserScramCredentialsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!(
-                "DescribeUserScramCredentialsRequest v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         types::CompactArray(types::Struct { version }).encode(buf, &self.users)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -95,10 +92,7 @@ impl Encodable for DescribeUserScramCredentialsRequest {
 impl Decodable for DescribeUserScramCredentialsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!(
-                "DescribeUserScramCredentialsRequest v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         let users = types::CompactArray(types::Struct { version }).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
@@ -169,7 +163,7 @@ impl UserName {
 impl Encodable for UserName {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("UserName v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::CompactString.encode(buf, &self.name)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -205,7 +199,7 @@ impl Encodable for UserName {
 impl Decodable for UserName {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("UserName v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = types::CompactString.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();

--- a/src/messages/describe_user_scram_credentials_request.rs
+++ b/src/messages/describe_user_scram_credentials_request.rs
@@ -55,6 +55,12 @@ impl DescribeUserScramCredentialsRequest {
 #[cfg(feature = "client")]
 impl Encodable for DescribeUserScramCredentialsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!(
+                "DescribeUserScramCredentialsRequest v{} is not supported",
+                version
+            );
+        }
         types::CompactArray(types::Struct { version }).encode(buf, &self.users)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
@@ -88,6 +94,12 @@ impl Encodable for DescribeUserScramCredentialsRequest {
 #[cfg(feature = "broker")]
 impl Decodable for DescribeUserScramCredentialsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!(
+                "DescribeUserScramCredentialsRequest v{} is not supported",
+                version
+            );
+        }
         let users = types::CompactArray(types::Struct { version }).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
         let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
@@ -156,6 +168,9 @@ impl UserName {
 #[cfg(feature = "client")]
 impl Encodable for UserName {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("UserName v{} is not supported", version);
+        }
         types::CompactString.encode(buf, &self.name)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
@@ -189,6 +204,9 @@ impl Encodable for UserName {
 #[cfg(feature = "broker")]
 impl Decodable for UserName {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("UserName v{} is not supported", version);
+        }
         let name = types::CompactString.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
         let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;

--- a/src/messages/describe_user_scram_credentials_response.rs
+++ b/src/messages/describe_user_scram_credentials_response.rs
@@ -69,6 +69,9 @@ impl CredentialInfo {
 #[cfg(feature = "broker")]
 impl Encodable for CredentialInfo {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("CredentialInfo v{} is not supported", version);
+        }
         types::Int8.encode(buf, &self.mechanism)?;
         types::Int32.encode(buf, &self.iterations)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -104,6 +107,9 @@ impl Encodable for CredentialInfo {
 #[cfg(feature = "client")]
 impl Decodable for CredentialInfo {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("CredentialInfo v{} is not supported", version);
+        }
         let mechanism = types::Int8.decode(buf)?;
         let iterations = types::Int32.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
@@ -217,6 +223,12 @@ impl DescribeUserScramCredentialsResponse {
 #[cfg(feature = "broker")]
 impl Encodable for DescribeUserScramCredentialsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!(
+                "DescribeUserScramCredentialsResponse v{} is not supported",
+                version
+            );
+        }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
         types::CompactString.encode(buf, &self.error_message)?;
@@ -256,6 +268,12 @@ impl Encodable for DescribeUserScramCredentialsResponse {
 #[cfg(feature = "client")]
 impl Decodable for DescribeUserScramCredentialsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!(
+                "DescribeUserScramCredentialsResponse v{} is not supported",
+                version
+            );
+        }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let error_message = types::CompactString.decode(buf)?;
@@ -375,6 +393,12 @@ impl DescribeUserScramCredentialsResult {
 #[cfg(feature = "broker")]
 impl Encodable for DescribeUserScramCredentialsResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!(
+                "DescribeUserScramCredentialsResult v{} is not supported",
+                version
+            );
+        }
         types::CompactString.encode(buf, &self.user)?;
         types::Int16.encode(buf, &self.error_code)?;
         types::CompactString.encode(buf, &self.error_message)?;
@@ -415,6 +439,12 @@ impl Encodable for DescribeUserScramCredentialsResult {
 #[cfg(feature = "client")]
 impl Decodable for DescribeUserScramCredentialsResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!(
+                "DescribeUserScramCredentialsResult v{} is not supported",
+                version
+            );
+        }
         let user = types::CompactString.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let error_message = types::CompactString.decode(buf)?;

--- a/src/messages/describe_user_scram_credentials_response.rs
+++ b/src/messages/describe_user_scram_credentials_response.rs
@@ -70,7 +70,7 @@ impl CredentialInfo {
 impl Encodable for CredentialInfo {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("CredentialInfo v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int8.encode(buf, &self.mechanism)?;
         types::Int32.encode(buf, &self.iterations)?;
@@ -108,7 +108,7 @@ impl Encodable for CredentialInfo {
 impl Decodable for CredentialInfo {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("CredentialInfo v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let mechanism = types::Int8.decode(buf)?;
         let iterations = types::Int32.decode(buf)?;
@@ -224,10 +224,7 @@ impl DescribeUserScramCredentialsResponse {
 impl Encodable for DescribeUserScramCredentialsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!(
-                "DescribeUserScramCredentialsResponse v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -269,10 +266,7 @@ impl Encodable for DescribeUserScramCredentialsResponse {
 impl Decodable for DescribeUserScramCredentialsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!(
-                "DescribeUserScramCredentialsResponse v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
@@ -394,10 +388,7 @@ impl DescribeUserScramCredentialsResult {
 impl Encodable for DescribeUserScramCredentialsResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!(
-                "DescribeUserScramCredentialsResult v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         types::CompactString.encode(buf, &self.user)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -440,10 +431,7 @@ impl Encodable for DescribeUserScramCredentialsResult {
 impl Decodable for DescribeUserScramCredentialsResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!(
-                "DescribeUserScramCredentialsResult v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         let user = types::CompactString.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;

--- a/src/messages/elect_leaders_request.rs
+++ b/src/messages/elect_leaders_request.rs
@@ -83,6 +83,9 @@ impl ElectLeadersRequest {
 #[cfg(feature = "client")]
 impl Encodable for ElectLeadersRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 2 {
+            bail!("ElectLeadersRequest v{} is not supported", version);
+        }
         if version >= 1 {
             types::Int8.encode(buf, &self.election_type)?;
         } else {
@@ -146,6 +149,9 @@ impl Encodable for ElectLeadersRequest {
 #[cfg(feature = "broker")]
 impl Decodable for ElectLeadersRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 2 {
+            bail!("ElectLeadersRequest v{} is not supported", version);
+        }
         let election_type = if version >= 1 {
             types::Int8.decode(buf)?
         } else {
@@ -244,6 +250,9 @@ impl TopicPartitions {
 #[cfg(feature = "client")]
 impl Encodable for TopicPartitions {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 2 {
+            bail!("TopicPartitions v{} is not supported", version);
+        }
         if version >= 2 {
             types::CompactString.encode(buf, &self.topic)?;
         } else {
@@ -299,6 +308,9 @@ impl Encodable for TopicPartitions {
 #[cfg(feature = "broker")]
 impl Decodable for TopicPartitions {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 2 {
+            bail!("TopicPartitions v{} is not supported", version);
+        }
         let topic = if version >= 2 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/elect_leaders_request.rs
+++ b/src/messages/elect_leaders_request.rs
@@ -84,7 +84,7 @@ impl ElectLeadersRequest {
 impl Encodable for ElectLeadersRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 2 {
-            bail!("ElectLeadersRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 1 {
             types::Int8.encode(buf, &self.election_type)?;
@@ -150,7 +150,7 @@ impl Encodable for ElectLeadersRequest {
 impl Decodable for ElectLeadersRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 2 {
-            bail!("ElectLeadersRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let election_type = if version >= 1 {
             types::Int8.decode(buf)?
@@ -251,7 +251,7 @@ impl TopicPartitions {
 impl Encodable for TopicPartitions {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 2 {
-            bail!("TopicPartitions v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 2 {
             types::CompactString.encode(buf, &self.topic)?;
@@ -309,7 +309,7 @@ impl Encodable for TopicPartitions {
 impl Decodable for TopicPartitions {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 2 {
-            bail!("TopicPartitions v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topic = if version >= 2 {
             types::CompactString.decode(buf)?

--- a/src/messages/elect_leaders_response.rs
+++ b/src/messages/elect_leaders_response.rs
@@ -83,6 +83,9 @@ impl ElectLeadersResponse {
 #[cfg(feature = "broker")]
 impl Encodable for ElectLeadersResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 2 {
+            bail!("ElectLeadersResponse v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         if version >= 1 {
             types::Int16.encode(buf, &self.error_code)?;
@@ -147,6 +150,9 @@ impl Encodable for ElectLeadersResponse {
 #[cfg(feature = "client")]
 impl Decodable for ElectLeadersResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 2 {
+            bail!("ElectLeadersResponse v{} is not supported", version);
+        }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = if version >= 1 {
             types::Int16.decode(buf)?
@@ -259,6 +265,9 @@ impl PartitionResult {
 #[cfg(feature = "broker")]
 impl Encodable for PartitionResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 2 {
+            bail!("PartitionResult v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.partition_id)?;
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 2 {
@@ -308,6 +317,9 @@ impl Encodable for PartitionResult {
 #[cfg(feature = "client")]
 impl Decodable for PartitionResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 2 {
+            bail!("PartitionResult v{} is not supported", version);
+        }
         let partition_id = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let error_message = if version >= 2 {
@@ -402,6 +414,9 @@ impl ReplicaElectionResult {
 #[cfg(feature = "broker")]
 impl Encodable for ReplicaElectionResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 2 {
+            bail!("ReplicaElectionResult v{} is not supported", version);
+        }
         if version >= 2 {
             types::CompactString.encode(buf, &self.topic)?;
         } else {
@@ -459,6 +474,9 @@ impl Encodable for ReplicaElectionResult {
 #[cfg(feature = "client")]
 impl Decodable for ReplicaElectionResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 2 {
+            bail!("ReplicaElectionResult v{} is not supported", version);
+        }
         let topic = if version >= 2 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/elect_leaders_response.rs
+++ b/src/messages/elect_leaders_response.rs
@@ -84,7 +84,7 @@ impl ElectLeadersResponse {
 impl Encodable for ElectLeadersResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 2 {
-            bail!("ElectLeadersResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         if version >= 1 {
@@ -151,7 +151,7 @@ impl Encodable for ElectLeadersResponse {
 impl Decodable for ElectLeadersResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 2 {
-            bail!("ElectLeadersResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = if version >= 1 {
@@ -266,7 +266,7 @@ impl PartitionResult {
 impl Encodable for PartitionResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 2 {
-            bail!("PartitionResult v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.partition_id)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -318,7 +318,7 @@ impl Encodable for PartitionResult {
 impl Decodable for PartitionResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 2 {
-            bail!("PartitionResult v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let partition_id = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
@@ -415,7 +415,7 @@ impl ReplicaElectionResult {
 impl Encodable for ReplicaElectionResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 2 {
-            bail!("ReplicaElectionResult v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 2 {
             types::CompactString.encode(buf, &self.topic)?;
@@ -475,7 +475,7 @@ impl Encodable for ReplicaElectionResult {
 impl Decodable for ReplicaElectionResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 2 {
-            bail!("ReplicaElectionResult v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topic = if version >= 2 {
             types::CompactString.decode(buf)?

--- a/src/messages/end_quorum_epoch_request.rs
+++ b/src/messages/end_quorum_epoch_request.rs
@@ -83,6 +83,9 @@ impl EndQuorumEpochRequest {
 #[cfg(feature = "client")]
 impl Encodable for EndQuorumEpochRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("EndQuorumEpochRequest v{} is not supported", version);
+        }
         if version >= 1 {
             types::CompactString.encode(buf, &self.cluster_id)?;
         } else {
@@ -146,6 +149,9 @@ impl Encodable for EndQuorumEpochRequest {
 #[cfg(feature = "broker")]
 impl Decodable for EndQuorumEpochRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("EndQuorumEpochRequest v{} is not supported", version);
+        }
         let cluster_id = if version >= 1 {
             types::CompactString.decode(buf)?
         } else {
@@ -262,6 +268,9 @@ impl LeaderEndpoint {
 #[cfg(feature = "client")]
 impl Encodable for LeaderEndpoint {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("LeaderEndpoint v{} is not supported", version);
+        }
         if version >= 1 {
             types::CompactString.encode(buf, &self.name)?;
         } else {
@@ -339,6 +348,9 @@ impl Encodable for LeaderEndpoint {
 #[cfg(feature = "broker")]
 impl Decodable for LeaderEndpoint {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("LeaderEndpoint v{} is not supported", version);
+        }
         let name = if version >= 1 {
             types::CompactString.decode(buf)?
         } else {
@@ -483,6 +495,9 @@ impl PartitionData {
 #[cfg(feature = "client")]
 impl Encodable for PartitionData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("PartitionData v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int32.encode(buf, &self.leader_id)?;
         types::Int32.encode(buf, &self.leader_epoch)?;
@@ -538,6 +553,9 @@ impl Encodable for PartitionData {
 #[cfg(feature = "broker")]
 impl Decodable for PartitionData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("PartitionData v{} is not supported", version);
+        }
         let partition_index = types::Int32.decode(buf)?;
         let leader_id = types::Int32.decode(buf)?;
         let leader_epoch = types::Int32.decode(buf)?;
@@ -642,6 +660,9 @@ impl ReplicaInfo {
 #[cfg(feature = "client")]
 impl Encodable for ReplicaInfo {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("ReplicaInfo v{} is not supported", version);
+        }
         if version >= 1 {
             types::Int32.encode(buf, &self.candidate_id)?;
         } else {
@@ -705,6 +726,9 @@ impl Encodable for ReplicaInfo {
 #[cfg(feature = "broker")]
 impl Decodable for ReplicaInfo {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("ReplicaInfo v{} is not supported", version);
+        }
         let candidate_id = if version >= 1 {
             types::Int32.decode(buf)?
         } else {
@@ -800,6 +824,9 @@ impl TopicData {
 #[cfg(feature = "client")]
 impl Encodable for TopicData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("TopicData v{} is not supported", version);
+        }
         if version >= 1 {
             types::CompactString.encode(buf, &self.topic_name)?;
         } else {
@@ -856,6 +883,9 @@ impl Encodable for TopicData {
 #[cfg(feature = "broker")]
 impl Decodable for TopicData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("TopicData v{} is not supported", version);
+        }
         let topic_name = if version >= 1 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/end_quorum_epoch_request.rs
+++ b/src/messages/end_quorum_epoch_request.rs
@@ -84,7 +84,7 @@ impl EndQuorumEpochRequest {
 impl Encodable for EndQuorumEpochRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("EndQuorumEpochRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 1 {
             types::CompactString.encode(buf, &self.cluster_id)?;
@@ -150,7 +150,7 @@ impl Encodable for EndQuorumEpochRequest {
 impl Decodable for EndQuorumEpochRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("EndQuorumEpochRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let cluster_id = if version >= 1 {
             types::CompactString.decode(buf)?
@@ -269,7 +269,7 @@ impl LeaderEndpoint {
 impl Encodable for LeaderEndpoint {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("LeaderEndpoint v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 1 {
             types::CompactString.encode(buf, &self.name)?;
@@ -349,7 +349,7 @@ impl Encodable for LeaderEndpoint {
 impl Decodable for LeaderEndpoint {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("LeaderEndpoint v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = if version >= 1 {
             types::CompactString.decode(buf)?
@@ -496,7 +496,7 @@ impl PartitionData {
 impl Encodable for PartitionData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("PartitionData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int32.encode(buf, &self.leader_id)?;
@@ -554,7 +554,7 @@ impl Encodable for PartitionData {
 impl Decodable for PartitionData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("PartitionData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let partition_index = types::Int32.decode(buf)?;
         let leader_id = types::Int32.decode(buf)?;
@@ -661,7 +661,7 @@ impl ReplicaInfo {
 impl Encodable for ReplicaInfo {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("ReplicaInfo v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 1 {
             types::Int32.encode(buf, &self.candidate_id)?;
@@ -727,7 +727,7 @@ impl Encodable for ReplicaInfo {
 impl Decodable for ReplicaInfo {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("ReplicaInfo v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let candidate_id = if version >= 1 {
             types::Int32.decode(buf)?
@@ -825,7 +825,7 @@ impl TopicData {
 impl Encodable for TopicData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("TopicData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 1 {
             types::CompactString.encode(buf, &self.topic_name)?;
@@ -884,7 +884,7 @@ impl Encodable for TopicData {
 impl Decodable for TopicData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("TopicData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topic_name = if version >= 1 {
             types::CompactString.decode(buf)?

--- a/src/messages/end_quorum_epoch_response.rs
+++ b/src/messages/end_quorum_epoch_response.rs
@@ -83,6 +83,9 @@ impl EndQuorumEpochResponse {
 #[cfg(feature = "broker")]
 impl Encodable for EndQuorumEpochResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("EndQuorumEpochResponse v{} is not supported", version);
+        }
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 1 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
@@ -163,6 +166,9 @@ impl Encodable for EndQuorumEpochResponse {
 #[cfg(feature = "client")]
 impl Decodable for EndQuorumEpochResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("EndQuorumEpochResponse v{} is not supported", version);
+        }
         let error_code = types::Int16.decode(buf)?;
         let topics = if version >= 1 {
             types::CompactArray(types::Struct { version }).decode(buf)?
@@ -279,6 +285,9 @@ impl NodeEndpoint {
 #[cfg(feature = "broker")]
 impl Encodable for NodeEndpoint {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("NodeEndpoint v{} is not supported", version);
+        }
         if version >= 1 {
             types::Int32.encode(buf, &self.node_id)?;
         } else {
@@ -356,6 +365,9 @@ impl Encodable for NodeEndpoint {
 #[cfg(feature = "client")]
 impl Decodable for NodeEndpoint {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("NodeEndpoint v{} is not supported", version);
+        }
         let node_id = if version >= 1 {
             types::Int32.decode(buf)?
         } else {
@@ -486,6 +498,9 @@ impl PartitionData {
 #[cfg(feature = "broker")]
 impl Encodable for PartitionData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("PartitionData v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int16.encode(buf, &self.error_code)?;
         types::Int32.encode(buf, &self.leader_id)?;
@@ -529,6 +544,9 @@ impl Encodable for PartitionData {
 #[cfg(feature = "client")]
 impl Decodable for PartitionData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("PartitionData v{} is not supported", version);
+        }
         let partition_index = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let leader_id = types::Int32.decode(buf)?;
@@ -622,6 +640,9 @@ impl TopicData {
 #[cfg(feature = "broker")]
 impl Encodable for TopicData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("TopicData v{} is not supported", version);
+        }
         if version >= 1 {
             types::CompactString.encode(buf, &self.topic_name)?;
         } else {
@@ -678,6 +699,9 @@ impl Encodable for TopicData {
 #[cfg(feature = "client")]
 impl Decodable for TopicData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("TopicData v{} is not supported", version);
+        }
         let topic_name = if version >= 1 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/end_quorum_epoch_response.rs
+++ b/src/messages/end_quorum_epoch_response.rs
@@ -84,7 +84,7 @@ impl EndQuorumEpochResponse {
 impl Encodable for EndQuorumEpochResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("EndQuorumEpochResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 1 {
@@ -167,7 +167,7 @@ impl Encodable for EndQuorumEpochResponse {
 impl Decodable for EndQuorumEpochResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("EndQuorumEpochResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let error_code = types::Int16.decode(buf)?;
         let topics = if version >= 1 {
@@ -286,7 +286,7 @@ impl NodeEndpoint {
 impl Encodable for NodeEndpoint {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("NodeEndpoint v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 1 {
             types::Int32.encode(buf, &self.node_id)?;
@@ -366,7 +366,7 @@ impl Encodable for NodeEndpoint {
 impl Decodable for NodeEndpoint {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("NodeEndpoint v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let node_id = if version >= 1 {
             types::Int32.decode(buf)?
@@ -499,7 +499,7 @@ impl PartitionData {
 impl Encodable for PartitionData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("PartitionData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -545,7 +545,7 @@ impl Encodable for PartitionData {
 impl Decodable for PartitionData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("PartitionData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let partition_index = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
@@ -641,7 +641,7 @@ impl TopicData {
 impl Encodable for TopicData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("TopicData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 1 {
             types::CompactString.encode(buf, &self.topic_name)?;
@@ -700,7 +700,7 @@ impl Encodable for TopicData {
 impl Decodable for TopicData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("TopicData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topic_name = if version >= 1 {
             types::CompactString.decode(buf)?

--- a/src/messages/end_txn_request.rs
+++ b/src/messages/end_txn_request.rs
@@ -98,7 +98,7 @@ impl EndTxnRequest {
 impl Encodable for EndTxnRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 4 {
-            bail!("EndTxnRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 3 {
             types::CompactString.encode(buf, &self.transactional_id)?;
@@ -152,7 +152,7 @@ impl Encodable for EndTxnRequest {
 impl Decodable for EndTxnRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 4 {
-            bail!("EndTxnRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let transactional_id = if version >= 3 {
             types::CompactString.decode(buf)?

--- a/src/messages/end_txn_request.rs
+++ b/src/messages/end_txn_request.rs
@@ -97,6 +97,9 @@ impl EndTxnRequest {
 #[cfg(feature = "client")]
 impl Encodable for EndTxnRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 4 {
+            bail!("EndTxnRequest v{} is not supported", version);
+        }
         if version >= 3 {
             types::CompactString.encode(buf, &self.transactional_id)?;
         } else {
@@ -148,6 +151,9 @@ impl Encodable for EndTxnRequest {
 #[cfg(feature = "broker")]
 impl Decodable for EndTxnRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 4 {
+            bail!("EndTxnRequest v{} is not supported", version);
+        }
         let transactional_id = if version >= 3 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/end_txn_response.rs
+++ b/src/messages/end_txn_response.rs
@@ -69,6 +69,9 @@ impl EndTxnResponse {
 #[cfg(feature = "broker")]
 impl Encodable for EndTxnResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 4 {
+            bail!("EndTxnResponse v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 3 {
@@ -108,6 +111,9 @@ impl Encodable for EndTxnResponse {
 #[cfg(feature = "client")]
 impl Decodable for EndTxnResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 4 {
+            bail!("EndTxnResponse v{} is not supported", version);
+        }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();

--- a/src/messages/end_txn_response.rs
+++ b/src/messages/end_txn_response.rs
@@ -70,7 +70,7 @@ impl EndTxnResponse {
 impl Encodable for EndTxnResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 4 {
-            bail!("EndTxnResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -112,7 +112,7 @@ impl Encodable for EndTxnResponse {
 impl Decodable for EndTxnResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 4 {
-            bail!("EndTxnResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;

--- a/src/messages/envelope_request.rs
+++ b/src/messages/envelope_request.rs
@@ -84,7 +84,7 @@ impl EnvelopeRequest {
 impl Encodable for EnvelopeRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("EnvelopeRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::CompactBytes.encode(buf, &self.request_data)?;
         types::CompactBytes.encode(buf, &self.request_principal)?;
@@ -124,7 +124,7 @@ impl Encodable for EnvelopeRequest {
 impl Decodable for EnvelopeRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("EnvelopeRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let request_data = types::CompactBytes.decode(buf)?;
         let request_principal = types::CompactBytes.decode(buf)?;

--- a/src/messages/envelope_request.rs
+++ b/src/messages/envelope_request.rs
@@ -83,6 +83,9 @@ impl EnvelopeRequest {
 #[cfg(feature = "client")]
 impl Encodable for EnvelopeRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("EnvelopeRequest v{} is not supported", version);
+        }
         types::CompactBytes.encode(buf, &self.request_data)?;
         types::CompactBytes.encode(buf, &self.request_principal)?;
         types::CompactBytes.encode(buf, &self.client_host_address)?;
@@ -120,6 +123,9 @@ impl Encodable for EnvelopeRequest {
 #[cfg(feature = "broker")]
 impl Decodable for EnvelopeRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("EnvelopeRequest v{} is not supported", version);
+        }
         let request_data = types::CompactBytes.decode(buf)?;
         let request_principal = types::CompactBytes.decode(buf)?;
         let client_host_address = types::CompactBytes.decode(buf)?;

--- a/src/messages/envelope_response.rs
+++ b/src/messages/envelope_response.rs
@@ -69,6 +69,9 @@ impl EnvelopeResponse {
 #[cfg(feature = "broker")]
 impl Encodable for EnvelopeResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("EnvelopeResponse v{} is not supported", version);
+        }
         types::CompactBytes.encode(buf, &self.response_data)?;
         types::Int16.encode(buf, &self.error_code)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -104,6 +107,9 @@ impl Encodable for EnvelopeResponse {
 #[cfg(feature = "client")]
 impl Decodable for EnvelopeResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("EnvelopeResponse v{} is not supported", version);
+        }
         let response_data = types::CompactBytes.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();

--- a/src/messages/envelope_response.rs
+++ b/src/messages/envelope_response.rs
@@ -70,7 +70,7 @@ impl EnvelopeResponse {
 impl Encodable for EnvelopeResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("EnvelopeResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::CompactBytes.encode(buf, &self.response_data)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -108,7 +108,7 @@ impl Encodable for EnvelopeResponse {
 impl Decodable for EnvelopeResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("EnvelopeResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let response_data = types::CompactBytes.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;

--- a/src/messages/expire_delegation_token_request.rs
+++ b/src/messages/expire_delegation_token_request.rs
@@ -69,6 +69,9 @@ impl ExpireDelegationTokenRequest {
 #[cfg(feature = "client")]
 impl Encodable for ExpireDelegationTokenRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 2 {
+            bail!("ExpireDelegationTokenRequest v{} is not supported", version);
+        }
         if version >= 2 {
             types::CompactBytes.encode(buf, &self.hmac)?;
         } else {
@@ -116,6 +119,9 @@ impl Encodable for ExpireDelegationTokenRequest {
 #[cfg(feature = "broker")]
 impl Decodable for ExpireDelegationTokenRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 2 {
+            bail!("ExpireDelegationTokenRequest v{} is not supported", version);
+        }
         let hmac = if version >= 2 {
             types::CompactBytes.decode(buf)?
         } else {

--- a/src/messages/expire_delegation_token_request.rs
+++ b/src/messages/expire_delegation_token_request.rs
@@ -70,7 +70,7 @@ impl ExpireDelegationTokenRequest {
 impl Encodable for ExpireDelegationTokenRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 2 {
-            bail!("ExpireDelegationTokenRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 2 {
             types::CompactBytes.encode(buf, &self.hmac)?;
@@ -120,7 +120,7 @@ impl Encodable for ExpireDelegationTokenRequest {
 impl Decodable for ExpireDelegationTokenRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 2 {
-            bail!("ExpireDelegationTokenRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let hmac = if version >= 2 {
             types::CompactBytes.decode(buf)?

--- a/src/messages/expire_delegation_token_response.rs
+++ b/src/messages/expire_delegation_token_response.rs
@@ -83,6 +83,12 @@ impl ExpireDelegationTokenResponse {
 #[cfg(feature = "broker")]
 impl Encodable for ExpireDelegationTokenResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 2 {
+            bail!(
+                "ExpireDelegationTokenResponse v{} is not supported",
+                version
+            );
+        }
         types::Int16.encode(buf, &self.error_code)?;
         types::Int64.encode(buf, &self.expiry_timestamp_ms)?;
         types::Int32.encode(buf, &self.throttle_time_ms)?;
@@ -124,6 +130,12 @@ impl Encodable for ExpireDelegationTokenResponse {
 #[cfg(feature = "client")]
 impl Decodable for ExpireDelegationTokenResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 2 {
+            bail!(
+                "ExpireDelegationTokenResponse v{} is not supported",
+                version
+            );
+        }
         let error_code = types::Int16.decode(buf)?;
         let expiry_timestamp_ms = types::Int64.decode(buf)?;
         let throttle_time_ms = types::Int32.decode(buf)?;

--- a/src/messages/expire_delegation_token_response.rs
+++ b/src/messages/expire_delegation_token_response.rs
@@ -84,10 +84,7 @@ impl ExpireDelegationTokenResponse {
 impl Encodable for ExpireDelegationTokenResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 2 {
-            bail!(
-                "ExpireDelegationTokenResponse v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         types::Int16.encode(buf, &self.error_code)?;
         types::Int64.encode(buf, &self.expiry_timestamp_ms)?;
@@ -131,10 +128,7 @@ impl Encodable for ExpireDelegationTokenResponse {
 impl Decodable for ExpireDelegationTokenResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 2 {
-            bail!(
-                "ExpireDelegationTokenResponse v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         let error_code = types::Int16.decode(buf)?;
         let expiry_timestamp_ms = types::Int64.decode(buf)?;

--- a/src/messages/fetch_request.rs
+++ b/src/messages/fetch_request.rs
@@ -140,7 +140,7 @@ impl FetchPartition {
 impl Encodable for FetchPartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 17 {
-            bail!("FetchPartition v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.partition)?;
         if version >= 9 {
@@ -246,7 +246,7 @@ impl Encodable for FetchPartition {
 impl Decodable for FetchPartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 17 {
-            bail!("FetchPartition v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let partition = types::Int32.decode(buf)?;
         let current_leader_epoch = if version >= 9 {
@@ -514,7 +514,7 @@ impl FetchRequest {
 impl Encodable for FetchRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 17 {
-            bail!("FetchRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version <= 14 {
             types::Int32.encode(buf, &self.replica_id)?;
@@ -712,7 +712,7 @@ impl Encodable for FetchRequest {
 impl Decodable for FetchRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 17 {
-            bail!("FetchRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let mut cluster_id = None;
         let replica_id = if version <= 14 {
@@ -900,7 +900,7 @@ impl FetchTopic {
 impl Encodable for FetchTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 17 {
-            bail!("FetchTopic v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version <= 12 {
             if version >= 12 {
@@ -969,7 +969,7 @@ impl Encodable for FetchTopic {
 impl Decodable for FetchTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 17 {
-            bail!("FetchTopic v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topic = if version <= 12 {
             if version >= 12 {
@@ -1092,7 +1092,7 @@ impl ForgottenTopic {
 impl Encodable for ForgottenTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 17 {
-            bail!("ForgottenTopic v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 7 && version <= 12 {
             if version >= 12 {
@@ -1172,7 +1172,7 @@ impl Encodable for ForgottenTopic {
 impl Decodable for ForgottenTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 17 {
-            bail!("ForgottenTopic v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topic = if version >= 7 && version <= 12 {
             if version >= 12 {
@@ -1285,7 +1285,7 @@ impl ReplicaState {
 impl Encodable for ReplicaState {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 17 {
-            bail!("ReplicaState v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 15 {
             types::Int32.encode(buf, &self.replica_id)?;
@@ -1351,7 +1351,7 @@ impl Encodable for ReplicaState {
 impl Decodable for ReplicaState {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 17 {
-            bail!("ReplicaState v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let replica_id = if version >= 15 {
             types::Int32.decode(buf)?

--- a/src/messages/fetch_request.rs
+++ b/src/messages/fetch_request.rs
@@ -139,6 +139,9 @@ impl FetchPartition {
 #[cfg(feature = "client")]
 impl Encodable for FetchPartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 17 {
+            bail!("FetchPartition v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.partition)?;
         if version >= 9 {
             types::Int32.encode(buf, &self.current_leader_epoch)?;
@@ -242,6 +245,9 @@ impl Encodable for FetchPartition {
 #[cfg(feature = "broker")]
 impl Decodable for FetchPartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 17 {
+            bail!("FetchPartition v{} is not supported", version);
+        }
         let partition = types::Int32.decode(buf)?;
         let current_leader_epoch = if version >= 9 {
             types::Int32.decode(buf)?
@@ -507,6 +513,9 @@ impl FetchRequest {
 #[cfg(feature = "client")]
 impl Encodable for FetchRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 17 {
+            bail!("FetchRequest v{} is not supported", version);
+        }
         if version <= 14 {
             types::Int32.encode(buf, &self.replica_id)?;
         } else {
@@ -702,6 +711,9 @@ impl Encodable for FetchRequest {
 #[cfg(feature = "broker")]
 impl Decodable for FetchRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 17 {
+            bail!("FetchRequest v{} is not supported", version);
+        }
         let mut cluster_id = None;
         let replica_id = if version <= 14 {
             types::Int32.decode(buf)?
@@ -887,6 +899,9 @@ impl FetchTopic {
 #[cfg(feature = "client")]
 impl Encodable for FetchTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 17 {
+            bail!("FetchTopic v{} is not supported", version);
+        }
         if version <= 12 {
             if version >= 12 {
                 types::CompactString.encode(buf, &self.topic)?;
@@ -953,6 +968,9 @@ impl Encodable for FetchTopic {
 #[cfg(feature = "broker")]
 impl Decodable for FetchTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 17 {
+            bail!("FetchTopic v{} is not supported", version);
+        }
         let topic = if version <= 12 {
             if version >= 12 {
                 types::CompactString.decode(buf)?
@@ -1073,6 +1091,9 @@ impl ForgottenTopic {
 #[cfg(feature = "client")]
 impl Encodable for ForgottenTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 17 {
+            bail!("ForgottenTopic v{} is not supported", version);
+        }
         if version >= 7 && version <= 12 {
             if version >= 12 {
                 types::CompactString.encode(buf, &self.topic)?;
@@ -1150,6 +1171,9 @@ impl Encodable for ForgottenTopic {
 #[cfg(feature = "broker")]
 impl Decodable for ForgottenTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 17 {
+            bail!("ForgottenTopic v{} is not supported", version);
+        }
         let topic = if version >= 7 && version <= 12 {
             if version >= 12 {
                 types::CompactString.decode(buf)?
@@ -1260,6 +1284,9 @@ impl ReplicaState {
 #[cfg(feature = "client")]
 impl Encodable for ReplicaState {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 17 {
+            bail!("ReplicaState v{} is not supported", version);
+        }
         if version >= 15 {
             types::Int32.encode(buf, &self.replica_id)?;
         } else {
@@ -1323,6 +1350,9 @@ impl Encodable for ReplicaState {
 #[cfg(feature = "broker")]
 impl Decodable for ReplicaState {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 17 {
+            bail!("ReplicaState v{} is not supported", version);
+        }
         let replica_id = if version >= 15 {
             types::Int32.decode(buf)?
         } else {

--- a/src/messages/fetch_response.rs
+++ b/src/messages/fetch_response.rs
@@ -69,6 +69,9 @@ impl AbortedTransaction {
 #[cfg(feature = "broker")]
 impl Encodable for AbortedTransaction {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 17 {
+            bail!("AbortedTransaction v{} is not supported", version);
+        }
         if version >= 4 {
             types::Int64.encode(buf, &self.producer_id)?;
         } else {
@@ -132,6 +135,9 @@ impl Encodable for AbortedTransaction {
 #[cfg(feature = "client")]
 impl Decodable for AbortedTransaction {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 17 {
+            bail!("AbortedTransaction v{} is not supported", version);
+        }
         let producer_id = if version >= 4 {
             types::Int64.decode(buf)?
         } else {
@@ -227,6 +233,9 @@ impl EpochEndOffset {
 #[cfg(feature = "broker")]
 impl Encodable for EpochEndOffset {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 17 {
+            bail!("EpochEndOffset v{} is not supported", version);
+        }
         if version >= 12 {
             types::Int32.encode(buf, &self.epoch)?;
         } else {
@@ -290,6 +299,9 @@ impl Encodable for EpochEndOffset {
 #[cfg(feature = "client")]
 impl Decodable for EpochEndOffset {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 17 {
+            bail!("EpochEndOffset v{} is not supported", version);
+        }
         let epoch = if version >= 12 {
             types::Int32.decode(buf)?
         } else {
@@ -427,6 +439,9 @@ impl FetchResponse {
 #[cfg(feature = "broker")]
 impl Encodable for FetchResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 17 {
+            bail!("FetchResponse v{} is not supported", version);
+        }
         if version >= 1 {
             types::Int32.encode(buf, &self.throttle_time_ms)?;
         }
@@ -538,6 +553,9 @@ impl Encodable for FetchResponse {
 #[cfg(feature = "client")]
 impl Decodable for FetchResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 17 {
+            bail!("FetchResponse v{} is not supported", version);
+        }
         let throttle_time_ms = if version >= 1 {
             types::Int32.decode(buf)?
         } else {
@@ -676,6 +694,9 @@ impl FetchableTopicResponse {
 #[cfg(feature = "broker")]
 impl Encodable for FetchableTopicResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 17 {
+            bail!("FetchableTopicResponse v{} is not supported", version);
+        }
         if version <= 12 {
             if version >= 12 {
                 types::CompactString.encode(buf, &self.topic)?;
@@ -742,6 +763,9 @@ impl Encodable for FetchableTopicResponse {
 #[cfg(feature = "client")]
 impl Decodable for FetchableTopicResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 17 {
+            bail!("FetchableTopicResponse v{} is not supported", version);
+        }
         let topic = if version <= 12 {
             if version >= 12 {
                 types::CompactString.decode(buf)?
@@ -848,6 +872,9 @@ impl LeaderIdAndEpoch {
 #[cfg(feature = "broker")]
 impl Encodable for LeaderIdAndEpoch {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 17 {
+            bail!("LeaderIdAndEpoch v{} is not supported", version);
+        }
         if version >= 12 {
             types::Int32.encode(buf, &self.leader_id)?;
         } else {
@@ -911,6 +938,9 @@ impl Encodable for LeaderIdAndEpoch {
 #[cfg(feature = "client")]
 impl Decodable for LeaderIdAndEpoch {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 17 {
+            bail!("LeaderIdAndEpoch v{} is not supported", version);
+        }
         let leader_id = if version >= 12 {
             types::Int32.decode(buf)?
         } else {
@@ -1034,6 +1064,9 @@ impl NodeEndpoint {
 #[cfg(feature = "broker")]
 impl Encodable for NodeEndpoint {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 17 {
+            bail!("NodeEndpoint v{} is not supported", version);
+        }
         if version >= 16 {
             types::Int32.encode(buf, &self.node_id)?;
         } else {
@@ -1125,6 +1158,9 @@ impl Encodable for NodeEndpoint {
 #[cfg(feature = "client")]
 impl Decodable for NodeEndpoint {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 17 {
+            bail!("NodeEndpoint v{} is not supported", version);
+        }
         let node_id = if version >= 16 {
             types::Int32.decode(buf)?
         } else {
@@ -1360,6 +1396,9 @@ impl PartitionData {
 #[cfg(feature = "broker")]
 impl Encodable for PartitionData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 17 {
+            bail!("PartitionData v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int16.encode(buf, &self.error_code)?;
         types::Int64.encode(buf, &self.high_watermark)?;
@@ -1546,6 +1585,9 @@ impl Encodable for PartitionData {
 #[cfg(feature = "client")]
 impl Decodable for PartitionData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 17 {
+            bail!("PartitionData v{} is not supported", version);
+        }
         let partition_index = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let high_watermark = types::Int64.decode(buf)?;
@@ -1697,6 +1739,9 @@ impl SnapshotId {
 #[cfg(feature = "broker")]
 impl Encodable for SnapshotId {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 17 {
+            bail!("SnapshotId v{} is not supported", version);
+        }
         types::Int64.encode(buf, &self.end_offset)?;
         types::Int32.encode(buf, &self.epoch)?;
         if version >= 12 {
@@ -1736,6 +1781,9 @@ impl Encodable for SnapshotId {
 #[cfg(feature = "client")]
 impl Decodable for SnapshotId {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 17 {
+            bail!("SnapshotId v{} is not supported", version);
+        }
         let end_offset = types::Int64.decode(buf)?;
         let epoch = types::Int32.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();

--- a/src/messages/fetch_response.rs
+++ b/src/messages/fetch_response.rs
@@ -70,7 +70,7 @@ impl AbortedTransaction {
 impl Encodable for AbortedTransaction {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 17 {
-            bail!("AbortedTransaction v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 4 {
             types::Int64.encode(buf, &self.producer_id)?;
@@ -136,7 +136,7 @@ impl Encodable for AbortedTransaction {
 impl Decodable for AbortedTransaction {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 17 {
-            bail!("AbortedTransaction v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let producer_id = if version >= 4 {
             types::Int64.decode(buf)?
@@ -234,7 +234,7 @@ impl EpochEndOffset {
 impl Encodable for EpochEndOffset {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 17 {
-            bail!("EpochEndOffset v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 12 {
             types::Int32.encode(buf, &self.epoch)?;
@@ -300,7 +300,7 @@ impl Encodable for EpochEndOffset {
 impl Decodable for EpochEndOffset {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 17 {
-            bail!("EpochEndOffset v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let epoch = if version >= 12 {
             types::Int32.decode(buf)?
@@ -440,7 +440,7 @@ impl FetchResponse {
 impl Encodable for FetchResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 17 {
-            bail!("FetchResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 1 {
             types::Int32.encode(buf, &self.throttle_time_ms)?;
@@ -554,7 +554,7 @@ impl Encodable for FetchResponse {
 impl Decodable for FetchResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 17 {
-            bail!("FetchResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = if version >= 1 {
             types::Int32.decode(buf)?
@@ -695,7 +695,7 @@ impl FetchableTopicResponse {
 impl Encodable for FetchableTopicResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 17 {
-            bail!("FetchableTopicResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version <= 12 {
             if version >= 12 {
@@ -764,7 +764,7 @@ impl Encodable for FetchableTopicResponse {
 impl Decodable for FetchableTopicResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 17 {
-            bail!("FetchableTopicResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topic = if version <= 12 {
             if version >= 12 {
@@ -873,7 +873,7 @@ impl LeaderIdAndEpoch {
 impl Encodable for LeaderIdAndEpoch {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 17 {
-            bail!("LeaderIdAndEpoch v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 12 {
             types::Int32.encode(buf, &self.leader_id)?;
@@ -939,7 +939,7 @@ impl Encodable for LeaderIdAndEpoch {
 impl Decodable for LeaderIdAndEpoch {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 17 {
-            bail!("LeaderIdAndEpoch v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let leader_id = if version >= 12 {
             types::Int32.decode(buf)?
@@ -1065,7 +1065,7 @@ impl NodeEndpoint {
 impl Encodable for NodeEndpoint {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 17 {
-            bail!("NodeEndpoint v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 16 {
             types::Int32.encode(buf, &self.node_id)?;
@@ -1159,7 +1159,7 @@ impl Encodable for NodeEndpoint {
 impl Decodable for NodeEndpoint {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 17 {
-            bail!("NodeEndpoint v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let node_id = if version >= 16 {
             types::Int32.decode(buf)?
@@ -1397,7 +1397,7 @@ impl PartitionData {
 impl Encodable for PartitionData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 17 {
-            bail!("PartitionData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -1586,7 +1586,7 @@ impl Encodable for PartitionData {
 impl Decodable for PartitionData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 17 {
-            bail!("PartitionData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let partition_index = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
@@ -1740,7 +1740,7 @@ impl SnapshotId {
 impl Encodable for SnapshotId {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 17 {
-            bail!("SnapshotId v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int64.encode(buf, &self.end_offset)?;
         types::Int32.encode(buf, &self.epoch)?;
@@ -1782,7 +1782,7 @@ impl Encodable for SnapshotId {
 impl Decodable for SnapshotId {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 17 {
-            bail!("SnapshotId v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let end_offset = types::Int64.decode(buf)?;
         let epoch = types::Int32.decode(buf)?;

--- a/src/messages/fetch_snapshot_request.rs
+++ b/src/messages/fetch_snapshot_request.rs
@@ -97,6 +97,9 @@ impl FetchSnapshotRequest {
 #[cfg(feature = "client")]
 impl Encodable for FetchSnapshotRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("FetchSnapshotRequest v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.replica_id)?;
         types::Int32.encode(buf, &self.max_bytes)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
@@ -164,6 +167,9 @@ impl Encodable for FetchSnapshotRequest {
 #[cfg(feature = "broker")]
 impl Decodable for FetchSnapshotRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("FetchSnapshotRequest v{} is not supported", version);
+        }
         let mut cluster_id = None;
         let replica_id = types::Int32.decode(buf)?;
         let max_bytes = types::Int32.decode(buf)?;
@@ -304,6 +310,9 @@ impl PartitionSnapshot {
 #[cfg(feature = "client")]
 impl Encodable for PartitionSnapshot {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("PartitionSnapshot v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.partition)?;
         types::Int32.encode(buf, &self.current_leader_epoch)?;
         types::Struct { version }.encode(buf, &self.snapshot_id)?;
@@ -379,6 +388,9 @@ impl Encodable for PartitionSnapshot {
 #[cfg(feature = "broker")]
 impl Decodable for PartitionSnapshot {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("PartitionSnapshot v{} is not supported", version);
+        }
         let partition = types::Int32.decode(buf)?;
         let current_leader_epoch = types::Int32.decode(buf)?;
         let snapshot_id = types::Struct { version }.decode(buf)?;
@@ -484,6 +496,9 @@ impl SnapshotId {
 #[cfg(feature = "client")]
 impl Encodable for SnapshotId {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("SnapshotId v{} is not supported", version);
+        }
         types::Int64.encode(buf, &self.end_offset)?;
         types::Int32.encode(buf, &self.epoch)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -519,6 +534,9 @@ impl Encodable for SnapshotId {
 #[cfg(feature = "broker")]
 impl Decodable for SnapshotId {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("SnapshotId v{} is not supported", version);
+        }
         let end_offset = types::Int64.decode(buf)?;
         let epoch = types::Int32.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
@@ -604,6 +622,9 @@ impl TopicSnapshot {
 #[cfg(feature = "client")]
 impl Encodable for TopicSnapshot {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("TopicSnapshot v{} is not supported", version);
+        }
         types::CompactString.encode(buf, &self.name)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.partitions)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -640,6 +661,9 @@ impl Encodable for TopicSnapshot {
 #[cfg(feature = "broker")]
 impl Decodable for TopicSnapshot {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("TopicSnapshot v{} is not supported", version);
+        }
         let name = types::CompactString.decode(buf)?;
         let partitions = types::CompactArray(types::Struct { version }).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();

--- a/src/messages/fetch_snapshot_request.rs
+++ b/src/messages/fetch_snapshot_request.rs
@@ -98,7 +98,7 @@ impl FetchSnapshotRequest {
 impl Encodable for FetchSnapshotRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("FetchSnapshotRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.replica_id)?;
         types::Int32.encode(buf, &self.max_bytes)?;
@@ -168,7 +168,7 @@ impl Encodable for FetchSnapshotRequest {
 impl Decodable for FetchSnapshotRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("FetchSnapshotRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let mut cluster_id = None;
         let replica_id = types::Int32.decode(buf)?;
@@ -311,7 +311,7 @@ impl PartitionSnapshot {
 impl Encodable for PartitionSnapshot {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("PartitionSnapshot v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.partition)?;
         types::Int32.encode(buf, &self.current_leader_epoch)?;
@@ -389,7 +389,7 @@ impl Encodable for PartitionSnapshot {
 impl Decodable for PartitionSnapshot {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("PartitionSnapshot v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let partition = types::Int32.decode(buf)?;
         let current_leader_epoch = types::Int32.decode(buf)?;
@@ -497,7 +497,7 @@ impl SnapshotId {
 impl Encodable for SnapshotId {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("SnapshotId v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int64.encode(buf, &self.end_offset)?;
         types::Int32.encode(buf, &self.epoch)?;
@@ -535,7 +535,7 @@ impl Encodable for SnapshotId {
 impl Decodable for SnapshotId {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("SnapshotId v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let end_offset = types::Int64.decode(buf)?;
         let epoch = types::Int32.decode(buf)?;
@@ -623,7 +623,7 @@ impl TopicSnapshot {
 impl Encodable for TopicSnapshot {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("TopicSnapshot v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::CompactString.encode(buf, &self.name)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.partitions)?;
@@ -662,7 +662,7 @@ impl Encodable for TopicSnapshot {
 impl Decodable for TopicSnapshot {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("TopicSnapshot v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = types::CompactString.decode(buf)?;
         let partitions = types::CompactArray(types::Struct { version }).decode(buf)?;

--- a/src/messages/fetch_snapshot_response.rs
+++ b/src/messages/fetch_snapshot_response.rs
@@ -98,7 +98,7 @@ impl FetchSnapshotResponse {
 impl Encodable for FetchSnapshotResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("FetchSnapshotResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -176,7 +176,7 @@ impl Encodable for FetchSnapshotResponse {
 impl Decodable for FetchSnapshotResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("FetchSnapshotResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
@@ -282,7 +282,7 @@ impl LeaderIdAndEpoch {
 impl Encodable for LeaderIdAndEpoch {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("LeaderIdAndEpoch v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.leader_id)?;
         types::Int32.encode(buf, &self.leader_epoch)?;
@@ -320,7 +320,7 @@ impl Encodable for LeaderIdAndEpoch {
 impl Decodable for LeaderIdAndEpoch {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("LeaderIdAndEpoch v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let leader_id = types::Int32.decode(buf)?;
         let leader_epoch = types::Int32.decode(buf)?;
@@ -422,7 +422,7 @@ impl NodeEndpoint {
 impl Encodable for NodeEndpoint {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("NodeEndpoint v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 1 {
             types::Int32.encode(buf, &self.node_id)?;
@@ -498,7 +498,7 @@ impl Encodable for NodeEndpoint {
 impl Decodable for NodeEndpoint {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("NodeEndpoint v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let node_id = if version >= 1 {
             types::Int32.decode(buf)?
@@ -671,7 +671,7 @@ impl PartitionSnapshot {
 impl Encodable for PartitionSnapshot {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("PartitionSnapshot v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.index)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -747,7 +747,7 @@ impl Encodable for PartitionSnapshot {
 impl Decodable for PartitionSnapshot {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("PartitionSnapshot v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let index = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
@@ -857,7 +857,7 @@ impl SnapshotId {
 impl Encodable for SnapshotId {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("SnapshotId v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int64.encode(buf, &self.end_offset)?;
         types::Int32.encode(buf, &self.epoch)?;
@@ -895,7 +895,7 @@ impl Encodable for SnapshotId {
 impl Decodable for SnapshotId {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("SnapshotId v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let end_offset = types::Int64.decode(buf)?;
         let epoch = types::Int32.decode(buf)?;
@@ -983,7 +983,7 @@ impl TopicSnapshot {
 impl Encodable for TopicSnapshot {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("TopicSnapshot v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::CompactString.encode(buf, &self.name)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.partitions)?;
@@ -1022,7 +1022,7 @@ impl Encodable for TopicSnapshot {
 impl Decodable for TopicSnapshot {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("TopicSnapshot v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = types::CompactString.decode(buf)?;
         let partitions = types::CompactArray(types::Struct { version }).decode(buf)?;

--- a/src/messages/fetch_snapshot_response.rs
+++ b/src/messages/fetch_snapshot_response.rs
@@ -97,6 +97,9 @@ impl FetchSnapshotResponse {
 #[cfg(feature = "broker")]
 impl Encodable for FetchSnapshotResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("FetchSnapshotResponse v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
@@ -172,6 +175,9 @@ impl Encodable for FetchSnapshotResponse {
 #[cfg(feature = "client")]
 impl Decodable for FetchSnapshotResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("FetchSnapshotResponse v{} is not supported", version);
+        }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let topics = types::CompactArray(types::Struct { version }).decode(buf)?;
@@ -275,6 +281,9 @@ impl LeaderIdAndEpoch {
 #[cfg(feature = "broker")]
 impl Encodable for LeaderIdAndEpoch {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("LeaderIdAndEpoch v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.leader_id)?;
         types::Int32.encode(buf, &self.leader_epoch)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -310,6 +319,9 @@ impl Encodable for LeaderIdAndEpoch {
 #[cfg(feature = "client")]
 impl Decodable for LeaderIdAndEpoch {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("LeaderIdAndEpoch v{} is not supported", version);
+        }
         let leader_id = types::Int32.decode(buf)?;
         let leader_epoch = types::Int32.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
@@ -409,6 +421,9 @@ impl NodeEndpoint {
 #[cfg(feature = "broker")]
 impl Encodable for NodeEndpoint {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("NodeEndpoint v{} is not supported", version);
+        }
         if version >= 1 {
             types::Int32.encode(buf, &self.node_id)?;
         } else {
@@ -482,6 +497,9 @@ impl Encodable for NodeEndpoint {
 #[cfg(feature = "client")]
 impl Decodable for NodeEndpoint {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("NodeEndpoint v{} is not supported", version);
+        }
         let node_id = if version >= 1 {
             types::Int32.decode(buf)?
         } else {
@@ -652,6 +670,9 @@ impl PartitionSnapshot {
 #[cfg(feature = "broker")]
 impl Encodable for PartitionSnapshot {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("PartitionSnapshot v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.index)?;
         types::Int16.encode(buf, &self.error_code)?;
         types::Struct { version }.encode(buf, &self.snapshot_id)?;
@@ -725,6 +746,9 @@ impl Encodable for PartitionSnapshot {
 #[cfg(feature = "client")]
 impl Decodable for PartitionSnapshot {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("PartitionSnapshot v{} is not supported", version);
+        }
         let index = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let snapshot_id = types::Struct { version }.decode(buf)?;
@@ -832,6 +856,9 @@ impl SnapshotId {
 #[cfg(feature = "broker")]
 impl Encodable for SnapshotId {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("SnapshotId v{} is not supported", version);
+        }
         types::Int64.encode(buf, &self.end_offset)?;
         types::Int32.encode(buf, &self.epoch)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -867,6 +894,9 @@ impl Encodable for SnapshotId {
 #[cfg(feature = "client")]
 impl Decodable for SnapshotId {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("SnapshotId v{} is not supported", version);
+        }
         let end_offset = types::Int64.decode(buf)?;
         let epoch = types::Int32.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
@@ -952,6 +982,9 @@ impl TopicSnapshot {
 #[cfg(feature = "broker")]
 impl Encodable for TopicSnapshot {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("TopicSnapshot v{} is not supported", version);
+        }
         types::CompactString.encode(buf, &self.name)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.partitions)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -988,6 +1021,9 @@ impl Encodable for TopicSnapshot {
 #[cfg(feature = "client")]
 impl Decodable for TopicSnapshot {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("TopicSnapshot v{} is not supported", version);
+        }
         let name = types::CompactString.decode(buf)?;
         let partitions = types::CompactArray(types::Struct { version }).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();

--- a/src/messages/find_coordinator_request.rs
+++ b/src/messages/find_coordinator_request.rs
@@ -83,6 +83,9 @@ impl FindCoordinatorRequest {
 #[cfg(feature = "client")]
 impl Encodable for FindCoordinatorRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 6 {
+            bail!("FindCoordinatorRequest v{} is not supported", version);
+        }
         if version <= 3 {
             if version >= 3 {
                 types::CompactString.encode(buf, &self.key)?;
@@ -169,6 +172,9 @@ impl Encodable for FindCoordinatorRequest {
 #[cfg(feature = "broker")]
 impl Decodable for FindCoordinatorRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 6 {
+            bail!("FindCoordinatorRequest v{} is not supported", version);
+        }
         let key = if version <= 3 {
             if version >= 3 {
                 types::CompactString.decode(buf)?

--- a/src/messages/find_coordinator_request.rs
+++ b/src/messages/find_coordinator_request.rs
@@ -84,7 +84,7 @@ impl FindCoordinatorRequest {
 impl Encodable for FindCoordinatorRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 6 {
-            bail!("FindCoordinatorRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version <= 3 {
             if version >= 3 {
@@ -173,7 +173,7 @@ impl Encodable for FindCoordinatorRequest {
 impl Decodable for FindCoordinatorRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 6 {
-            bail!("FindCoordinatorRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let key = if version <= 3 {
             if version >= 3 {

--- a/src/messages/find_coordinator_response.rs
+++ b/src/messages/find_coordinator_response.rs
@@ -126,7 +126,7 @@ impl Coordinator {
 impl Encodable for Coordinator {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 6 {
-            bail!("Coordinator v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 4 {
             types::CompactString.encode(buf, &self.key)?;
@@ -240,7 +240,7 @@ impl Encodable for Coordinator {
 impl Decodable for Coordinator {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 6 {
-            bail!("Coordinator v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let key = if version >= 4 {
             types::CompactString.decode(buf)?
@@ -436,7 +436,7 @@ impl FindCoordinatorResponse {
 impl Encodable for FindCoordinatorResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 6 {
-            bail!("FindCoordinatorResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 1 {
             types::Int32.encode(buf, &self.throttle_time_ms)?;
@@ -573,7 +573,7 @@ impl Encodable for FindCoordinatorResponse {
 impl Decodable for FindCoordinatorResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 6 {
-            bail!("FindCoordinatorResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = if version >= 1 {
             types::Int32.decode(buf)?

--- a/src/messages/find_coordinator_response.rs
+++ b/src/messages/find_coordinator_response.rs
@@ -125,6 +125,9 @@ impl Coordinator {
 #[cfg(feature = "broker")]
 impl Encodable for Coordinator {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 6 {
+            bail!("Coordinator v{} is not supported", version);
+        }
         if version >= 4 {
             types::CompactString.encode(buf, &self.key)?;
         } else {
@@ -236,6 +239,9 @@ impl Encodable for Coordinator {
 #[cfg(feature = "client")]
 impl Decodable for Coordinator {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 6 {
+            bail!("Coordinator v{} is not supported", version);
+        }
         let key = if version >= 4 {
             types::CompactString.decode(buf)?
         } else {
@@ -429,6 +435,9 @@ impl FindCoordinatorResponse {
 #[cfg(feature = "broker")]
 impl Encodable for FindCoordinatorResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 6 {
+            bail!("FindCoordinatorResponse v{} is not supported", version);
+        }
         if version >= 1 {
             types::Int32.encode(buf, &self.throttle_time_ms)?;
         }
@@ -563,6 +572,9 @@ impl Encodable for FindCoordinatorResponse {
 #[cfg(feature = "client")]
 impl Decodable for FindCoordinatorResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 6 {
+            bail!("FindCoordinatorResponse v{} is not supported", version);
+        }
         let throttle_time_ms = if version >= 1 {
             types::Int32.decode(buf)?
         } else {

--- a/src/messages/get_telemetry_subscriptions_request.rs
+++ b/src/messages/get_telemetry_subscriptions_request.rs
@@ -56,10 +56,7 @@ impl GetTelemetrySubscriptionsRequest {
 impl Encodable for GetTelemetrySubscriptionsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!(
-                "GetTelemetrySubscriptionsRequest v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         types::Uuid.encode(buf, &self.client_instance_id)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -95,10 +92,7 @@ impl Encodable for GetTelemetrySubscriptionsRequest {
 impl Decodable for GetTelemetrySubscriptionsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!(
-                "GetTelemetrySubscriptionsRequest v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         let client_instance_id = types::Uuid.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();

--- a/src/messages/get_telemetry_subscriptions_request.rs
+++ b/src/messages/get_telemetry_subscriptions_request.rs
@@ -55,6 +55,12 @@ impl GetTelemetrySubscriptionsRequest {
 #[cfg(feature = "client")]
 impl Encodable for GetTelemetrySubscriptionsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!(
+                "GetTelemetrySubscriptionsRequest v{} is not supported",
+                version
+            );
+        }
         types::Uuid.encode(buf, &self.client_instance_id)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
@@ -88,6 +94,12 @@ impl Encodable for GetTelemetrySubscriptionsRequest {
 #[cfg(feature = "broker")]
 impl Decodable for GetTelemetrySubscriptionsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!(
+                "GetTelemetrySubscriptionsRequest v{} is not supported",
+                version
+            );
+        }
         let client_instance_id = types::Uuid.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
         let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;

--- a/src/messages/get_telemetry_subscriptions_response.rs
+++ b/src/messages/get_telemetry_subscriptions_response.rs
@@ -168,10 +168,7 @@ impl GetTelemetrySubscriptionsResponse {
 impl Encodable for GetTelemetrySubscriptionsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!(
-                "GetTelemetrySubscriptionsResponse v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -225,10 +222,7 @@ impl Encodable for GetTelemetrySubscriptionsResponse {
 impl Decodable for GetTelemetrySubscriptionsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!(
-                "GetTelemetrySubscriptionsResponse v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;

--- a/src/messages/get_telemetry_subscriptions_response.rs
+++ b/src/messages/get_telemetry_subscriptions_response.rs
@@ -167,6 +167,12 @@ impl GetTelemetrySubscriptionsResponse {
 #[cfg(feature = "broker")]
 impl Encodable for GetTelemetrySubscriptionsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!(
+                "GetTelemetrySubscriptionsResponse v{} is not supported",
+                version
+            );
+        }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
         types::Uuid.encode(buf, &self.client_instance_id)?;
@@ -218,6 +224,12 @@ impl Encodable for GetTelemetrySubscriptionsResponse {
 #[cfg(feature = "client")]
 impl Decodable for GetTelemetrySubscriptionsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!(
+                "GetTelemetrySubscriptionsResponse v{} is not supported",
+                version
+            );
+        }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let client_instance_id = types::Uuid.decode(buf)?;

--- a/src/messages/heartbeat_request.rs
+++ b/src/messages/heartbeat_request.rs
@@ -97,6 +97,9 @@ impl HeartbeatRequest {
 #[cfg(feature = "client")]
 impl Encodable for HeartbeatRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 4 {
+            bail!("HeartbeatRequest v{} is not supported", version);
+        }
         if version >= 4 {
             types::CompactString.encode(buf, &self.group_id)?;
         } else {
@@ -176,6 +179,9 @@ impl Encodable for HeartbeatRequest {
 #[cfg(feature = "broker")]
 impl Decodable for HeartbeatRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 4 {
+            bail!("HeartbeatRequest v{} is not supported", version);
+        }
         let group_id = if version >= 4 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/heartbeat_request.rs
+++ b/src/messages/heartbeat_request.rs
@@ -98,7 +98,7 @@ impl HeartbeatRequest {
 impl Encodable for HeartbeatRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 4 {
-            bail!("HeartbeatRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 4 {
             types::CompactString.encode(buf, &self.group_id)?;
@@ -180,7 +180,7 @@ impl Encodable for HeartbeatRequest {
 impl Decodable for HeartbeatRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 4 {
-            bail!("HeartbeatRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let group_id = if version >= 4 {
             types::CompactString.decode(buf)?

--- a/src/messages/heartbeat_response.rs
+++ b/src/messages/heartbeat_response.rs
@@ -69,6 +69,9 @@ impl HeartbeatResponse {
 #[cfg(feature = "broker")]
 impl Encodable for HeartbeatResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 4 {
+            bail!("HeartbeatResponse v{} is not supported", version);
+        }
         if version >= 1 {
             types::Int32.encode(buf, &self.throttle_time_ms)?;
         }
@@ -112,6 +115,9 @@ impl Encodable for HeartbeatResponse {
 #[cfg(feature = "client")]
 impl Decodable for HeartbeatResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 4 {
+            bail!("HeartbeatResponse v{} is not supported", version);
+        }
         let throttle_time_ms = if version >= 1 {
             types::Int32.decode(buf)?
         } else {

--- a/src/messages/heartbeat_response.rs
+++ b/src/messages/heartbeat_response.rs
@@ -70,7 +70,7 @@ impl HeartbeatResponse {
 impl Encodable for HeartbeatResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 4 {
-            bail!("HeartbeatResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 1 {
             types::Int32.encode(buf, &self.throttle_time_ms)?;
@@ -116,7 +116,7 @@ impl Encodable for HeartbeatResponse {
 impl Decodable for HeartbeatResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 4 {
-            bail!("HeartbeatResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = if version >= 1 {
             types::Int32.decode(buf)?

--- a/src/messages/incremental_alter_configs_request.rs
+++ b/src/messages/incremental_alter_configs_request.rs
@@ -84,7 +84,7 @@ impl AlterConfigsResource {
 impl Encodable for AlterConfigsResource {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("AlterConfigsResource v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int8.encode(buf, &self.resource_type)?;
         if version >= 1 {
@@ -145,7 +145,7 @@ impl Encodable for AlterConfigsResource {
 impl Decodable for AlterConfigsResource {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("AlterConfigsResource v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let resource_type = types::Int8.decode(buf)?;
         let resource_name = if version >= 1 {
@@ -260,7 +260,7 @@ impl AlterableConfig {
 impl Encodable for AlterableConfig {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("AlterableConfig v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 1 {
             types::CompactString.encode(buf, &self.name)?;
@@ -320,7 +320,7 @@ impl Encodable for AlterableConfig {
 impl Decodable for AlterableConfig {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("AlterableConfig v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = if version >= 1 {
             types::CompactString.decode(buf)?
@@ -421,10 +421,7 @@ impl IncrementalAlterConfigsRequest {
 impl Encodable for IncrementalAlterConfigsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!(
-                "IncrementalAlterConfigsRequest v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         if version >= 1 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.resources)?;
@@ -475,10 +472,7 @@ impl Encodable for IncrementalAlterConfigsRequest {
 impl Decodable for IncrementalAlterConfigsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!(
-                "IncrementalAlterConfigsRequest v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         let resources = if version >= 1 {
             types::CompactArray(types::Struct { version }).decode(buf)?

--- a/src/messages/incremental_alter_configs_request.rs
+++ b/src/messages/incremental_alter_configs_request.rs
@@ -83,6 +83,9 @@ impl AlterConfigsResource {
 #[cfg(feature = "client")]
 impl Encodable for AlterConfigsResource {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("AlterConfigsResource v{} is not supported", version);
+        }
         types::Int8.encode(buf, &self.resource_type)?;
         if version >= 1 {
             types::CompactString.encode(buf, &self.resource_name)?;
@@ -141,6 +144,9 @@ impl Encodable for AlterConfigsResource {
 #[cfg(feature = "broker")]
 impl Decodable for AlterConfigsResource {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("AlterConfigsResource v{} is not supported", version);
+        }
         let resource_type = types::Int8.decode(buf)?;
         let resource_name = if version >= 1 {
             types::CompactString.decode(buf)?
@@ -253,6 +259,9 @@ impl AlterableConfig {
 #[cfg(feature = "client")]
 impl Encodable for AlterableConfig {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("AlterableConfig v{} is not supported", version);
+        }
         if version >= 1 {
             types::CompactString.encode(buf, &self.name)?;
         } else {
@@ -310,6 +319,9 @@ impl Encodable for AlterableConfig {
 #[cfg(feature = "broker")]
 impl Decodable for AlterableConfig {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("AlterableConfig v{} is not supported", version);
+        }
         let name = if version >= 1 {
             types::CompactString.decode(buf)?
         } else {
@@ -408,6 +420,12 @@ impl IncrementalAlterConfigsRequest {
 #[cfg(feature = "client")]
 impl Encodable for IncrementalAlterConfigsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!(
+                "IncrementalAlterConfigsRequest v{} is not supported",
+                version
+            );
+        }
         if version >= 1 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.resources)?;
         } else {
@@ -456,6 +474,12 @@ impl Encodable for IncrementalAlterConfigsRequest {
 #[cfg(feature = "broker")]
 impl Decodable for IncrementalAlterConfigsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!(
+                "IncrementalAlterConfigsRequest v{} is not supported",
+                version
+            );
+        }
         let resources = if version >= 1 {
             types::CompactArray(types::Struct { version }).decode(buf)?
         } else {

--- a/src/messages/incremental_alter_configs_response.rs
+++ b/src/messages/incremental_alter_configs_response.rs
@@ -98,7 +98,7 @@ impl AlterConfigsResourceResponse {
 impl Encodable for AlterConfigsResourceResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("AlterConfigsResourceResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 1 {
@@ -160,7 +160,7 @@ impl Encodable for AlterConfigsResourceResponse {
 impl Decodable for AlterConfigsResourceResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("AlterConfigsResourceResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let error_code = types::Int16.decode(buf)?;
         let error_message = if version >= 1 {
@@ -264,10 +264,7 @@ impl IncrementalAlterConfigsResponse {
 impl Encodable for IncrementalAlterConfigsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!(
-                "IncrementalAlterConfigsResponse v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         if version >= 1 {
@@ -318,10 +315,7 @@ impl Encodable for IncrementalAlterConfigsResponse {
 impl Decodable for IncrementalAlterConfigsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!(
-                "IncrementalAlterConfigsResponse v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let responses = if version >= 1 {

--- a/src/messages/incremental_alter_configs_response.rs
+++ b/src/messages/incremental_alter_configs_response.rs
@@ -97,6 +97,9 @@ impl AlterConfigsResourceResponse {
 #[cfg(feature = "broker")]
 impl Encodable for AlterConfigsResourceResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("AlterConfigsResourceResponse v{} is not supported", version);
+        }
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 1 {
             types::CompactString.encode(buf, &self.error_message)?;
@@ -156,6 +159,9 @@ impl Encodable for AlterConfigsResourceResponse {
 #[cfg(feature = "client")]
 impl Decodable for AlterConfigsResourceResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("AlterConfigsResourceResponse v{} is not supported", version);
+        }
         let error_code = types::Int16.decode(buf)?;
         let error_message = if version >= 1 {
             types::CompactString.decode(buf)?
@@ -257,6 +263,12 @@ impl IncrementalAlterConfigsResponse {
 #[cfg(feature = "broker")]
 impl Encodable for IncrementalAlterConfigsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!(
+                "IncrementalAlterConfigsResponse v{} is not supported",
+                version
+            );
+        }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         if version >= 1 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.responses)?;
@@ -305,6 +317,12 @@ impl Encodable for IncrementalAlterConfigsResponse {
 #[cfg(feature = "client")]
 impl Decodable for IncrementalAlterConfigsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!(
+                "IncrementalAlterConfigsResponse v{} is not supported",
+                version
+            );
+        }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let responses = if version >= 1 {
             types::CompactArray(types::Struct { version }).decode(buf)?

--- a/src/messages/init_producer_id_request.rs
+++ b/src/messages/init_producer_id_request.rs
@@ -98,7 +98,7 @@ impl InitProducerIdRequest {
 impl Encodable for InitProducerIdRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 5 {
-            bail!("InitProducerIdRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 2 {
             types::CompactString.encode(buf, &self.transactional_id)?;
@@ -176,7 +176,7 @@ impl Encodable for InitProducerIdRequest {
 impl Decodable for InitProducerIdRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 5 {
-            bail!("InitProducerIdRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let transactional_id = if version >= 2 {
             types::CompactString.decode(buf)?

--- a/src/messages/init_producer_id_request.rs
+++ b/src/messages/init_producer_id_request.rs
@@ -97,6 +97,9 @@ impl InitProducerIdRequest {
 #[cfg(feature = "client")]
 impl Encodable for InitProducerIdRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 5 {
+            bail!("InitProducerIdRequest v{} is not supported", version);
+        }
         if version >= 2 {
             types::CompactString.encode(buf, &self.transactional_id)?;
         } else {
@@ -172,6 +175,9 @@ impl Encodable for InitProducerIdRequest {
 #[cfg(feature = "broker")]
 impl Decodable for InitProducerIdRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 5 {
+            bail!("InitProducerIdRequest v{} is not supported", version);
+        }
         let transactional_id = if version >= 2 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/init_producer_id_response.rs
+++ b/src/messages/init_producer_id_response.rs
@@ -98,7 +98,7 @@ impl InitProducerIdResponse {
 impl Encodable for InitProducerIdResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 5 {
-            bail!("InitProducerIdResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -144,7 +144,7 @@ impl Encodable for InitProducerIdResponse {
 impl Decodable for InitProducerIdResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 5 {
-            bail!("InitProducerIdResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;

--- a/src/messages/init_producer_id_response.rs
+++ b/src/messages/init_producer_id_response.rs
@@ -97,6 +97,9 @@ impl InitProducerIdResponse {
 #[cfg(feature = "broker")]
 impl Encodable for InitProducerIdResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 5 {
+            bail!("InitProducerIdResponse v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
         types::Int64.encode(buf, &self.producer_id)?;
@@ -140,6 +143,9 @@ impl Encodable for InitProducerIdResponse {
 #[cfg(feature = "client")]
 impl Decodable for InitProducerIdResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 5 {
+            bail!("InitProducerIdResponse v{} is not supported", version);
+        }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let producer_id = types::Int64.decode(buf)?;

--- a/src/messages/join_group_request.rs
+++ b/src/messages/join_group_request.rs
@@ -153,6 +153,9 @@ impl JoinGroupRequest {
 #[cfg(feature = "client")]
 impl Encodable for JoinGroupRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 9 {
+            bail!("JoinGroupRequest v{} is not supported", version);
+        }
         if version >= 6 {
             types::CompactString.encode(buf, &self.group_id)?;
         } else {
@@ -265,6 +268,9 @@ impl Encodable for JoinGroupRequest {
 #[cfg(feature = "broker")]
 impl Decodable for JoinGroupRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 9 {
+            bail!("JoinGroupRequest v{} is not supported", version);
+        }
         let group_id = if version >= 6 {
             types::CompactString.decode(buf)?
         } else {
@@ -402,6 +408,9 @@ impl JoinGroupRequestProtocol {
 #[cfg(feature = "client")]
 impl Encodable for JoinGroupRequestProtocol {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 9 {
+            bail!("JoinGroupRequestProtocol v{} is not supported", version);
+        }
         if version >= 6 {
             types::CompactString.encode(buf, &self.name)?;
         } else {
@@ -457,6 +466,9 @@ impl Encodable for JoinGroupRequestProtocol {
 #[cfg(feature = "broker")]
 impl Decodable for JoinGroupRequestProtocol {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 9 {
+            bail!("JoinGroupRequestProtocol v{} is not supported", version);
+        }
         let name = if version >= 6 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/join_group_request.rs
+++ b/src/messages/join_group_request.rs
@@ -154,7 +154,7 @@ impl JoinGroupRequest {
 impl Encodable for JoinGroupRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 9 {
-            bail!("JoinGroupRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 6 {
             types::CompactString.encode(buf, &self.group_id)?;
@@ -269,7 +269,7 @@ impl Encodable for JoinGroupRequest {
 impl Decodable for JoinGroupRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 9 {
-            bail!("JoinGroupRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let group_id = if version >= 6 {
             types::CompactString.decode(buf)?
@@ -409,7 +409,7 @@ impl JoinGroupRequestProtocol {
 impl Encodable for JoinGroupRequestProtocol {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 9 {
-            bail!("JoinGroupRequestProtocol v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 6 {
             types::CompactString.encode(buf, &self.name)?;
@@ -467,7 +467,7 @@ impl Encodable for JoinGroupRequestProtocol {
 impl Decodable for JoinGroupRequestProtocol {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 9 {
-            bail!("JoinGroupRequestProtocol v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = if version >= 6 {
             types::CompactString.decode(buf)?

--- a/src/messages/join_group_response.rs
+++ b/src/messages/join_group_response.rs
@@ -168,7 +168,7 @@ impl JoinGroupResponse {
 impl Encodable for JoinGroupResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 9 {
-            bail!("JoinGroupResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 2 {
             types::Int32.encode(buf, &self.throttle_time_ms)?;
@@ -277,7 +277,7 @@ impl Encodable for JoinGroupResponse {
 impl Decodable for JoinGroupResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 9 {
-            bail!("JoinGroupResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = if version >= 2 {
             types::Int32.decode(buf)?
@@ -430,7 +430,7 @@ impl JoinGroupResponseMember {
 impl Encodable for JoinGroupResponseMember {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 9 {
-            bail!("JoinGroupResponseMember v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 6 {
             types::CompactString.encode(buf, &self.member_id)?;
@@ -502,7 +502,7 @@ impl Encodable for JoinGroupResponseMember {
 impl Decodable for JoinGroupResponseMember {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 9 {
-            bail!("JoinGroupResponseMember v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let member_id = if version >= 6 {
             types::CompactString.decode(buf)?

--- a/src/messages/join_group_response.rs
+++ b/src/messages/join_group_response.rs
@@ -167,6 +167,9 @@ impl JoinGroupResponse {
 #[cfg(feature = "broker")]
 impl Encodable for JoinGroupResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 9 {
+            bail!("JoinGroupResponse v{} is not supported", version);
+        }
         if version >= 2 {
             types::Int32.encode(buf, &self.throttle_time_ms)?;
         }
@@ -273,6 +276,9 @@ impl Encodable for JoinGroupResponse {
 #[cfg(feature = "client")]
 impl Decodable for JoinGroupResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 9 {
+            bail!("JoinGroupResponse v{} is not supported", version);
+        }
         let throttle_time_ms = if version >= 2 {
             types::Int32.decode(buf)?
         } else {
@@ -423,6 +429,9 @@ impl JoinGroupResponseMember {
 #[cfg(feature = "broker")]
 impl Encodable for JoinGroupResponseMember {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 9 {
+            bail!("JoinGroupResponseMember v{} is not supported", version);
+        }
         if version >= 6 {
             types::CompactString.encode(buf, &self.member_id)?;
         } else {
@@ -492,6 +501,9 @@ impl Encodable for JoinGroupResponseMember {
 #[cfg(feature = "client")]
 impl Decodable for JoinGroupResponseMember {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 9 {
+            bail!("JoinGroupResponseMember v{} is not supported", version);
+        }
         let member_id = if version >= 6 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/k_raft_version_record.rs
+++ b/src/messages/k_raft_version_record.rs
@@ -68,6 +68,9 @@ impl KRaftVersionRecord {
 
 impl Encodable for KRaftVersionRecord {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("KRaftVersionRecord v{} is not supported", version);
+        }
         types::Int16.encode(buf, &self.version)?;
         types::Int16.encode(buf, &self.k_raft_version)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -102,6 +105,9 @@ impl Encodable for KRaftVersionRecord {
 
 impl Decodable for KRaftVersionRecord {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("KRaftVersionRecord v{} is not supported", version);
+        }
         let version = types::Int16.decode(buf)?;
         let k_raft_version = types::Int16.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();

--- a/src/messages/k_raft_version_record.rs
+++ b/src/messages/k_raft_version_record.rs
@@ -69,7 +69,7 @@ impl KRaftVersionRecord {
 impl Encodable for KRaftVersionRecord {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("KRaftVersionRecord v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int16.encode(buf, &self.version)?;
         types::Int16.encode(buf, &self.k_raft_version)?;
@@ -106,7 +106,7 @@ impl Encodable for KRaftVersionRecord {
 impl Decodable for KRaftVersionRecord {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("KRaftVersionRecord v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let version = types::Int16.decode(buf)?;
         let k_raft_version = types::Int16.decode(buf)?;

--- a/src/messages/leader_and_isr_request.rs
+++ b/src/messages/leader_and_isr_request.rs
@@ -83,6 +83,9 @@ impl LeaderAndIsrLiveLeader {
 #[cfg(feature = "client")]
 impl Encodable for LeaderAndIsrLiveLeader {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 7 {
+            bail!("LeaderAndIsrLiveLeader v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.broker_id)?;
         if version >= 4 {
             types::CompactString.encode(buf, &self.host_name)?;
@@ -132,6 +135,9 @@ impl Encodable for LeaderAndIsrLiveLeader {
 #[cfg(feature = "broker")]
 impl Decodable for LeaderAndIsrLiveLeader {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 7 {
+            bail!("LeaderAndIsrLiveLeader v{} is not supported", version);
+        }
         let broker_id = types::Int32.decode(buf)?;
         let host_name = if version >= 4 {
             types::CompactString.decode(buf)?
@@ -366,6 +372,9 @@ impl LeaderAndIsrPartitionState {
 #[cfg(feature = "client")]
 impl Encodable for LeaderAndIsrPartitionState {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 7 {
+            bail!("LeaderAndIsrPartitionState v{} is not supported", version);
+        }
         if version <= 1 {
             types::String.encode(buf, &self.topic_name)?;
         }
@@ -487,6 +496,9 @@ impl Encodable for LeaderAndIsrPartitionState {
 #[cfg(feature = "broker")]
 impl Decodable for LeaderAndIsrPartitionState {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 7 {
+            bail!("LeaderAndIsrPartitionState v{} is not supported", version);
+        }
         let topic_name = if version <= 1 {
             types::String.decode(buf)?
         } else {
@@ -727,6 +739,9 @@ impl LeaderAndIsrRequest {
 #[cfg(feature = "client")]
 impl Encodable for LeaderAndIsrRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 7 {
+            bail!("LeaderAndIsrRequest v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.controller_id)?;
         if version >= 7 {
             types::Boolean.encode(buf, &self.is_k_raft_controller)?;
@@ -852,6 +867,9 @@ impl Encodable for LeaderAndIsrRequest {
 #[cfg(feature = "broker")]
 impl Decodable for LeaderAndIsrRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 7 {
+            bail!("LeaderAndIsrRequest v{} is not supported", version);
+        }
         let controller_id = types::Int32.decode(buf)?;
         let is_k_raft_controller = if version >= 7 {
             types::Boolean.decode(buf)?
@@ -999,6 +1017,9 @@ impl LeaderAndIsrTopicState {
 #[cfg(feature = "client")]
 impl Encodable for LeaderAndIsrTopicState {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 7 {
+            bail!("LeaderAndIsrTopicState v{} is not supported", version);
+        }
         if version >= 2 {
             if version >= 4 {
                 types::CompactString.encode(buf, &self.topic_name)?;
@@ -1087,6 +1108,9 @@ impl Encodable for LeaderAndIsrTopicState {
 #[cfg(feature = "broker")]
 impl Decodable for LeaderAndIsrTopicState {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 7 {
+            bail!("LeaderAndIsrTopicState v{} is not supported", version);
+        }
         let topic_name = if version >= 2 {
             if version >= 4 {
                 types::CompactString.decode(buf)?

--- a/src/messages/leader_and_isr_request.rs
+++ b/src/messages/leader_and_isr_request.rs
@@ -84,7 +84,7 @@ impl LeaderAndIsrLiveLeader {
 impl Encodable for LeaderAndIsrLiveLeader {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 7 {
-            bail!("LeaderAndIsrLiveLeader v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.broker_id)?;
         if version >= 4 {
@@ -136,7 +136,7 @@ impl Encodable for LeaderAndIsrLiveLeader {
 impl Decodable for LeaderAndIsrLiveLeader {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 7 {
-            bail!("LeaderAndIsrLiveLeader v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let broker_id = types::Int32.decode(buf)?;
         let host_name = if version >= 4 {
@@ -373,7 +373,7 @@ impl LeaderAndIsrPartitionState {
 impl Encodable for LeaderAndIsrPartitionState {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 7 {
-            bail!("LeaderAndIsrPartitionState v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version <= 1 {
             types::String.encode(buf, &self.topic_name)?;
@@ -497,7 +497,7 @@ impl Encodable for LeaderAndIsrPartitionState {
 impl Decodable for LeaderAndIsrPartitionState {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 7 {
-            bail!("LeaderAndIsrPartitionState v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topic_name = if version <= 1 {
             types::String.decode(buf)?
@@ -740,7 +740,7 @@ impl LeaderAndIsrRequest {
 impl Encodable for LeaderAndIsrRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 7 {
-            bail!("LeaderAndIsrRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.controller_id)?;
         if version >= 7 {
@@ -868,7 +868,7 @@ impl Encodable for LeaderAndIsrRequest {
 impl Decodable for LeaderAndIsrRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 7 {
-            bail!("LeaderAndIsrRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let controller_id = types::Int32.decode(buf)?;
         let is_k_raft_controller = if version >= 7 {
@@ -1018,7 +1018,7 @@ impl LeaderAndIsrTopicState {
 impl Encodable for LeaderAndIsrTopicState {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 7 {
-            bail!("LeaderAndIsrTopicState v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 2 {
             if version >= 4 {
@@ -1109,7 +1109,7 @@ impl Encodable for LeaderAndIsrTopicState {
 impl Decodable for LeaderAndIsrTopicState {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 7 {
-            bail!("LeaderAndIsrTopicState v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topic_name = if version >= 2 {
             if version >= 4 {

--- a/src/messages/leader_and_isr_response.rs
+++ b/src/messages/leader_and_isr_response.rs
@@ -83,6 +83,9 @@ impl LeaderAndIsrPartitionError {
 #[cfg(feature = "broker")]
 impl Encodable for LeaderAndIsrPartitionError {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 7 {
+            bail!("LeaderAndIsrPartitionError v{} is not supported", version);
+        }
         if version <= 4 {
             if version >= 4 {
                 types::CompactString.encode(buf, &self.topic_name)?;
@@ -136,6 +139,9 @@ impl Encodable for LeaderAndIsrPartitionError {
 #[cfg(feature = "client")]
 impl Decodable for LeaderAndIsrPartitionError {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 7 {
+            bail!("LeaderAndIsrPartitionError v{} is not supported", version);
+        }
         let topic_name = if version <= 4 {
             if version >= 4 {
                 types::CompactString.decode(buf)?
@@ -248,6 +254,9 @@ impl LeaderAndIsrResponse {
 #[cfg(feature = "broker")]
 impl Encodable for LeaderAndIsrResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 7 {
+            bail!("LeaderAndIsrResponse v{} is not supported", version);
+        }
         types::Int16.encode(buf, &self.error_code)?;
         if version <= 4 {
             if version >= 4 {
@@ -325,6 +334,9 @@ impl Encodable for LeaderAndIsrResponse {
 #[cfg(feature = "client")]
 impl Decodable for LeaderAndIsrResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 7 {
+            bail!("LeaderAndIsrResponse v{} is not supported", version);
+        }
         let error_code = types::Int16.decode(buf)?;
         let partition_errors = if version <= 4 {
             if version >= 4 {
@@ -427,6 +439,9 @@ impl LeaderAndIsrTopicError {
 #[cfg(feature = "broker")]
 impl Encodable for LeaderAndIsrTopicError {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 7 {
+            bail!("LeaderAndIsrTopicError v{} is not supported", version);
+        }
         if version >= 5 {
             types::Uuid.encode(buf, &self.topic_id)?;
         } else {
@@ -491,6 +506,9 @@ impl Encodable for LeaderAndIsrTopicError {
 #[cfg(feature = "client")]
 impl Decodable for LeaderAndIsrTopicError {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 7 {
+            bail!("LeaderAndIsrTopicError v{} is not supported", version);
+        }
         let topic_id = if version >= 5 {
             types::Uuid.decode(buf)?
         } else {

--- a/src/messages/leader_and_isr_response.rs
+++ b/src/messages/leader_and_isr_response.rs
@@ -84,7 +84,7 @@ impl LeaderAndIsrPartitionError {
 impl Encodable for LeaderAndIsrPartitionError {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 7 {
-            bail!("LeaderAndIsrPartitionError v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version <= 4 {
             if version >= 4 {
@@ -140,7 +140,7 @@ impl Encodable for LeaderAndIsrPartitionError {
 impl Decodable for LeaderAndIsrPartitionError {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 7 {
-            bail!("LeaderAndIsrPartitionError v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topic_name = if version <= 4 {
             if version >= 4 {
@@ -255,7 +255,7 @@ impl LeaderAndIsrResponse {
 impl Encodable for LeaderAndIsrResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 7 {
-            bail!("LeaderAndIsrResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int16.encode(buf, &self.error_code)?;
         if version <= 4 {
@@ -335,7 +335,7 @@ impl Encodable for LeaderAndIsrResponse {
 impl Decodable for LeaderAndIsrResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 7 {
-            bail!("LeaderAndIsrResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let error_code = types::Int16.decode(buf)?;
         let partition_errors = if version <= 4 {
@@ -440,7 +440,7 @@ impl LeaderAndIsrTopicError {
 impl Encodable for LeaderAndIsrTopicError {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 7 {
-            bail!("LeaderAndIsrTopicError v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 5 {
             types::Uuid.encode(buf, &self.topic_id)?;
@@ -507,7 +507,7 @@ impl Encodable for LeaderAndIsrTopicError {
 impl Decodable for LeaderAndIsrTopicError {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 7 {
-            bail!("LeaderAndIsrTopicError v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topic_id = if version >= 5 {
             types::Uuid.decode(buf)?

--- a/src/messages/leader_change_message.rs
+++ b/src/messages/leader_change_message.rs
@@ -97,7 +97,7 @@ impl LeaderChangeMessage {
 impl Encodable for LeaderChangeMessage {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("LeaderChangeMessage v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int16.encode(buf, &self.version)?;
         types::Int32.encode(buf, &self.leader_id)?;
@@ -139,7 +139,7 @@ impl Encodable for LeaderChangeMessage {
 impl Decodable for LeaderChangeMessage {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("LeaderChangeMessage v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let version = types::Int16.decode(buf)?;
         let leader_id = types::Int32.decode(buf)?;
@@ -232,7 +232,7 @@ impl Voter {
 impl Encodable for Voter {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("Voter v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.voter_id)?;
         if version >= 1 {
@@ -281,7 +281,7 @@ impl Encodable for Voter {
 impl Decodable for Voter {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("Voter v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let voter_id = types::Int32.decode(buf)?;
         let voter_directory_id = if version >= 1 {

--- a/src/messages/leader_change_message.rs
+++ b/src/messages/leader_change_message.rs
@@ -96,6 +96,9 @@ impl LeaderChangeMessage {
 
 impl Encodable for LeaderChangeMessage {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("LeaderChangeMessage v{} is not supported", version);
+        }
         types::Int16.encode(buf, &self.version)?;
         types::Int32.encode(buf, &self.leader_id)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.voters)?;
@@ -135,6 +138,9 @@ impl Encodable for LeaderChangeMessage {
 
 impl Decodable for LeaderChangeMessage {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("LeaderChangeMessage v{} is not supported", version);
+        }
         let version = types::Int16.decode(buf)?;
         let leader_id = types::Int32.decode(buf)?;
         let voters = types::CompactArray(types::Struct { version }).decode(buf)?;
@@ -225,6 +231,9 @@ impl Voter {
 
 impl Encodable for Voter {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("Voter v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.voter_id)?;
         if version >= 1 {
             types::Uuid.encode(buf, &self.voter_directory_id)?;
@@ -271,6 +280,9 @@ impl Encodable for Voter {
 
 impl Decodable for Voter {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("Voter v{} is not supported", version);
+        }
         let voter_id = types::Int32.decode(buf)?;
         let voter_directory_id = if version >= 1 {
             types::Uuid.decode(buf)?

--- a/src/messages/leave_group_request.rs
+++ b/src/messages/leave_group_request.rs
@@ -83,6 +83,9 @@ impl LeaveGroupRequest {
 #[cfg(feature = "client")]
 impl Encodable for LeaveGroupRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 5 {
+            bail!("LeaveGroupRequest v{} is not supported", version);
+        }
         if version >= 4 {
             types::CompactString.encode(buf, &self.group_id)?;
         } else {
@@ -166,6 +169,9 @@ impl Encodable for LeaveGroupRequest {
 #[cfg(feature = "broker")]
 impl Decodable for LeaveGroupRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 5 {
+            bail!("LeaveGroupRequest v{} is not supported", version);
+        }
         let group_id = if version >= 4 {
             types::CompactString.decode(buf)?
         } else {
@@ -286,6 +292,9 @@ impl MemberIdentity {
 #[cfg(feature = "client")]
 impl Encodable for MemberIdentity {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 5 {
+            bail!("MemberIdentity v{} is not supported", version);
+        }
         if version >= 3 {
             if version >= 4 {
                 types::CompactString.encode(buf, &self.member_id)?;
@@ -371,6 +380,9 @@ impl Encodable for MemberIdentity {
 #[cfg(feature = "broker")]
 impl Decodable for MemberIdentity {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 5 {
+            bail!("MemberIdentity v{} is not supported", version);
+        }
         let member_id = if version >= 3 {
             if version >= 4 {
                 types::CompactString.decode(buf)?

--- a/src/messages/leave_group_request.rs
+++ b/src/messages/leave_group_request.rs
@@ -84,7 +84,7 @@ impl LeaveGroupRequest {
 impl Encodable for LeaveGroupRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 5 {
-            bail!("LeaveGroupRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 4 {
             types::CompactString.encode(buf, &self.group_id)?;
@@ -170,7 +170,7 @@ impl Encodable for LeaveGroupRequest {
 impl Decodable for LeaveGroupRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 5 {
-            bail!("LeaveGroupRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let group_id = if version >= 4 {
             types::CompactString.decode(buf)?
@@ -293,7 +293,7 @@ impl MemberIdentity {
 impl Encodable for MemberIdentity {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 5 {
-            bail!("MemberIdentity v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 3 {
             if version >= 4 {
@@ -381,7 +381,7 @@ impl Encodable for MemberIdentity {
 impl Decodable for MemberIdentity {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 5 {
-            bail!("MemberIdentity v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let member_id = if version >= 3 {
             if version >= 4 {

--- a/src/messages/leave_group_response.rs
+++ b/src/messages/leave_group_response.rs
@@ -84,7 +84,7 @@ impl LeaveGroupResponse {
 impl Encodable for LeaveGroupResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 5 {
-            bail!("LeaveGroupResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 1 {
             types::Int32.encode(buf, &self.throttle_time_ms)?;
@@ -154,7 +154,7 @@ impl Encodable for LeaveGroupResponse {
 impl Decodable for LeaveGroupResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 5 {
-            bail!("LeaveGroupResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = if version >= 1 {
             types::Int32.decode(buf)?
@@ -273,7 +273,7 @@ impl MemberResponse {
 impl Encodable for MemberResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 5 {
-            bail!("MemberResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 3 {
             if version >= 4 {
@@ -379,7 +379,7 @@ impl Encodable for MemberResponse {
 impl Decodable for MemberResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 5 {
-            bail!("MemberResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let member_id = if version >= 3 {
             if version >= 4 {

--- a/src/messages/leave_group_response.rs
+++ b/src/messages/leave_group_response.rs
@@ -83,6 +83,9 @@ impl LeaveGroupResponse {
 #[cfg(feature = "broker")]
 impl Encodable for LeaveGroupResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 5 {
+            bail!("LeaveGroupResponse v{} is not supported", version);
+        }
         if version >= 1 {
             types::Int32.encode(buf, &self.throttle_time_ms)?;
         }
@@ -150,6 +153,9 @@ impl Encodable for LeaveGroupResponse {
 #[cfg(feature = "client")]
 impl Decodable for LeaveGroupResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 5 {
+            bail!("LeaveGroupResponse v{} is not supported", version);
+        }
         let throttle_time_ms = if version >= 1 {
             types::Int32.decode(buf)?
         } else {
@@ -266,6 +272,9 @@ impl MemberResponse {
 #[cfg(feature = "broker")]
 impl Encodable for MemberResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 5 {
+            bail!("MemberResponse v{} is not supported", version);
+        }
         if version >= 3 {
             if version >= 4 {
                 types::CompactString.encode(buf, &self.member_id)?;
@@ -369,6 +378,9 @@ impl Encodable for MemberResponse {
 #[cfg(feature = "client")]
 impl Decodable for MemberResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 5 {
+            bail!("MemberResponse v{} is not supported", version);
+        }
         let member_id = if version >= 3 {
             if version >= 4 {
                 types::CompactString.decode(buf)?

--- a/src/messages/list_client_metrics_resources_request.rs
+++ b/src/messages/list_client_metrics_resources_request.rs
@@ -42,10 +42,7 @@ impl ListClientMetricsResourcesRequest {
 impl Encodable for ListClientMetricsResourcesRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!(
-                "ListClientMetricsResourcesRequest v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
@@ -79,10 +76,7 @@ impl Encodable for ListClientMetricsResourcesRequest {
 impl Decodable for ListClientMetricsResourcesRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!(
-                "ListClientMetricsResourcesRequest v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         let mut unknown_tagged_fields = BTreeMap::new();
         let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;

--- a/src/messages/list_client_metrics_resources_request.rs
+++ b/src/messages/list_client_metrics_resources_request.rs
@@ -41,6 +41,12 @@ impl ListClientMetricsResourcesRequest {
 #[cfg(feature = "client")]
 impl Encodable for ListClientMetricsResourcesRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!(
+                "ListClientMetricsResourcesRequest v{} is not supported",
+                version
+            );
+        }
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
             bail!(
@@ -72,6 +78,12 @@ impl Encodable for ListClientMetricsResourcesRequest {
 #[cfg(feature = "broker")]
 impl Decodable for ListClientMetricsResourcesRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!(
+                "ListClientMetricsResourcesRequest v{} is not supported",
+                version
+            );
+        }
         let mut unknown_tagged_fields = BTreeMap::new();
         let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
         for _ in 0..num_tagged_fields {

--- a/src/messages/list_client_metrics_resources_response.rs
+++ b/src/messages/list_client_metrics_resources_response.rs
@@ -55,6 +55,9 @@ impl ClientMetricsResource {
 #[cfg(feature = "broker")]
 impl Encodable for ClientMetricsResource {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("ClientMetricsResource v{} is not supported", version);
+        }
         types::CompactString.encode(buf, &self.name)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
@@ -88,6 +91,9 @@ impl Encodable for ClientMetricsResource {
 #[cfg(feature = "client")]
 impl Decodable for ClientMetricsResource {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("ClientMetricsResource v{} is not supported", version);
+        }
         let name = types::CompactString.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
         let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;
@@ -184,6 +190,12 @@ impl ListClientMetricsResourcesResponse {
 #[cfg(feature = "broker")]
 impl Encodable for ListClientMetricsResourcesResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!(
+                "ListClientMetricsResourcesResponse v{} is not supported",
+                version
+            );
+        }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
         types::CompactArray(types::Struct { version })
@@ -223,6 +235,12 @@ impl Encodable for ListClientMetricsResourcesResponse {
 #[cfg(feature = "client")]
 impl Decodable for ListClientMetricsResourcesResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!(
+                "ListClientMetricsResourcesResponse v{} is not supported",
+                version
+            );
+        }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let client_metrics_resources =

--- a/src/messages/list_client_metrics_resources_response.rs
+++ b/src/messages/list_client_metrics_resources_response.rs
@@ -56,7 +56,7 @@ impl ClientMetricsResource {
 impl Encodable for ClientMetricsResource {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("ClientMetricsResource v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::CompactString.encode(buf, &self.name)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -92,7 +92,7 @@ impl Encodable for ClientMetricsResource {
 impl Decodable for ClientMetricsResource {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("ClientMetricsResource v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = types::CompactString.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
@@ -191,10 +191,7 @@ impl ListClientMetricsResourcesResponse {
 impl Encodable for ListClientMetricsResourcesResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!(
-                "ListClientMetricsResourcesResponse v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -236,10 +233,7 @@ impl Encodable for ListClientMetricsResourcesResponse {
 impl Decodable for ListClientMetricsResourcesResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!(
-                "ListClientMetricsResourcesResponse v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;

--- a/src/messages/list_groups_request.rs
+++ b/src/messages/list_groups_request.rs
@@ -69,6 +69,9 @@ impl ListGroupsRequest {
 #[cfg(feature = "client")]
 impl Encodable for ListGroupsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 5 {
+            bail!("ListGroupsRequest v{} is not supported", version);
+        }
         if version >= 4 {
             types::CompactArray(types::CompactString).encode(buf, &self.states_filter)?;
         } else {
@@ -134,6 +137,9 @@ impl Encodable for ListGroupsRequest {
 #[cfg(feature = "broker")]
 impl Decodable for ListGroupsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 5 {
+            bail!("ListGroupsRequest v{} is not supported", version);
+        }
         let states_filter = if version >= 4 {
             types::CompactArray(types::CompactString).decode(buf)?
         } else {

--- a/src/messages/list_groups_request.rs
+++ b/src/messages/list_groups_request.rs
@@ -70,7 +70,7 @@ impl ListGroupsRequest {
 impl Encodable for ListGroupsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 5 {
-            bail!("ListGroupsRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 4 {
             types::CompactArray(types::CompactString).encode(buf, &self.states_filter)?;
@@ -138,7 +138,7 @@ impl Encodable for ListGroupsRequest {
 impl Decodable for ListGroupsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 5 {
-            bail!("ListGroupsRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let states_filter = if version >= 4 {
             types::CompactArray(types::CompactString).decode(buf)?

--- a/src/messages/list_groups_response.rs
+++ b/src/messages/list_groups_response.rs
@@ -83,6 +83,9 @@ impl ListGroupsResponse {
 #[cfg(feature = "broker")]
 impl Encodable for ListGroupsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 5 {
+            bail!("ListGroupsResponse v{} is not supported", version);
+        }
         if version >= 1 {
             types::Int32.encode(buf, &self.throttle_time_ms)?;
         }
@@ -137,6 +140,9 @@ impl Encodable for ListGroupsResponse {
 #[cfg(feature = "client")]
 impl Decodable for ListGroupsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 5 {
+            bail!("ListGroupsResponse v{} is not supported", version);
+        }
         let throttle_time_ms = if version >= 1 {
             types::Int32.decode(buf)?
         } else {
@@ -263,6 +269,9 @@ impl ListedGroup {
 #[cfg(feature = "broker")]
 impl Encodable for ListedGroup {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 5 {
+            bail!("ListedGroup v{} is not supported", version);
+        }
         if version >= 3 {
             types::CompactString.encode(buf, &self.group_id)?;
         } else {
@@ -330,6 +339,9 @@ impl Encodable for ListedGroup {
 #[cfg(feature = "client")]
 impl Decodable for ListedGroup {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 5 {
+            bail!("ListedGroup v{} is not supported", version);
+        }
         let group_id = if version >= 3 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/list_groups_response.rs
+++ b/src/messages/list_groups_response.rs
@@ -84,7 +84,7 @@ impl ListGroupsResponse {
 impl Encodable for ListGroupsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 5 {
-            bail!("ListGroupsResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 1 {
             types::Int32.encode(buf, &self.throttle_time_ms)?;
@@ -141,7 +141,7 @@ impl Encodable for ListGroupsResponse {
 impl Decodable for ListGroupsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 5 {
-            bail!("ListGroupsResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = if version >= 1 {
             types::Int32.decode(buf)?
@@ -270,7 +270,7 @@ impl ListedGroup {
 impl Encodable for ListedGroup {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 5 {
-            bail!("ListedGroup v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 3 {
             types::CompactString.encode(buf, &self.group_id)?;
@@ -340,7 +340,7 @@ impl Encodable for ListedGroup {
 impl Decodable for ListedGroup {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 5 {
-            bail!("ListedGroup v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let group_id = if version >= 3 {
             types::CompactString.decode(buf)?

--- a/src/messages/list_offsets_request.rs
+++ b/src/messages/list_offsets_request.rs
@@ -97,6 +97,9 @@ impl ListOffsetsPartition {
 #[cfg(feature = "client")]
 impl Encodable for ListOffsetsPartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 9 {
+            bail!("ListOffsetsPartition v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.partition_index)?;
         if version >= 4 {
             types::Int32.encode(buf, &self.current_leader_epoch)?;
@@ -156,6 +159,9 @@ impl Encodable for ListOffsetsPartition {
 #[cfg(feature = "broker")]
 impl Decodable for ListOffsetsPartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 9 {
+            bail!("ListOffsetsPartition v{} is not supported", version);
+        }
         let partition_index = types::Int32.decode(buf)?;
         let current_leader_epoch = if version >= 4 {
             types::Int32.decode(buf)?
@@ -271,6 +277,9 @@ impl ListOffsetsRequest {
 #[cfg(feature = "client")]
 impl Encodable for ListOffsetsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 9 {
+            bail!("ListOffsetsRequest v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.replica_id)?;
         if version >= 2 {
             types::Int8.encode(buf, &self.isolation_level)?;
@@ -333,6 +342,9 @@ impl Encodable for ListOffsetsRequest {
 #[cfg(feature = "broker")]
 impl Decodable for ListOffsetsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 9 {
+            bail!("ListOffsetsRequest v{} is not supported", version);
+        }
         let replica_id = types::Int32.decode(buf)?;
         let isolation_level = if version >= 2 {
             types::Int8.decode(buf)?
@@ -431,6 +443,9 @@ impl ListOffsetsTopic {
 #[cfg(feature = "client")]
 impl Encodable for ListOffsetsTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 9 {
+            bail!("ListOffsetsTopic v{} is not supported", version);
+        }
         if version >= 6 {
             types::CompactString.encode(buf, &self.name)?;
         } else {
@@ -487,6 +502,9 @@ impl Encodable for ListOffsetsTopic {
 #[cfg(feature = "broker")]
 impl Decodable for ListOffsetsTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 9 {
+            bail!("ListOffsetsTopic v{} is not supported", version);
+        }
         let name = if version >= 6 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/list_offsets_request.rs
+++ b/src/messages/list_offsets_request.rs
@@ -98,7 +98,7 @@ impl ListOffsetsPartition {
 impl Encodable for ListOffsetsPartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 9 {
-            bail!("ListOffsetsPartition v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.partition_index)?;
         if version >= 4 {
@@ -160,7 +160,7 @@ impl Encodable for ListOffsetsPartition {
 impl Decodable for ListOffsetsPartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 9 {
-            bail!("ListOffsetsPartition v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let partition_index = types::Int32.decode(buf)?;
         let current_leader_epoch = if version >= 4 {
@@ -278,7 +278,7 @@ impl ListOffsetsRequest {
 impl Encodable for ListOffsetsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 9 {
-            bail!("ListOffsetsRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.replica_id)?;
         if version >= 2 {
@@ -343,7 +343,7 @@ impl Encodable for ListOffsetsRequest {
 impl Decodable for ListOffsetsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 9 {
-            bail!("ListOffsetsRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let replica_id = types::Int32.decode(buf)?;
         let isolation_level = if version >= 2 {
@@ -444,7 +444,7 @@ impl ListOffsetsTopic {
 impl Encodable for ListOffsetsTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 9 {
-            bail!("ListOffsetsTopic v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 6 {
             types::CompactString.encode(buf, &self.name)?;
@@ -503,7 +503,7 @@ impl Encodable for ListOffsetsTopic {
 impl Decodable for ListOffsetsTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 9 {
-            bail!("ListOffsetsTopic v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = if version >= 6 {
             types::CompactString.decode(buf)?

--- a/src/messages/list_offsets_response.rs
+++ b/src/messages/list_offsets_response.rs
@@ -126,7 +126,7 @@ impl ListOffsetsPartitionResponse {
 impl Encodable for ListOffsetsPartitionResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 9 {
-            bail!("ListOffsetsPartitionResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -224,7 +224,7 @@ impl Encodable for ListOffsetsPartitionResponse {
 impl Decodable for ListOffsetsPartitionResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 9 {
-            bail!("ListOffsetsPartitionResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let partition_index = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
@@ -342,7 +342,7 @@ impl ListOffsetsResponse {
 impl Encodable for ListOffsetsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 9 {
-            bail!("ListOffsetsResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 2 {
             types::Int32.encode(buf, &self.throttle_time_ms)?;
@@ -397,7 +397,7 @@ impl Encodable for ListOffsetsResponse {
 impl Decodable for ListOffsetsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 9 {
-            bail!("ListOffsetsResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = if version >= 2 {
             types::Int32.decode(buf)?
@@ -495,7 +495,7 @@ impl ListOffsetsTopicResponse {
 impl Encodable for ListOffsetsTopicResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 9 {
-            bail!("ListOffsetsTopicResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 6 {
             types::CompactString.encode(buf, &self.name)?;
@@ -554,7 +554,7 @@ impl Encodable for ListOffsetsTopicResponse {
 impl Decodable for ListOffsetsTopicResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 9 {
-            bail!("ListOffsetsTopicResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = if version >= 6 {
             types::CompactString.decode(buf)?

--- a/src/messages/list_offsets_response.rs
+++ b/src/messages/list_offsets_response.rs
@@ -125,6 +125,9 @@ impl ListOffsetsPartitionResponse {
 #[cfg(feature = "broker")]
 impl Encodable for ListOffsetsPartitionResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 9 {
+            bail!("ListOffsetsPartitionResponse v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int16.encode(buf, &self.error_code)?;
         if version == 0 {
@@ -220,6 +223,9 @@ impl Encodable for ListOffsetsPartitionResponse {
 #[cfg(feature = "client")]
 impl Decodable for ListOffsetsPartitionResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 9 {
+            bail!("ListOffsetsPartitionResponse v{} is not supported", version);
+        }
         let partition_index = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let old_style_offsets = if version == 0 {
@@ -335,6 +341,9 @@ impl ListOffsetsResponse {
 #[cfg(feature = "broker")]
 impl Encodable for ListOffsetsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 9 {
+            bail!("ListOffsetsResponse v{} is not supported", version);
+        }
         if version >= 2 {
             types::Int32.encode(buf, &self.throttle_time_ms)?;
         }
@@ -387,6 +396,9 @@ impl Encodable for ListOffsetsResponse {
 #[cfg(feature = "client")]
 impl Decodable for ListOffsetsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 9 {
+            bail!("ListOffsetsResponse v{} is not supported", version);
+        }
         let throttle_time_ms = if version >= 2 {
             types::Int32.decode(buf)?
         } else {
@@ -482,6 +494,9 @@ impl ListOffsetsTopicResponse {
 #[cfg(feature = "broker")]
 impl Encodable for ListOffsetsTopicResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 9 {
+            bail!("ListOffsetsTopicResponse v{} is not supported", version);
+        }
         if version >= 6 {
             types::CompactString.encode(buf, &self.name)?;
         } else {
@@ -538,6 +553,9 @@ impl Encodable for ListOffsetsTopicResponse {
 #[cfg(feature = "client")]
 impl Decodable for ListOffsetsTopicResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 9 {
+            bail!("ListOffsetsTopicResponse v{} is not supported", version);
+        }
         let name = if version >= 6 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/list_partition_reassignments_request.rs
+++ b/src/messages/list_partition_reassignments_request.rs
@@ -69,6 +69,12 @@ impl ListPartitionReassignmentsRequest {
 #[cfg(feature = "client")]
 impl Encodable for ListPartitionReassignmentsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!(
+                "ListPartitionReassignmentsRequest v{} is not supported",
+                version
+            );
+        }
         types::Int32.encode(buf, &self.timeout_ms)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -104,6 +110,12 @@ impl Encodable for ListPartitionReassignmentsRequest {
 #[cfg(feature = "broker")]
 impl Decodable for ListPartitionReassignmentsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!(
+                "ListPartitionReassignmentsRequest v{} is not supported",
+                version
+            );
+        }
         let timeout_ms = types::Int32.decode(buf)?;
         let topics = types::CompactArray(types::Struct { version }).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
@@ -189,6 +201,12 @@ impl ListPartitionReassignmentsTopics {
 #[cfg(feature = "client")]
 impl Encodable for ListPartitionReassignmentsTopics {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!(
+                "ListPartitionReassignmentsTopics v{} is not supported",
+                version
+            );
+        }
         types::CompactString.encode(buf, &self.name)?;
         types::CompactArray(types::Int32).encode(buf, &self.partition_indexes)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -224,6 +242,12 @@ impl Encodable for ListPartitionReassignmentsTopics {
 #[cfg(feature = "broker")]
 impl Decodable for ListPartitionReassignmentsTopics {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!(
+                "ListPartitionReassignmentsTopics v{} is not supported",
+                version
+            );
+        }
         let name = types::CompactString.decode(buf)?;
         let partition_indexes = types::CompactArray(types::Int32).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();

--- a/src/messages/list_partition_reassignments_request.rs
+++ b/src/messages/list_partition_reassignments_request.rs
@@ -70,10 +70,7 @@ impl ListPartitionReassignmentsRequest {
 impl Encodable for ListPartitionReassignmentsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!(
-                "ListPartitionReassignmentsRequest v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.timeout_ms)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
@@ -111,10 +108,7 @@ impl Encodable for ListPartitionReassignmentsRequest {
 impl Decodable for ListPartitionReassignmentsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!(
-                "ListPartitionReassignmentsRequest v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         let timeout_ms = types::Int32.decode(buf)?;
         let topics = types::CompactArray(types::Struct { version }).decode(buf)?;
@@ -202,10 +196,7 @@ impl ListPartitionReassignmentsTopics {
 impl Encodable for ListPartitionReassignmentsTopics {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!(
-                "ListPartitionReassignmentsTopics v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         types::CompactString.encode(buf, &self.name)?;
         types::CompactArray(types::Int32).encode(buf, &self.partition_indexes)?;
@@ -243,10 +234,7 @@ impl Encodable for ListPartitionReassignmentsTopics {
 impl Decodable for ListPartitionReassignmentsTopics {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!(
-                "ListPartitionReassignmentsTopics v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         let name = types::CompactString.decode(buf)?;
         let partition_indexes = types::CompactArray(types::Int32).decode(buf)?;

--- a/src/messages/list_partition_reassignments_response.rs
+++ b/src/messages/list_partition_reassignments_response.rs
@@ -98,10 +98,7 @@ impl ListPartitionReassignmentsResponse {
 impl Encodable for ListPartitionReassignmentsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!(
-                "ListPartitionReassignmentsResponse v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -143,10 +140,7 @@ impl Encodable for ListPartitionReassignmentsResponse {
 impl Decodable for ListPartitionReassignmentsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!(
-                "ListPartitionReassignmentsResponse v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
@@ -268,7 +262,7 @@ impl OngoingPartitionReassignment {
 impl Encodable for OngoingPartitionReassignment {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("OngoingPartitionReassignment v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.partition_index)?;
         types::CompactArray(types::Int32).encode(buf, &self.replicas)?;
@@ -310,7 +304,7 @@ impl Encodable for OngoingPartitionReassignment {
 impl Decodable for OngoingPartitionReassignment {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("OngoingPartitionReassignment v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let partition_index = types::Int32.decode(buf)?;
         let replicas = types::CompactArray(types::Int32).decode(buf)?;
@@ -404,7 +398,7 @@ impl OngoingTopicReassignment {
 impl Encodable for OngoingTopicReassignment {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("OngoingTopicReassignment v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::CompactString.encode(buf, &self.name)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.partitions)?;
@@ -443,7 +437,7 @@ impl Encodable for OngoingTopicReassignment {
 impl Decodable for OngoingTopicReassignment {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("OngoingTopicReassignment v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = types::CompactString.decode(buf)?;
         let partitions = types::CompactArray(types::Struct { version }).decode(buf)?;

--- a/src/messages/list_partition_reassignments_response.rs
+++ b/src/messages/list_partition_reassignments_response.rs
@@ -97,6 +97,12 @@ impl ListPartitionReassignmentsResponse {
 #[cfg(feature = "broker")]
 impl Encodable for ListPartitionReassignmentsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!(
+                "ListPartitionReassignmentsResponse v{} is not supported",
+                version
+            );
+        }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
         types::CompactString.encode(buf, &self.error_message)?;
@@ -136,6 +142,12 @@ impl Encodable for ListPartitionReassignmentsResponse {
 #[cfg(feature = "client")]
 impl Decodable for ListPartitionReassignmentsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!(
+                "ListPartitionReassignmentsResponse v{} is not supported",
+                version
+            );
+        }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let error_message = types::CompactString.decode(buf)?;
@@ -255,6 +267,9 @@ impl OngoingPartitionReassignment {
 #[cfg(feature = "broker")]
 impl Encodable for OngoingPartitionReassignment {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("OngoingPartitionReassignment v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.partition_index)?;
         types::CompactArray(types::Int32).encode(buf, &self.replicas)?;
         types::CompactArray(types::Int32).encode(buf, &self.adding_replicas)?;
@@ -294,6 +309,9 @@ impl Encodable for OngoingPartitionReassignment {
 #[cfg(feature = "client")]
 impl Decodable for OngoingPartitionReassignment {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("OngoingPartitionReassignment v{} is not supported", version);
+        }
         let partition_index = types::Int32.decode(buf)?;
         let replicas = types::CompactArray(types::Int32).decode(buf)?;
         let adding_replicas = types::CompactArray(types::Int32).decode(buf)?;
@@ -385,6 +403,9 @@ impl OngoingTopicReassignment {
 #[cfg(feature = "broker")]
 impl Encodable for OngoingTopicReassignment {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("OngoingTopicReassignment v{} is not supported", version);
+        }
         types::CompactString.encode(buf, &self.name)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.partitions)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -421,6 +442,9 @@ impl Encodable for OngoingTopicReassignment {
 #[cfg(feature = "client")]
 impl Decodable for OngoingTopicReassignment {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("OngoingTopicReassignment v{} is not supported", version);
+        }
         let name = types::CompactString.decode(buf)?;
         let partitions = types::CompactArray(types::Struct { version }).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();

--- a/src/messages/list_transactions_request.rs
+++ b/src/messages/list_transactions_request.rs
@@ -83,6 +83,9 @@ impl ListTransactionsRequest {
 #[cfg(feature = "client")]
 impl Encodable for ListTransactionsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("ListTransactionsRequest v{} is not supported", version);
+        }
         types::CompactArray(types::CompactString).encode(buf, &self.state_filters)?;
         types::CompactArray(types::Int64).encode(buf, &self.producer_id_filters)?;
         if version >= 1 {
@@ -133,6 +136,9 @@ impl Encodable for ListTransactionsRequest {
 #[cfg(feature = "broker")]
 impl Decodable for ListTransactionsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("ListTransactionsRequest v{} is not supported", version);
+        }
         let state_filters = types::CompactArray(types::CompactString).decode(buf)?;
         let producer_id_filters = types::CompactArray(types::Int64).decode(buf)?;
         let duration_filter = if version >= 1 {

--- a/src/messages/list_transactions_request.rs
+++ b/src/messages/list_transactions_request.rs
@@ -84,7 +84,7 @@ impl ListTransactionsRequest {
 impl Encodable for ListTransactionsRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("ListTransactionsRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::CompactArray(types::CompactString).encode(buf, &self.state_filters)?;
         types::CompactArray(types::Int64).encode(buf, &self.producer_id_filters)?;
@@ -137,7 +137,7 @@ impl Encodable for ListTransactionsRequest {
 impl Decodable for ListTransactionsRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("ListTransactionsRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let state_filters = types::CompactArray(types::CompactString).decode(buf)?;
         let producer_id_filters = types::CompactArray(types::Int64).decode(buf)?;

--- a/src/messages/list_transactions_response.rs
+++ b/src/messages/list_transactions_response.rs
@@ -98,7 +98,7 @@ impl ListTransactionsResponse {
 impl Encodable for ListTransactionsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("ListTransactionsResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -142,7 +142,7 @@ impl Encodable for ListTransactionsResponse {
 impl Decodable for ListTransactionsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("ListTransactionsResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
@@ -250,7 +250,7 @@ impl TransactionState {
 impl Encodable for TransactionState {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("TransactionState v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::CompactString.encode(buf, &self.transactional_id)?;
         types::Int64.encode(buf, &self.producer_id)?;
@@ -290,7 +290,7 @@ impl Encodable for TransactionState {
 impl Decodable for TransactionState {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("TransactionState v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let transactional_id = types::CompactString.decode(buf)?;
         let producer_id = types::Int64.decode(buf)?;

--- a/src/messages/list_transactions_response.rs
+++ b/src/messages/list_transactions_response.rs
@@ -97,6 +97,9 @@ impl ListTransactionsResponse {
 #[cfg(feature = "broker")]
 impl Encodable for ListTransactionsResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("ListTransactionsResponse v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
         types::CompactArray(types::CompactString).encode(buf, &self.unknown_state_filters)?;
@@ -138,6 +141,9 @@ impl Encodable for ListTransactionsResponse {
 #[cfg(feature = "client")]
 impl Decodable for ListTransactionsResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("ListTransactionsResponse v{} is not supported", version);
+        }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let unknown_state_filters = types::CompactArray(types::CompactString).decode(buf)?;
@@ -243,6 +249,9 @@ impl TransactionState {
 #[cfg(feature = "broker")]
 impl Encodable for TransactionState {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("TransactionState v{} is not supported", version);
+        }
         types::CompactString.encode(buf, &self.transactional_id)?;
         types::Int64.encode(buf, &self.producer_id)?;
         types::CompactString.encode(buf, &self.transaction_state)?;
@@ -280,6 +289,9 @@ impl Encodable for TransactionState {
 #[cfg(feature = "client")]
 impl Decodable for TransactionState {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("TransactionState v{} is not supported", version);
+        }
         let transactional_id = types::CompactString.decode(buf)?;
         let producer_id = types::Int64.decode(buf)?;
         let transaction_state = types::CompactString.decode(buf)?;

--- a/src/messages/metadata_request.rs
+++ b/src/messages/metadata_request.rs
@@ -97,6 +97,9 @@ impl MetadataRequest {
 #[cfg(feature = "client")]
 impl Encodable for MetadataRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 12 {
+            bail!("MetadataRequest v{} is not supported", version);
+        }
         if version >= 9 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
         } else {
@@ -186,6 +189,9 @@ impl Encodable for MetadataRequest {
 #[cfg(feature = "broker")]
 impl Decodable for MetadataRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 12 {
+            bail!("MetadataRequest v{} is not supported", version);
+        }
         let topics = if version >= 9 {
             types::CompactArray(types::Struct { version }).decode(buf)?
         } else {
@@ -295,6 +301,9 @@ impl MetadataRequestTopic {
 #[cfg(feature = "client")]
 impl Encodable for MetadataRequestTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 12 {
+            bail!("MetadataRequestTopic v{} is not supported", version);
+        }
         if version >= 10 {
             types::Uuid.encode(buf, &self.topic_id)?;
         }
@@ -346,6 +355,9 @@ impl Encodable for MetadataRequestTopic {
 #[cfg(feature = "broker")]
 impl Decodable for MetadataRequestTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 12 {
+            bail!("MetadataRequestTopic v{} is not supported", version);
+        }
         let topic_id = if version >= 10 {
             types::Uuid.decode(buf)?
         } else {

--- a/src/messages/metadata_request.rs
+++ b/src/messages/metadata_request.rs
@@ -98,7 +98,7 @@ impl MetadataRequest {
 impl Encodable for MetadataRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 12 {
-            bail!("MetadataRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 9 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
@@ -190,7 +190,7 @@ impl Encodable for MetadataRequest {
 impl Decodable for MetadataRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 12 {
-            bail!("MetadataRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topics = if version >= 9 {
             types::CompactArray(types::Struct { version }).decode(buf)?
@@ -302,7 +302,7 @@ impl MetadataRequestTopic {
 impl Encodable for MetadataRequestTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 12 {
-            bail!("MetadataRequestTopic v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 10 {
             types::Uuid.encode(buf, &self.topic_id)?;
@@ -356,7 +356,7 @@ impl Encodable for MetadataRequestTopic {
 impl Decodable for MetadataRequestTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 12 {
-            bail!("MetadataRequestTopic v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topic_id = if version >= 10 {
             types::Uuid.decode(buf)?

--- a/src/messages/metadata_response.rs
+++ b/src/messages/metadata_response.rs
@@ -126,7 +126,7 @@ impl MetadataResponse {
 impl Encodable for MetadataResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 12 {
-            bail!("MetadataResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 3 {
             types::Int32.encode(buf, &self.throttle_time_ms)?;
@@ -226,7 +226,7 @@ impl Encodable for MetadataResponse {
 impl Decodable for MetadataResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 12 {
-            bail!("MetadataResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = if version >= 3 {
             types::Int32.decode(buf)?
@@ -384,7 +384,7 @@ impl MetadataResponseBroker {
 impl Encodable for MetadataResponseBroker {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 12 {
-            bail!("MetadataResponseBroker v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.node_id)?;
         if version >= 9 {
@@ -450,7 +450,7 @@ impl Encodable for MetadataResponseBroker {
 impl Decodable for MetadataResponseBroker {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 12 {
-            bail!("MetadataResponseBroker v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let node_id = types::Int32.decode(buf)?;
         let host = if version >= 9 {
@@ -628,7 +628,7 @@ impl MetadataResponsePartition {
 impl Encodable for MetadataResponsePartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 12 {
-            bail!("MetadataResponsePartition v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int16.encode(buf, &self.error_code)?;
         types::Int32.encode(buf, &self.partition_index)?;
@@ -713,7 +713,7 @@ impl Encodable for MetadataResponsePartition {
 impl Decodable for MetadataResponsePartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 12 {
-            bail!("MetadataResponsePartition v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let error_code = types::Int16.decode(buf)?;
         let partition_index = types::Int32.decode(buf)?;
@@ -894,7 +894,7 @@ impl MetadataResponseTopic {
 impl Encodable for MetadataResponseTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 12 {
-            bail!("MetadataResponseTopic v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 9 {
@@ -981,7 +981,7 @@ impl Encodable for MetadataResponseTopic {
 impl Decodable for MetadataResponseTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 12 {
-            bail!("MetadataResponseTopic v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let error_code = types::Int16.decode(buf)?;
         let name = if version >= 9 {

--- a/src/messages/metadata_response.rs
+++ b/src/messages/metadata_response.rs
@@ -125,6 +125,9 @@ impl MetadataResponse {
 #[cfg(feature = "broker")]
 impl Encodable for MetadataResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 12 {
+            bail!("MetadataResponse v{} is not supported", version);
+        }
         if version >= 3 {
             types::Int32.encode(buf, &self.throttle_time_ms)?;
         }
@@ -222,6 +225,9 @@ impl Encodable for MetadataResponse {
 #[cfg(feature = "client")]
 impl Decodable for MetadataResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 12 {
+            bail!("MetadataResponse v{} is not supported", version);
+        }
         let throttle_time_ms = if version >= 3 {
             types::Int32.decode(buf)?
         } else {
@@ -377,6 +383,9 @@ impl MetadataResponseBroker {
 #[cfg(feature = "broker")]
 impl Encodable for MetadataResponseBroker {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 12 {
+            bail!("MetadataResponseBroker v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.node_id)?;
         if version >= 9 {
             types::CompactString.encode(buf, &self.host)?;
@@ -440,6 +449,9 @@ impl Encodable for MetadataResponseBroker {
 #[cfg(feature = "client")]
 impl Decodable for MetadataResponseBroker {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 12 {
+            bail!("MetadataResponseBroker v{} is not supported", version);
+        }
         let node_id = types::Int32.decode(buf)?;
         let host = if version >= 9 {
             types::CompactString.decode(buf)?
@@ -615,6 +627,9 @@ impl MetadataResponsePartition {
 #[cfg(feature = "broker")]
 impl Encodable for MetadataResponsePartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 12 {
+            bail!("MetadataResponsePartition v{} is not supported", version);
+        }
         types::Int16.encode(buf, &self.error_code)?;
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int32.encode(buf, &self.leader_id)?;
@@ -697,6 +712,9 @@ impl Encodable for MetadataResponsePartition {
 #[cfg(feature = "client")]
 impl Decodable for MetadataResponsePartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 12 {
+            bail!("MetadataResponsePartition v{} is not supported", version);
+        }
         let error_code = types::Int16.decode(buf)?;
         let partition_index = types::Int32.decode(buf)?;
         let leader_id = types::Int32.decode(buf)?;
@@ -875,6 +893,9 @@ impl MetadataResponseTopic {
 #[cfg(feature = "broker")]
 impl Encodable for MetadataResponseTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 12 {
+            bail!("MetadataResponseTopic v{} is not supported", version);
+        }
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 9 {
             types::CompactString.encode(buf, &self.name)?;
@@ -959,6 +980,9 @@ impl Encodable for MetadataResponseTopic {
 #[cfg(feature = "client")]
 impl Decodable for MetadataResponseTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 12 {
+            bail!("MetadataResponseTopic v{} is not supported", version);
+        }
         let error_code = types::Int16.decode(buf)?;
         let name = if version >= 9 {
             types::CompactString.decode(buf)?

--- a/src/messages/offset_commit_request.rs
+++ b/src/messages/offset_commit_request.rs
@@ -126,7 +126,7 @@ impl OffsetCommitRequest {
 impl Encodable for OffsetCommitRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 9 {
-            bail!("OffsetCommitRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 8 {
             types::CompactString.encode(buf, &self.group_id)?;
@@ -233,7 +233,7 @@ impl Encodable for OffsetCommitRequest {
 impl Decodable for OffsetCommitRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 9 {
-            bail!("OffsetCommitRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let group_id = if version >= 8 {
             types::CompactString.decode(buf)?
@@ -409,7 +409,7 @@ impl OffsetCommitRequestPartition {
 impl Encodable for OffsetCommitRequestPartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 9 {
-            bail!("OffsetCommitRequestPartition v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int64.encode(buf, &self.committed_offset)?;
@@ -481,7 +481,7 @@ impl Encodable for OffsetCommitRequestPartition {
 impl Decodable for OffsetCommitRequestPartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 9 {
-            bail!("OffsetCommitRequestPartition v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let partition_index = types::Int32.decode(buf)?;
         let committed_offset = types::Int64.decode(buf)?;
@@ -592,7 +592,7 @@ impl OffsetCommitRequestTopic {
 impl Encodable for OffsetCommitRequestTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 9 {
-            bail!("OffsetCommitRequestTopic v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 8 {
             types::CompactString.encode(buf, &self.name)?;
@@ -651,7 +651,7 @@ impl Encodable for OffsetCommitRequestTopic {
 impl Decodable for OffsetCommitRequestTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 9 {
-            bail!("OffsetCommitRequestTopic v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = if version >= 8 {
             types::CompactString.decode(buf)?

--- a/src/messages/offset_commit_request.rs
+++ b/src/messages/offset_commit_request.rs
@@ -125,6 +125,9 @@ impl OffsetCommitRequest {
 #[cfg(feature = "client")]
 impl Encodable for OffsetCommitRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 9 {
+            bail!("OffsetCommitRequest v{} is not supported", version);
+        }
         if version >= 8 {
             types::CompactString.encode(buf, &self.group_id)?;
         } else {
@@ -229,6 +232,9 @@ impl Encodable for OffsetCommitRequest {
 #[cfg(feature = "broker")]
 impl Decodable for OffsetCommitRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 9 {
+            bail!("OffsetCommitRequest v{} is not supported", version);
+        }
         let group_id = if version >= 8 {
             types::CompactString.decode(buf)?
         } else {
@@ -402,6 +408,9 @@ impl OffsetCommitRequestPartition {
 #[cfg(feature = "client")]
 impl Encodable for OffsetCommitRequestPartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 9 {
+            bail!("OffsetCommitRequestPartition v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int64.encode(buf, &self.committed_offset)?;
         if version >= 6 {
@@ -471,6 +480,9 @@ impl Encodable for OffsetCommitRequestPartition {
 #[cfg(feature = "broker")]
 impl Decodable for OffsetCommitRequestPartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 9 {
+            bail!("OffsetCommitRequestPartition v{} is not supported", version);
+        }
         let partition_index = types::Int32.decode(buf)?;
         let committed_offset = types::Int64.decode(buf)?;
         let committed_leader_epoch = if version >= 6 {
@@ -579,6 +591,9 @@ impl OffsetCommitRequestTopic {
 #[cfg(feature = "client")]
 impl Encodable for OffsetCommitRequestTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 9 {
+            bail!("OffsetCommitRequestTopic v{} is not supported", version);
+        }
         if version >= 8 {
             types::CompactString.encode(buf, &self.name)?;
         } else {
@@ -635,6 +650,9 @@ impl Encodable for OffsetCommitRequestTopic {
 #[cfg(feature = "broker")]
 impl Decodable for OffsetCommitRequestTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 9 {
+            bail!("OffsetCommitRequestTopic v{} is not supported", version);
+        }
         let name = if version >= 8 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/offset_commit_response.rs
+++ b/src/messages/offset_commit_response.rs
@@ -70,7 +70,7 @@ impl OffsetCommitResponse {
 impl Encodable for OffsetCommitResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 9 {
-            bail!("OffsetCommitResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 3 {
             types::Int32.encode(buf, &self.throttle_time_ms)?;
@@ -125,7 +125,7 @@ impl Encodable for OffsetCommitResponse {
 impl Decodable for OffsetCommitResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 9 {
-            bail!("OffsetCommitResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = if version >= 3 {
             types::Int32.decode(buf)?
@@ -223,10 +223,7 @@ impl OffsetCommitResponsePartition {
 impl Encodable for OffsetCommitResponsePartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 9 {
-            bail!(
-                "OffsetCommitResponsePartition v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -268,10 +265,7 @@ impl Encodable for OffsetCommitResponsePartition {
 impl Decodable for OffsetCommitResponsePartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 9 {
-            bail!(
-                "OffsetCommitResponsePartition v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         let partition_index = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
@@ -361,7 +355,7 @@ impl OffsetCommitResponseTopic {
 impl Encodable for OffsetCommitResponseTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 9 {
-            bail!("OffsetCommitResponseTopic v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 8 {
             types::CompactString.encode(buf, &self.name)?;
@@ -420,7 +414,7 @@ impl Encodable for OffsetCommitResponseTopic {
 impl Decodable for OffsetCommitResponseTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 9 {
-            bail!("OffsetCommitResponseTopic v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = if version >= 8 {
             types::CompactString.decode(buf)?

--- a/src/messages/offset_commit_response.rs
+++ b/src/messages/offset_commit_response.rs
@@ -69,6 +69,9 @@ impl OffsetCommitResponse {
 #[cfg(feature = "broker")]
 impl Encodable for OffsetCommitResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 9 {
+            bail!("OffsetCommitResponse v{} is not supported", version);
+        }
         if version >= 3 {
             types::Int32.encode(buf, &self.throttle_time_ms)?;
         }
@@ -121,6 +124,9 @@ impl Encodable for OffsetCommitResponse {
 #[cfg(feature = "client")]
 impl Decodable for OffsetCommitResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 9 {
+            bail!("OffsetCommitResponse v{} is not supported", version);
+        }
         let throttle_time_ms = if version >= 3 {
             types::Int32.decode(buf)?
         } else {
@@ -216,6 +222,12 @@ impl OffsetCommitResponsePartition {
 #[cfg(feature = "broker")]
 impl Encodable for OffsetCommitResponsePartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 9 {
+            bail!(
+                "OffsetCommitResponsePartition v{} is not supported",
+                version
+            );
+        }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 8 {
@@ -255,6 +267,12 @@ impl Encodable for OffsetCommitResponsePartition {
 #[cfg(feature = "client")]
 impl Decodable for OffsetCommitResponsePartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 9 {
+            bail!(
+                "OffsetCommitResponsePartition v{} is not supported",
+                version
+            );
+        }
         let partition_index = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
@@ -342,6 +360,9 @@ impl OffsetCommitResponseTopic {
 #[cfg(feature = "broker")]
 impl Encodable for OffsetCommitResponseTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 9 {
+            bail!("OffsetCommitResponseTopic v{} is not supported", version);
+        }
         if version >= 8 {
             types::CompactString.encode(buf, &self.name)?;
         } else {
@@ -398,6 +419,9 @@ impl Encodable for OffsetCommitResponseTopic {
 #[cfg(feature = "client")]
 impl Decodable for OffsetCommitResponseTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 9 {
+            bail!("OffsetCommitResponseTopic v{} is not supported", version);
+        }
         let name = if version >= 8 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/offset_delete_request.rs
+++ b/src/messages/offset_delete_request.rs
@@ -57,7 +57,7 @@ impl OffsetDeleteRequest {
 impl Encodable for OffsetDeleteRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("OffsetDeleteRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::String.encode(buf, &self.group_id)?;
         types::Array(types::Struct { version }).encode(buf, &self.topics)?;
@@ -77,7 +77,7 @@ impl Encodable for OffsetDeleteRequest {
 impl Decodable for OffsetDeleteRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("OffsetDeleteRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let group_id = types::String.decode(buf)?;
         let topics = types::Array(types::Struct { version }).decode(buf)?;
@@ -125,7 +125,7 @@ impl OffsetDeleteRequestPartition {
 impl Encodable for OffsetDeleteRequestPartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("OffsetDeleteRequestPartition v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.partition_index)?;
 
@@ -143,7 +143,7 @@ impl Encodable for OffsetDeleteRequestPartition {
 impl Decodable for OffsetDeleteRequestPartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("OffsetDeleteRequestPartition v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let partition_index = types::Int32.decode(buf)?;
         Ok(Self { partition_index })
@@ -201,7 +201,7 @@ impl OffsetDeleteRequestTopic {
 impl Encodable for OffsetDeleteRequestTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("OffsetDeleteRequestTopic v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::String.encode(buf, &self.name)?;
         types::Array(types::Struct { version }).encode(buf, &self.partitions)?;
@@ -221,7 +221,7 @@ impl Encodable for OffsetDeleteRequestTopic {
 impl Decodable for OffsetDeleteRequestTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("OffsetDeleteRequestTopic v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = types::String.decode(buf)?;
         let partitions = types::Array(types::Struct { version }).decode(buf)?;

--- a/src/messages/offset_delete_request.rs
+++ b/src/messages/offset_delete_request.rs
@@ -56,6 +56,9 @@ impl OffsetDeleteRequest {
 #[cfg(feature = "client")]
 impl Encodable for OffsetDeleteRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("OffsetDeleteRequest v{} is not supported", version);
+        }
         types::String.encode(buf, &self.group_id)?;
         types::Array(types::Struct { version }).encode(buf, &self.topics)?;
 
@@ -73,6 +76,9 @@ impl Encodable for OffsetDeleteRequest {
 #[cfg(feature = "broker")]
 impl Decodable for OffsetDeleteRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("OffsetDeleteRequest v{} is not supported", version);
+        }
         let group_id = types::String.decode(buf)?;
         let topics = types::Array(types::Struct { version }).decode(buf)?;
         Ok(Self { group_id, topics })
@@ -118,6 +124,9 @@ impl OffsetDeleteRequestPartition {
 #[cfg(feature = "client")]
 impl Encodable for OffsetDeleteRequestPartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("OffsetDeleteRequestPartition v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.partition_index)?;
 
         Ok(())
@@ -133,6 +142,9 @@ impl Encodable for OffsetDeleteRequestPartition {
 #[cfg(feature = "broker")]
 impl Decodable for OffsetDeleteRequestPartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("OffsetDeleteRequestPartition v{} is not supported", version);
+        }
         let partition_index = types::Int32.decode(buf)?;
         Ok(Self { partition_index })
     }
@@ -188,6 +200,9 @@ impl OffsetDeleteRequestTopic {
 #[cfg(feature = "client")]
 impl Encodable for OffsetDeleteRequestTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("OffsetDeleteRequestTopic v{} is not supported", version);
+        }
         types::String.encode(buf, &self.name)?;
         types::Array(types::Struct { version }).encode(buf, &self.partitions)?;
 
@@ -205,6 +220,9 @@ impl Encodable for OffsetDeleteRequestTopic {
 #[cfg(feature = "broker")]
 impl Decodable for OffsetDeleteRequestTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("OffsetDeleteRequestTopic v{} is not supported", version);
+        }
         let name = types::String.decode(buf)?;
         let partitions = types::Array(types::Struct { version }).decode(buf)?;
         Ok(Self { name, partitions })

--- a/src/messages/offset_delete_response.rs
+++ b/src/messages/offset_delete_response.rs
@@ -71,7 +71,7 @@ impl OffsetDeleteResponse {
 impl Encodable for OffsetDeleteResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("OffsetDeleteResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int16.encode(buf, &self.error_code)?;
         types::Int32.encode(buf, &self.throttle_time_ms)?;
@@ -93,7 +93,7 @@ impl Encodable for OffsetDeleteResponse {
 impl Decodable for OffsetDeleteResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("OffsetDeleteResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let error_code = types::Int16.decode(buf)?;
         let throttle_time_ms = types::Int32.decode(buf)?;
@@ -161,10 +161,7 @@ impl OffsetDeleteResponsePartition {
 impl Encodable for OffsetDeleteResponsePartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!(
-                "OffsetDeleteResponsePartition v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -184,10 +181,7 @@ impl Encodable for OffsetDeleteResponsePartition {
 impl Decodable for OffsetDeleteResponsePartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!(
-                "OffsetDeleteResponsePartition v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         let partition_index = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
@@ -252,7 +246,7 @@ impl OffsetDeleteResponseTopic {
 impl Encodable for OffsetDeleteResponseTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("OffsetDeleteResponseTopic v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::String.encode(buf, &self.name)?;
         types::Array(types::Struct { version }).encode(buf, &self.partitions)?;
@@ -272,7 +266,7 @@ impl Encodable for OffsetDeleteResponseTopic {
 impl Decodable for OffsetDeleteResponseTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("OffsetDeleteResponseTopic v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = types::String.decode(buf)?;
         let partitions = types::Array(types::Struct { version }).decode(buf)?;

--- a/src/messages/offset_delete_response.rs
+++ b/src/messages/offset_delete_response.rs
@@ -70,6 +70,9 @@ impl OffsetDeleteResponse {
 #[cfg(feature = "broker")]
 impl Encodable for OffsetDeleteResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("OffsetDeleteResponse v{} is not supported", version);
+        }
         types::Int16.encode(buf, &self.error_code)?;
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Array(types::Struct { version }).encode(buf, &self.topics)?;
@@ -89,6 +92,9 @@ impl Encodable for OffsetDeleteResponse {
 #[cfg(feature = "client")]
 impl Decodable for OffsetDeleteResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("OffsetDeleteResponse v{} is not supported", version);
+        }
         let error_code = types::Int16.decode(buf)?;
         let throttle_time_ms = types::Int32.decode(buf)?;
         let topics = types::Array(types::Struct { version }).decode(buf)?;
@@ -154,6 +160,12 @@ impl OffsetDeleteResponsePartition {
 #[cfg(feature = "broker")]
 impl Encodable for OffsetDeleteResponsePartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!(
+                "OffsetDeleteResponsePartition v{} is not supported",
+                version
+            );
+        }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int16.encode(buf, &self.error_code)?;
 
@@ -171,6 +183,12 @@ impl Encodable for OffsetDeleteResponsePartition {
 #[cfg(feature = "client")]
 impl Decodable for OffsetDeleteResponsePartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!(
+                "OffsetDeleteResponsePartition v{} is not supported",
+                version
+            );
+        }
         let partition_index = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         Ok(Self {
@@ -233,6 +251,9 @@ impl OffsetDeleteResponseTopic {
 #[cfg(feature = "broker")]
 impl Encodable for OffsetDeleteResponseTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("OffsetDeleteResponseTopic v{} is not supported", version);
+        }
         types::String.encode(buf, &self.name)?;
         types::Array(types::Struct { version }).encode(buf, &self.partitions)?;
 
@@ -250,6 +271,9 @@ impl Encodable for OffsetDeleteResponseTopic {
 #[cfg(feature = "client")]
 impl Decodable for OffsetDeleteResponseTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("OffsetDeleteResponseTopic v{} is not supported", version);
+        }
         let name = types::String.decode(buf)?;
         let partitions = types::Array(types::Struct { version }).decode(buf)?;
         Ok(Self { name, partitions })

--- a/src/messages/offset_fetch_request.rs
+++ b/src/messages/offset_fetch_request.rs
@@ -97,6 +97,9 @@ impl OffsetFetchRequest {
 #[cfg(feature = "client")]
 impl Encodable for OffsetFetchRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 9 {
+            bail!("OffsetFetchRequest v{} is not supported", version);
+        }
         if version <= 7 {
             if version >= 6 {
                 types::CompactString.encode(buf, &self.group_id)?;
@@ -216,6 +219,9 @@ impl Encodable for OffsetFetchRequest {
 #[cfg(feature = "broker")]
 impl Decodable for OffsetFetchRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 9 {
+            bail!("OffsetFetchRequest v{} is not supported", version);
+        }
         let group_id = if version <= 7 {
             if version >= 6 {
                 types::CompactString.decode(buf)?
@@ -361,6 +367,9 @@ impl OffsetFetchRequestGroup {
 #[cfg(feature = "client")]
 impl Encodable for OffsetFetchRequestGroup {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 9 {
+            bail!("OffsetFetchRequestGroup v{} is not supported", version);
+        }
         if version >= 8 {
             types::CompactString.encode(buf, &self.group_id)?;
         } else {
@@ -447,6 +456,9 @@ impl Encodable for OffsetFetchRequestGroup {
 #[cfg(feature = "broker")]
 impl Decodable for OffsetFetchRequestGroup {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 9 {
+            bail!("OffsetFetchRequestGroup v{} is not supported", version);
+        }
         let group_id = if version >= 8 {
             types::CompactString.decode(buf)?
         } else {
@@ -556,6 +568,9 @@ impl OffsetFetchRequestTopic {
 #[cfg(feature = "client")]
 impl Encodable for OffsetFetchRequestTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 9 {
+            bail!("OffsetFetchRequestTopic v{} is not supported", version);
+        }
         if version <= 7 {
             if version >= 6 {
                 types::CompactString.encode(buf, &self.name)?;
@@ -636,6 +651,9 @@ impl Encodable for OffsetFetchRequestTopic {
 #[cfg(feature = "broker")]
 impl Decodable for OffsetFetchRequestTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 9 {
+            bail!("OffsetFetchRequestTopic v{} is not supported", version);
+        }
         let name = if version <= 7 {
             if version >= 6 {
                 types::CompactString.decode(buf)?
@@ -739,6 +757,9 @@ impl OffsetFetchRequestTopics {
 #[cfg(feature = "client")]
 impl Encodable for OffsetFetchRequestTopics {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 9 {
+            bail!("OffsetFetchRequestTopics v{} is not supported", version);
+        }
         if version >= 8 {
             types::CompactString.encode(buf, &self.name)?;
         } else {
@@ -803,6 +824,9 @@ impl Encodable for OffsetFetchRequestTopics {
 #[cfg(feature = "broker")]
 impl Decodable for OffsetFetchRequestTopics {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 9 {
+            bail!("OffsetFetchRequestTopics v{} is not supported", version);
+        }
         let name = if version >= 8 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/offset_fetch_request.rs
+++ b/src/messages/offset_fetch_request.rs
@@ -98,7 +98,7 @@ impl OffsetFetchRequest {
 impl Encodable for OffsetFetchRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 9 {
-            bail!("OffsetFetchRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version <= 7 {
             if version >= 6 {
@@ -220,7 +220,7 @@ impl Encodable for OffsetFetchRequest {
 impl Decodable for OffsetFetchRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 9 {
-            bail!("OffsetFetchRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let group_id = if version <= 7 {
             if version >= 6 {
@@ -368,7 +368,7 @@ impl OffsetFetchRequestGroup {
 impl Encodable for OffsetFetchRequestGroup {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 9 {
-            bail!("OffsetFetchRequestGroup v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 8 {
             types::CompactString.encode(buf, &self.group_id)?;
@@ -457,7 +457,7 @@ impl Encodable for OffsetFetchRequestGroup {
 impl Decodable for OffsetFetchRequestGroup {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 9 {
-            bail!("OffsetFetchRequestGroup v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let group_id = if version >= 8 {
             types::CompactString.decode(buf)?
@@ -569,7 +569,7 @@ impl OffsetFetchRequestTopic {
 impl Encodable for OffsetFetchRequestTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 9 {
-            bail!("OffsetFetchRequestTopic v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version <= 7 {
             if version >= 6 {
@@ -652,7 +652,7 @@ impl Encodable for OffsetFetchRequestTopic {
 impl Decodable for OffsetFetchRequestTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 9 {
-            bail!("OffsetFetchRequestTopic v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = if version <= 7 {
             if version >= 6 {
@@ -758,7 +758,7 @@ impl OffsetFetchRequestTopics {
 impl Encodable for OffsetFetchRequestTopics {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 9 {
-            bail!("OffsetFetchRequestTopics v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 8 {
             types::CompactString.encode(buf, &self.name)?;
@@ -825,7 +825,7 @@ impl Encodable for OffsetFetchRequestTopics {
 impl Decodable for OffsetFetchRequestTopics {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 9 {
-            bail!("OffsetFetchRequestTopics v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = if version >= 8 {
             types::CompactString.decode(buf)?

--- a/src/messages/offset_fetch_response.rs
+++ b/src/messages/offset_fetch_response.rs
@@ -98,7 +98,7 @@ impl OffsetFetchResponse {
 impl Encodable for OffsetFetchResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 9 {
-            bail!("OffsetFetchResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 3 {
             types::Int32.encode(buf, &self.throttle_time_ms)?;
@@ -186,7 +186,7 @@ impl Encodable for OffsetFetchResponse {
 impl Decodable for OffsetFetchResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 9 {
-            bail!("OffsetFetchResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = if version >= 3 {
             types::Int32.decode(buf)?
@@ -316,7 +316,7 @@ impl OffsetFetchResponseGroup {
 impl Encodable for OffsetFetchResponseGroup {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 9 {
-            bail!("OffsetFetchResponseGroup v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 8 {
             types::CompactString.encode(buf, &self.group_id)?;
@@ -397,7 +397,7 @@ impl Encodable for OffsetFetchResponseGroup {
 impl Decodable for OffsetFetchResponseGroup {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 9 {
-            bail!("OffsetFetchResponseGroup v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let group_id = if version >= 8 {
             types::CompactString.decode(buf)?
@@ -544,7 +544,7 @@ impl OffsetFetchResponsePartition {
 impl Encodable for OffsetFetchResponsePartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 9 {
-            bail!("OffsetFetchResponsePartition v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version <= 7 {
             types::Int32.encode(buf, &self.partition_index)?;
@@ -662,7 +662,7 @@ impl Encodable for OffsetFetchResponsePartition {
 impl Decodable for OffsetFetchResponsePartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 9 {
-            bail!("OffsetFetchResponsePartition v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let partition_index = if version <= 7 {
             types::Int32.decode(buf)?
@@ -827,10 +827,7 @@ impl OffsetFetchResponsePartitions {
 impl Encodable for OffsetFetchResponsePartitions {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 9 {
-            bail!(
-                "OffsetFetchResponsePartitions v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         if version >= 8 {
             types::Int32.encode(buf, &self.partition_index)?;
@@ -940,10 +937,7 @@ impl Encodable for OffsetFetchResponsePartitions {
 impl Decodable for OffsetFetchResponsePartitions {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 9 {
-            bail!(
-                "OffsetFetchResponsePartitions v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         let partition_index = if version >= 8 {
             types::Int32.decode(buf)?
@@ -1062,7 +1056,7 @@ impl OffsetFetchResponseTopic {
 impl Encodable for OffsetFetchResponseTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 9 {
-            bail!("OffsetFetchResponseTopic v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version <= 7 {
             if version >= 6 {
@@ -1146,7 +1140,7 @@ impl Encodable for OffsetFetchResponseTopic {
 impl Decodable for OffsetFetchResponseTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 9 {
-            bail!("OffsetFetchResponseTopic v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = if version <= 7 {
             if version >= 6 {
@@ -1252,7 +1246,7 @@ impl OffsetFetchResponseTopics {
 impl Encodable for OffsetFetchResponseTopics {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 9 {
-            bail!("OffsetFetchResponseTopics v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 8 {
             types::CompactString.encode(buf, &self.name)?;
@@ -1319,7 +1313,7 @@ impl Encodable for OffsetFetchResponseTopics {
 impl Decodable for OffsetFetchResponseTopics {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 9 {
-            bail!("OffsetFetchResponseTopics v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = if version >= 8 {
             types::CompactString.decode(buf)?

--- a/src/messages/offset_fetch_response.rs
+++ b/src/messages/offset_fetch_response.rs
@@ -97,6 +97,9 @@ impl OffsetFetchResponse {
 #[cfg(feature = "broker")]
 impl Encodable for OffsetFetchResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 9 {
+            bail!("OffsetFetchResponse v{} is not supported", version);
+        }
         if version >= 3 {
             types::Int32.encode(buf, &self.throttle_time_ms)?;
         }
@@ -182,6 +185,9 @@ impl Encodable for OffsetFetchResponse {
 #[cfg(feature = "client")]
 impl Decodable for OffsetFetchResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 9 {
+            bail!("OffsetFetchResponse v{} is not supported", version);
+        }
         let throttle_time_ms = if version >= 3 {
             types::Int32.decode(buf)?
         } else {
@@ -309,6 +315,9 @@ impl OffsetFetchResponseGroup {
 #[cfg(feature = "broker")]
 impl Encodable for OffsetFetchResponseGroup {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 9 {
+            bail!("OffsetFetchResponseGroup v{} is not supported", version);
+        }
         if version >= 8 {
             types::CompactString.encode(buf, &self.group_id)?;
         } else {
@@ -387,6 +396,9 @@ impl Encodable for OffsetFetchResponseGroup {
 #[cfg(feature = "client")]
 impl Decodable for OffsetFetchResponseGroup {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 9 {
+            bail!("OffsetFetchResponseGroup v{} is not supported", version);
+        }
         let group_id = if version >= 8 {
             types::CompactString.decode(buf)?
         } else {
@@ -531,6 +543,9 @@ impl OffsetFetchResponsePartition {
 #[cfg(feature = "broker")]
 impl Encodable for OffsetFetchResponsePartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 9 {
+            bail!("OffsetFetchResponsePartition v{} is not supported", version);
+        }
         if version <= 7 {
             types::Int32.encode(buf, &self.partition_index)?;
         } else {
@@ -646,6 +661,9 @@ impl Encodable for OffsetFetchResponsePartition {
 #[cfg(feature = "client")]
 impl Decodable for OffsetFetchResponsePartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 9 {
+            bail!("OffsetFetchResponsePartition v{} is not supported", version);
+        }
         let partition_index = if version <= 7 {
             types::Int32.decode(buf)?
         } else {
@@ -808,6 +826,12 @@ impl OffsetFetchResponsePartitions {
 #[cfg(feature = "broker")]
 impl Encodable for OffsetFetchResponsePartitions {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 9 {
+            bail!(
+                "OffsetFetchResponsePartitions v{} is not supported",
+                version
+            );
+        }
         if version >= 8 {
             types::Int32.encode(buf, &self.partition_index)?;
         } else {
@@ -915,6 +939,12 @@ impl Encodable for OffsetFetchResponsePartitions {
 #[cfg(feature = "client")]
 impl Decodable for OffsetFetchResponsePartitions {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 9 {
+            bail!(
+                "OffsetFetchResponsePartitions v{} is not supported",
+                version
+            );
+        }
         let partition_index = if version >= 8 {
             types::Int32.decode(buf)?
         } else {
@@ -1031,6 +1061,9 @@ impl OffsetFetchResponseTopic {
 #[cfg(feature = "broker")]
 impl Encodable for OffsetFetchResponseTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 9 {
+            bail!("OffsetFetchResponseTopic v{} is not supported", version);
+        }
         if version <= 7 {
             if version >= 6 {
                 types::CompactString.encode(buf, &self.name)?;
@@ -1112,6 +1145,9 @@ impl Encodable for OffsetFetchResponseTopic {
 #[cfg(feature = "client")]
 impl Decodable for OffsetFetchResponseTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 9 {
+            bail!("OffsetFetchResponseTopic v{} is not supported", version);
+        }
         let name = if version <= 7 {
             if version >= 6 {
                 types::CompactString.decode(buf)?
@@ -1215,6 +1251,9 @@ impl OffsetFetchResponseTopics {
 #[cfg(feature = "broker")]
 impl Encodable for OffsetFetchResponseTopics {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 9 {
+            bail!("OffsetFetchResponseTopics v{} is not supported", version);
+        }
         if version >= 8 {
             types::CompactString.encode(buf, &self.name)?;
         } else {
@@ -1279,6 +1318,9 @@ impl Encodable for OffsetFetchResponseTopics {
 #[cfg(feature = "client")]
 impl Decodable for OffsetFetchResponseTopics {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 9 {
+            bail!("OffsetFetchResponseTopics v{} is not supported", version);
+        }
         let name = if version >= 8 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/offset_for_leader_epoch_request.rs
+++ b/src/messages/offset_for_leader_epoch_request.rs
@@ -69,6 +69,9 @@ impl OffsetForLeaderEpochRequest {
 #[cfg(feature = "client")]
 impl Encodable for OffsetForLeaderEpochRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 4 {
+            bail!("OffsetForLeaderEpochRequest v{} is not supported", version);
+        }
         if version >= 3 {
             types::Int32.encode(buf, &self.replica_id)?;
         }
@@ -121,6 +124,9 @@ impl Encodable for OffsetForLeaderEpochRequest {
 #[cfg(feature = "broker")]
 impl Decodable for OffsetForLeaderEpochRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 4 {
+            bail!("OffsetForLeaderEpochRequest v{} is not supported", version);
+        }
         let replica_id = if version >= 3 {
             types::Int32.decode(buf)?
         } else {
@@ -230,6 +236,9 @@ impl OffsetForLeaderPartition {
 #[cfg(feature = "client")]
 impl Encodable for OffsetForLeaderPartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 4 {
+            bail!("OffsetForLeaderPartition v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.partition)?;
         if version >= 2 {
             types::Int32.encode(buf, &self.current_leader_epoch)?;
@@ -275,6 +284,9 @@ impl Encodable for OffsetForLeaderPartition {
 #[cfg(feature = "broker")]
 impl Decodable for OffsetForLeaderPartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 4 {
+            bail!("OffsetForLeaderPartition v{} is not supported", version);
+        }
         let partition = types::Int32.decode(buf)?;
         let current_leader_epoch = if version >= 2 {
             types::Int32.decode(buf)?
@@ -369,6 +381,9 @@ impl OffsetForLeaderTopic {
 #[cfg(feature = "client")]
 impl Encodable for OffsetForLeaderTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 4 {
+            bail!("OffsetForLeaderTopic v{} is not supported", version);
+        }
         if version >= 4 {
             types::CompactString.encode(buf, &self.topic)?;
         } else {
@@ -425,6 +440,9 @@ impl Encodable for OffsetForLeaderTopic {
 #[cfg(feature = "broker")]
 impl Decodable for OffsetForLeaderTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 4 {
+            bail!("OffsetForLeaderTopic v{} is not supported", version);
+        }
         let topic = if version >= 4 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/offset_for_leader_epoch_request.rs
+++ b/src/messages/offset_for_leader_epoch_request.rs
@@ -70,7 +70,7 @@ impl OffsetForLeaderEpochRequest {
 impl Encodable for OffsetForLeaderEpochRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 4 {
-            bail!("OffsetForLeaderEpochRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 3 {
             types::Int32.encode(buf, &self.replica_id)?;
@@ -125,7 +125,7 @@ impl Encodable for OffsetForLeaderEpochRequest {
 impl Decodable for OffsetForLeaderEpochRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 4 {
-            bail!("OffsetForLeaderEpochRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let replica_id = if version >= 3 {
             types::Int32.decode(buf)?
@@ -237,7 +237,7 @@ impl OffsetForLeaderPartition {
 impl Encodable for OffsetForLeaderPartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 4 {
-            bail!("OffsetForLeaderPartition v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.partition)?;
         if version >= 2 {
@@ -285,7 +285,7 @@ impl Encodable for OffsetForLeaderPartition {
 impl Decodable for OffsetForLeaderPartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 4 {
-            bail!("OffsetForLeaderPartition v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let partition = types::Int32.decode(buf)?;
         let current_leader_epoch = if version >= 2 {
@@ -382,7 +382,7 @@ impl OffsetForLeaderTopic {
 impl Encodable for OffsetForLeaderTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 4 {
-            bail!("OffsetForLeaderTopic v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 4 {
             types::CompactString.encode(buf, &self.topic)?;
@@ -441,7 +441,7 @@ impl Encodable for OffsetForLeaderTopic {
 impl Decodable for OffsetForLeaderTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 4 {
-            bail!("OffsetForLeaderTopic v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topic = if version >= 4 {
             types::CompactString.decode(buf)?

--- a/src/messages/offset_for_leader_epoch_response.rs
+++ b/src/messages/offset_for_leader_epoch_response.rs
@@ -98,7 +98,7 @@ impl EpochEndOffset {
 impl Encodable for EpochEndOffset {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 4 {
-            bail!("EpochEndOffset v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int16.encode(buf, &self.error_code)?;
         types::Int32.encode(buf, &self.partition)?;
@@ -148,7 +148,7 @@ impl Encodable for EpochEndOffset {
 impl Decodable for EpochEndOffset {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 4 {
-            bail!("EpochEndOffset v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let error_code = types::Int16.decode(buf)?;
         let partition = types::Int32.decode(buf)?;
@@ -248,7 +248,7 @@ impl OffsetForLeaderEpochResponse {
 impl Encodable for OffsetForLeaderEpochResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 4 {
-            bail!("OffsetForLeaderEpochResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 2 {
             types::Int32.encode(buf, &self.throttle_time_ms)?;
@@ -303,7 +303,7 @@ impl Encodable for OffsetForLeaderEpochResponse {
 impl Decodable for OffsetForLeaderEpochResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 4 {
-            bail!("OffsetForLeaderEpochResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = if version >= 2 {
             types::Int32.decode(buf)?
@@ -401,7 +401,7 @@ impl OffsetForLeaderTopicResult {
 impl Encodable for OffsetForLeaderTopicResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 4 {
-            bail!("OffsetForLeaderTopicResult v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 4 {
             types::CompactString.encode(buf, &self.topic)?;
@@ -460,7 +460,7 @@ impl Encodable for OffsetForLeaderTopicResult {
 impl Decodable for OffsetForLeaderTopicResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 4 {
-            bail!("OffsetForLeaderTopicResult v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topic = if version >= 4 {
             types::CompactString.decode(buf)?

--- a/src/messages/offset_for_leader_epoch_response.rs
+++ b/src/messages/offset_for_leader_epoch_response.rs
@@ -97,6 +97,9 @@ impl EpochEndOffset {
 #[cfg(feature = "broker")]
 impl Encodable for EpochEndOffset {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 4 {
+            bail!("EpochEndOffset v{} is not supported", version);
+        }
         types::Int16.encode(buf, &self.error_code)?;
         types::Int32.encode(buf, &self.partition)?;
         if version >= 1 {
@@ -144,6 +147,9 @@ impl Encodable for EpochEndOffset {
 #[cfg(feature = "client")]
 impl Decodable for EpochEndOffset {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 4 {
+            bail!("EpochEndOffset v{} is not supported", version);
+        }
         let error_code = types::Int16.decode(buf)?;
         let partition = types::Int32.decode(buf)?;
         let leader_epoch = if version >= 1 {
@@ -241,6 +247,9 @@ impl OffsetForLeaderEpochResponse {
 #[cfg(feature = "broker")]
 impl Encodable for OffsetForLeaderEpochResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 4 {
+            bail!("OffsetForLeaderEpochResponse v{} is not supported", version);
+        }
         if version >= 2 {
             types::Int32.encode(buf, &self.throttle_time_ms)?;
         }
@@ -293,6 +302,9 @@ impl Encodable for OffsetForLeaderEpochResponse {
 #[cfg(feature = "client")]
 impl Decodable for OffsetForLeaderEpochResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 4 {
+            bail!("OffsetForLeaderEpochResponse v{} is not supported", version);
+        }
         let throttle_time_ms = if version >= 2 {
             types::Int32.decode(buf)?
         } else {
@@ -388,6 +400,9 @@ impl OffsetForLeaderTopicResult {
 #[cfg(feature = "broker")]
 impl Encodable for OffsetForLeaderTopicResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 4 {
+            bail!("OffsetForLeaderTopicResult v{} is not supported", version);
+        }
         if version >= 4 {
             types::CompactString.encode(buf, &self.topic)?;
         } else {
@@ -444,6 +459,9 @@ impl Encodable for OffsetForLeaderTopicResult {
 #[cfg(feature = "client")]
 impl Decodable for OffsetForLeaderTopicResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 4 {
+            bail!("OffsetForLeaderTopicResult v{} is not supported", version);
+        }
         let topic = if version >= 4 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/produce_request.rs
+++ b/src/messages/produce_request.rs
@@ -70,7 +70,7 @@ impl PartitionProduceData {
 impl Encodable for PartitionProduceData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 11 {
-            bail!("PartitionProduceData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.index)?;
         if version >= 9 {
@@ -120,7 +120,7 @@ impl Encodable for PartitionProduceData {
 impl Decodable for PartitionProduceData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 11 {
-            bail!("PartitionProduceData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let index = types::Int32.decode(buf)?;
         let records = if version >= 9 {
@@ -242,7 +242,7 @@ impl ProduceRequest {
 impl Encodable for ProduceRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 11 {
-            bail!("ProduceRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 3 {
             if version >= 9 {
@@ -317,7 +317,7 @@ impl Encodable for ProduceRequest {
 impl Decodable for ProduceRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 11 {
-            bail!("ProduceRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let transactional_id = if version >= 3 {
             if version >= 9 {
@@ -425,7 +425,7 @@ impl TopicProduceData {
 impl Encodable for TopicProduceData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 11 {
-            bail!("TopicProduceData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 9 {
             types::CompactString.encode(buf, &self.name)?;
@@ -485,7 +485,7 @@ impl Encodable for TopicProduceData {
 impl Decodable for TopicProduceData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 11 {
-            bail!("TopicProduceData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = if version >= 9 {
             types::CompactString.decode(buf)?

--- a/src/messages/produce_request.rs
+++ b/src/messages/produce_request.rs
@@ -69,6 +69,9 @@ impl PartitionProduceData {
 #[cfg(feature = "client")]
 impl Encodable for PartitionProduceData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 11 {
+            bail!("PartitionProduceData v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.index)?;
         if version >= 9 {
             types::CompactBytes.encode(buf, &self.records)?;
@@ -116,6 +119,9 @@ impl Encodable for PartitionProduceData {
 #[cfg(feature = "broker")]
 impl Decodable for PartitionProduceData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 11 {
+            bail!("PartitionProduceData v{} is not supported", version);
+        }
         let index = types::Int32.decode(buf)?;
         let records = if version >= 9 {
             types::CompactBytes.decode(buf)?
@@ -235,6 +241,9 @@ impl ProduceRequest {
 #[cfg(feature = "client")]
 impl Encodable for ProduceRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 11 {
+            bail!("ProduceRequest v{} is not supported", version);
+        }
         if version >= 3 {
             if version >= 9 {
                 types::CompactString.encode(buf, &self.transactional_id)?;
@@ -307,6 +316,9 @@ impl Encodable for ProduceRequest {
 #[cfg(feature = "broker")]
 impl Decodable for ProduceRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 11 {
+            bail!("ProduceRequest v{} is not supported", version);
+        }
         let transactional_id = if version >= 3 {
             if version >= 9 {
                 types::CompactString.decode(buf)?
@@ -412,6 +424,9 @@ impl TopicProduceData {
 #[cfg(feature = "client")]
 impl Encodable for TopicProduceData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 11 {
+            bail!("TopicProduceData v{} is not supported", version);
+        }
         if version >= 9 {
             types::CompactString.encode(buf, &self.name)?;
         } else {
@@ -469,6 +484,9 @@ impl Encodable for TopicProduceData {
 #[cfg(feature = "broker")]
 impl Decodable for TopicProduceData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 11 {
+            bail!("TopicProduceData v{} is not supported", version);
+        }
         let name = if version >= 9 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/produce_response.rs
+++ b/src/messages/produce_response.rs
@@ -69,6 +69,9 @@ impl BatchIndexAndErrorMessage {
 #[cfg(feature = "broker")]
 impl Encodable for BatchIndexAndErrorMessage {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 11 {
+            bail!("BatchIndexAndErrorMessage v{} is not supported", version);
+        }
         if version >= 8 {
             types::Int32.encode(buf, &self.batch_index)?;
         } else {
@@ -140,6 +143,9 @@ impl Encodable for BatchIndexAndErrorMessage {
 #[cfg(feature = "client")]
 impl Decodable for BatchIndexAndErrorMessage {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 11 {
+            bail!("BatchIndexAndErrorMessage v{} is not supported", version);
+        }
         let batch_index = if version >= 8 {
             types::Int32.decode(buf)?
         } else {
@@ -239,6 +245,9 @@ impl LeaderIdAndEpoch {
 #[cfg(feature = "broker")]
 impl Encodable for LeaderIdAndEpoch {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 11 {
+            bail!("LeaderIdAndEpoch v{} is not supported", version);
+        }
         if version >= 10 {
             types::Int32.encode(buf, &self.leader_id)?;
         } else {
@@ -302,6 +311,9 @@ impl Encodable for LeaderIdAndEpoch {
 #[cfg(feature = "client")]
 impl Decodable for LeaderIdAndEpoch {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 11 {
+            bail!("LeaderIdAndEpoch v{} is not supported", version);
+        }
         let leader_id = if version >= 10 {
             types::Int32.decode(buf)?
         } else {
@@ -425,6 +437,9 @@ impl NodeEndpoint {
 #[cfg(feature = "broker")]
 impl Encodable for NodeEndpoint {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 11 {
+            bail!("NodeEndpoint v{} is not supported", version);
+        }
         if version >= 10 {
             types::Int32.encode(buf, &self.node_id)?;
         } else {
@@ -516,6 +531,9 @@ impl Encodable for NodeEndpoint {
 #[cfg(feature = "client")]
 impl Decodable for NodeEndpoint {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 11 {
+            bail!("NodeEndpoint v{} is not supported", version);
+        }
         let node_id = if version >= 10 {
             types::Int32.decode(buf)?
         } else {
@@ -709,6 +727,9 @@ impl PartitionProduceResponse {
 #[cfg(feature = "broker")]
 impl Encodable for PartitionProduceResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 11 {
+            bail!("PartitionProduceResponse v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.index)?;
         types::Int16.encode(buf, &self.error_code)?;
         types::Int64.encode(buf, &self.base_offset)?;
@@ -830,6 +851,9 @@ impl Encodable for PartitionProduceResponse {
 #[cfg(feature = "client")]
 impl Decodable for PartitionProduceResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 11 {
+            bail!("PartitionProduceResponse v{} is not supported", version);
+        }
         let index = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let base_offset = types::Int64.decode(buf)?;
@@ -984,6 +1008,9 @@ impl ProduceResponse {
 #[cfg(feature = "broker")]
 impl Encodable for ProduceResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 11 {
+            bail!("ProduceResponse v{} is not supported", version);
+        }
         if version >= 9 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.responses)?;
         } else {
@@ -1075,6 +1102,9 @@ impl Encodable for ProduceResponse {
 #[cfg(feature = "client")]
 impl Decodable for ProduceResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 11 {
+            bail!("ProduceResponse v{} is not supported", version);
+        }
         let responses = if version >= 9 {
             types::CompactArray(types::Struct { version }).decode(buf)?
         } else {
@@ -1185,6 +1215,9 @@ impl TopicProduceResponse {
 #[cfg(feature = "broker")]
 impl Encodable for TopicProduceResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 11 {
+            bail!("TopicProduceResponse v{} is not supported", version);
+        }
         if version >= 9 {
             types::CompactString.encode(buf, &self.name)?;
         } else {
@@ -1243,6 +1276,9 @@ impl Encodable for TopicProduceResponse {
 #[cfg(feature = "client")]
 impl Decodable for TopicProduceResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 11 {
+            bail!("TopicProduceResponse v{} is not supported", version);
+        }
         let name = if version >= 9 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/produce_response.rs
+++ b/src/messages/produce_response.rs
@@ -70,7 +70,7 @@ impl BatchIndexAndErrorMessage {
 impl Encodable for BatchIndexAndErrorMessage {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 11 {
-            bail!("BatchIndexAndErrorMessage v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 8 {
             types::Int32.encode(buf, &self.batch_index)?;
@@ -144,7 +144,7 @@ impl Encodable for BatchIndexAndErrorMessage {
 impl Decodable for BatchIndexAndErrorMessage {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 11 {
-            bail!("BatchIndexAndErrorMessage v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let batch_index = if version >= 8 {
             types::Int32.decode(buf)?
@@ -246,7 +246,7 @@ impl LeaderIdAndEpoch {
 impl Encodable for LeaderIdAndEpoch {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 11 {
-            bail!("LeaderIdAndEpoch v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 10 {
             types::Int32.encode(buf, &self.leader_id)?;
@@ -312,7 +312,7 @@ impl Encodable for LeaderIdAndEpoch {
 impl Decodable for LeaderIdAndEpoch {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 11 {
-            bail!("LeaderIdAndEpoch v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let leader_id = if version >= 10 {
             types::Int32.decode(buf)?
@@ -438,7 +438,7 @@ impl NodeEndpoint {
 impl Encodable for NodeEndpoint {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 11 {
-            bail!("NodeEndpoint v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 10 {
             types::Int32.encode(buf, &self.node_id)?;
@@ -532,7 +532,7 @@ impl Encodable for NodeEndpoint {
 impl Decodable for NodeEndpoint {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 11 {
-            bail!("NodeEndpoint v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let node_id = if version >= 10 {
             types::Int32.decode(buf)?
@@ -728,7 +728,7 @@ impl PartitionProduceResponse {
 impl Encodable for PartitionProduceResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 11 {
-            bail!("PartitionProduceResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.index)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -852,7 +852,7 @@ impl Encodable for PartitionProduceResponse {
 impl Decodable for PartitionProduceResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 11 {
-            bail!("PartitionProduceResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let index = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
@@ -1009,7 +1009,7 @@ impl ProduceResponse {
 impl Encodable for ProduceResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 11 {
-            bail!("ProduceResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 9 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.responses)?;
@@ -1103,7 +1103,7 @@ impl Encodable for ProduceResponse {
 impl Decodable for ProduceResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 11 {
-            bail!("ProduceResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let responses = if version >= 9 {
             types::CompactArray(types::Struct { version }).decode(buf)?
@@ -1216,7 +1216,7 @@ impl TopicProduceResponse {
 impl Encodable for TopicProduceResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 11 {
-            bail!("TopicProduceResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 9 {
             types::CompactString.encode(buf, &self.name)?;
@@ -1277,7 +1277,7 @@ impl Encodable for TopicProduceResponse {
 impl Decodable for TopicProduceResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 11 {
-            bail!("TopicProduceResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = if version >= 9 {
             types::CompactString.decode(buf)?

--- a/src/messages/push_telemetry_request.rs
+++ b/src/messages/push_telemetry_request.rs
@@ -111,6 +111,9 @@ impl PushTelemetryRequest {
 #[cfg(feature = "client")]
 impl Encodable for PushTelemetryRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("PushTelemetryRequest v{} is not supported", version);
+        }
         types::Uuid.encode(buf, &self.client_instance_id)?;
         types::Int32.encode(buf, &self.subscription_id)?;
         types::Boolean.encode(buf, &self.terminating)?;
@@ -152,6 +155,9 @@ impl Encodable for PushTelemetryRequest {
 #[cfg(feature = "broker")]
 impl Decodable for PushTelemetryRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("PushTelemetryRequest v{} is not supported", version);
+        }
         let client_instance_id = types::Uuid.decode(buf)?;
         let subscription_id = types::Int32.decode(buf)?;
         let terminating = types::Boolean.decode(buf)?;

--- a/src/messages/push_telemetry_request.rs
+++ b/src/messages/push_telemetry_request.rs
@@ -112,7 +112,7 @@ impl PushTelemetryRequest {
 impl Encodable for PushTelemetryRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("PushTelemetryRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Uuid.encode(buf, &self.client_instance_id)?;
         types::Int32.encode(buf, &self.subscription_id)?;
@@ -156,7 +156,7 @@ impl Encodable for PushTelemetryRequest {
 impl Decodable for PushTelemetryRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("PushTelemetryRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let client_instance_id = types::Uuid.decode(buf)?;
         let subscription_id = types::Int32.decode(buf)?;

--- a/src/messages/push_telemetry_response.rs
+++ b/src/messages/push_telemetry_response.rs
@@ -69,6 +69,9 @@ impl PushTelemetryResponse {
 #[cfg(feature = "broker")]
 impl Encodable for PushTelemetryResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("PushTelemetryResponse v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -104,6 +107,9 @@ impl Encodable for PushTelemetryResponse {
 #[cfg(feature = "client")]
 impl Decodable for PushTelemetryResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("PushTelemetryResponse v{} is not supported", version);
+        }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();

--- a/src/messages/push_telemetry_response.rs
+++ b/src/messages/push_telemetry_response.rs
@@ -70,7 +70,7 @@ impl PushTelemetryResponse {
 impl Encodable for PushTelemetryResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("PushTelemetryResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -108,7 +108,7 @@ impl Encodable for PushTelemetryResponse {
 impl Decodable for PushTelemetryResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("PushTelemetryResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;

--- a/src/messages/remove_raft_voter_request.rs
+++ b/src/messages/remove_raft_voter_request.rs
@@ -84,7 +84,7 @@ impl RemoveRaftVoterRequest {
 impl Encodable for RemoveRaftVoterRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("RemoveRaftVoterRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::CompactString.encode(buf, &self.cluster_id)?;
         types::Int32.encode(buf, &self.voter_id)?;
@@ -124,7 +124,7 @@ impl Encodable for RemoveRaftVoterRequest {
 impl Decodable for RemoveRaftVoterRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("RemoveRaftVoterRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let cluster_id = types::CompactString.decode(buf)?;
         let voter_id = types::Int32.decode(buf)?;

--- a/src/messages/remove_raft_voter_request.rs
+++ b/src/messages/remove_raft_voter_request.rs
@@ -83,6 +83,9 @@ impl RemoveRaftVoterRequest {
 #[cfg(feature = "client")]
 impl Encodable for RemoveRaftVoterRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("RemoveRaftVoterRequest v{} is not supported", version);
+        }
         types::CompactString.encode(buf, &self.cluster_id)?;
         types::Int32.encode(buf, &self.voter_id)?;
         types::Uuid.encode(buf, &self.voter_directory_id)?;
@@ -120,6 +123,9 @@ impl Encodable for RemoveRaftVoterRequest {
 #[cfg(feature = "broker")]
 impl Decodable for RemoveRaftVoterRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("RemoveRaftVoterRequest v{} is not supported", version);
+        }
         let cluster_id = types::CompactString.decode(buf)?;
         let voter_id = types::Int32.decode(buf)?;
         let voter_directory_id = types::Uuid.decode(buf)?;

--- a/src/messages/remove_raft_voter_response.rs
+++ b/src/messages/remove_raft_voter_response.rs
@@ -84,7 +84,7 @@ impl RemoveRaftVoterResponse {
 impl Encodable for RemoveRaftVoterResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("RemoveRaftVoterResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -124,7 +124,7 @@ impl Encodable for RemoveRaftVoterResponse {
 impl Decodable for RemoveRaftVoterResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("RemoveRaftVoterResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;

--- a/src/messages/remove_raft_voter_response.rs
+++ b/src/messages/remove_raft_voter_response.rs
@@ -83,6 +83,9 @@ impl RemoveRaftVoterResponse {
 #[cfg(feature = "broker")]
 impl Encodable for RemoveRaftVoterResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("RemoveRaftVoterResponse v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
         types::CompactString.encode(buf, &self.error_message)?;
@@ -120,6 +123,9 @@ impl Encodable for RemoveRaftVoterResponse {
 #[cfg(feature = "client")]
 impl Decodable for RemoveRaftVoterResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("RemoveRaftVoterResponse v{} is not supported", version);
+        }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let error_message = types::CompactString.decode(buf)?;

--- a/src/messages/renew_delegation_token_request.rs
+++ b/src/messages/renew_delegation_token_request.rs
@@ -69,6 +69,9 @@ impl RenewDelegationTokenRequest {
 #[cfg(feature = "client")]
 impl Encodable for RenewDelegationTokenRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 2 {
+            bail!("RenewDelegationTokenRequest v{} is not supported", version);
+        }
         if version >= 2 {
             types::CompactBytes.encode(buf, &self.hmac)?;
         } else {
@@ -116,6 +119,9 @@ impl Encodable for RenewDelegationTokenRequest {
 #[cfg(feature = "broker")]
 impl Decodable for RenewDelegationTokenRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 2 {
+            bail!("RenewDelegationTokenRequest v{} is not supported", version);
+        }
         let hmac = if version >= 2 {
             types::CompactBytes.decode(buf)?
         } else {

--- a/src/messages/renew_delegation_token_request.rs
+++ b/src/messages/renew_delegation_token_request.rs
@@ -70,7 +70,7 @@ impl RenewDelegationTokenRequest {
 impl Encodable for RenewDelegationTokenRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 2 {
-            bail!("RenewDelegationTokenRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 2 {
             types::CompactBytes.encode(buf, &self.hmac)?;
@@ -120,7 +120,7 @@ impl Encodable for RenewDelegationTokenRequest {
 impl Decodable for RenewDelegationTokenRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 2 {
-            bail!("RenewDelegationTokenRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let hmac = if version >= 2 {
             types::CompactBytes.decode(buf)?

--- a/src/messages/renew_delegation_token_response.rs
+++ b/src/messages/renew_delegation_token_response.rs
@@ -83,6 +83,9 @@ impl RenewDelegationTokenResponse {
 #[cfg(feature = "broker")]
 impl Encodable for RenewDelegationTokenResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 2 {
+            bail!("RenewDelegationTokenResponse v{} is not supported", version);
+        }
         types::Int16.encode(buf, &self.error_code)?;
         types::Int64.encode(buf, &self.expiry_timestamp_ms)?;
         types::Int32.encode(buf, &self.throttle_time_ms)?;
@@ -124,6 +127,9 @@ impl Encodable for RenewDelegationTokenResponse {
 #[cfg(feature = "client")]
 impl Decodable for RenewDelegationTokenResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 2 {
+            bail!("RenewDelegationTokenResponse v{} is not supported", version);
+        }
         let error_code = types::Int16.decode(buf)?;
         let expiry_timestamp_ms = types::Int64.decode(buf)?;
         let throttle_time_ms = types::Int32.decode(buf)?;

--- a/src/messages/renew_delegation_token_response.rs
+++ b/src/messages/renew_delegation_token_response.rs
@@ -84,7 +84,7 @@ impl RenewDelegationTokenResponse {
 impl Encodable for RenewDelegationTokenResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 2 {
-            bail!("RenewDelegationTokenResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int16.encode(buf, &self.error_code)?;
         types::Int64.encode(buf, &self.expiry_timestamp_ms)?;
@@ -128,7 +128,7 @@ impl Encodable for RenewDelegationTokenResponse {
 impl Decodable for RenewDelegationTokenResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 2 {
-            bail!("RenewDelegationTokenResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let error_code = types::Int16.decode(buf)?;
         let expiry_timestamp_ms = types::Int64.decode(buf)?;

--- a/src/messages/request_header.rs
+++ b/src/messages/request_header.rs
@@ -96,6 +96,9 @@ impl RequestHeader {
 
 impl Encodable for RequestHeader {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 2 {
+            bail!("RequestHeader v{} is not supported", version);
+        }
         types::Int16.encode(buf, &self.request_api_key)?;
         types::Int16.encode(buf, &self.request_api_version)?;
         types::Int32.encode(buf, &self.correlation_id)?;
@@ -142,6 +145,9 @@ impl Encodable for RequestHeader {
 
 impl Decodable for RequestHeader {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 2 {
+            bail!("RequestHeader v{} is not supported", version);
+        }
         let request_api_key = types::Int16.decode(buf)?;
         let request_api_version = types::Int16.decode(buf)?;
         let correlation_id = types::Int32.decode(buf)?;

--- a/src/messages/request_header.rs
+++ b/src/messages/request_header.rs
@@ -97,7 +97,7 @@ impl RequestHeader {
 impl Encodable for RequestHeader {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 2 {
-            bail!("RequestHeader v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int16.encode(buf, &self.request_api_key)?;
         types::Int16.encode(buf, &self.request_api_version)?;
@@ -146,7 +146,7 @@ impl Encodable for RequestHeader {
 impl Decodable for RequestHeader {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 2 {
-            bail!("RequestHeader v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let request_api_key = types::Int16.decode(buf)?;
         let request_api_version = types::Int16.decode(buf)?;

--- a/src/messages/response_header.rs
+++ b/src/messages/response_header.rs
@@ -55,7 +55,7 @@ impl ResponseHeader {
 impl Encodable for ResponseHeader {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("ResponseHeader v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.correlation_id)?;
         if version >= 1 {
@@ -94,7 +94,7 @@ impl Encodable for ResponseHeader {
 impl Decodable for ResponseHeader {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("ResponseHeader v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let correlation_id = types::Int32.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();

--- a/src/messages/response_header.rs
+++ b/src/messages/response_header.rs
@@ -54,6 +54,9 @@ impl ResponseHeader {
 
 impl Encodable for ResponseHeader {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("ResponseHeader v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.correlation_id)?;
         if version >= 1 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -90,6 +93,9 @@ impl Encodable for ResponseHeader {
 
 impl Decodable for ResponseHeader {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("ResponseHeader v{} is not supported", version);
+        }
         let correlation_id = types::Int32.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
         if version >= 1 {

--- a/src/messages/sasl_authenticate_request.rs
+++ b/src/messages/sasl_authenticate_request.rs
@@ -56,7 +56,7 @@ impl SaslAuthenticateRequest {
 impl Encodable for SaslAuthenticateRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 2 {
-            bail!("SaslAuthenticateRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 2 {
             types::CompactBytes.encode(buf, &self.auth_bytes)?;
@@ -104,7 +104,7 @@ impl Encodable for SaslAuthenticateRequest {
 impl Decodable for SaslAuthenticateRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 2 {
-            bail!("SaslAuthenticateRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let auth_bytes = if version >= 2 {
             types::CompactBytes.decode(buf)?

--- a/src/messages/sasl_authenticate_request.rs
+++ b/src/messages/sasl_authenticate_request.rs
@@ -55,6 +55,9 @@ impl SaslAuthenticateRequest {
 #[cfg(feature = "client")]
 impl Encodable for SaslAuthenticateRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 2 {
+            bail!("SaslAuthenticateRequest v{} is not supported", version);
+        }
         if version >= 2 {
             types::CompactBytes.encode(buf, &self.auth_bytes)?;
         } else {
@@ -100,6 +103,9 @@ impl Encodable for SaslAuthenticateRequest {
 #[cfg(feature = "broker")]
 impl Decodable for SaslAuthenticateRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 2 {
+            bail!("SaslAuthenticateRequest v{} is not supported", version);
+        }
         let auth_bytes = if version >= 2 {
             types::CompactBytes.decode(buf)?
         } else {

--- a/src/messages/sasl_authenticate_response.rs
+++ b/src/messages/sasl_authenticate_response.rs
@@ -97,6 +97,9 @@ impl SaslAuthenticateResponse {
 #[cfg(feature = "broker")]
 impl Encodable for SaslAuthenticateResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 2 {
+            bail!("SaslAuthenticateResponse v{} is not supported", version);
+        }
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 2 {
             types::CompactString.encode(buf, &self.error_message)?;
@@ -160,6 +163,9 @@ impl Encodable for SaslAuthenticateResponse {
 #[cfg(feature = "client")]
 impl Decodable for SaslAuthenticateResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 2 {
+            bail!("SaslAuthenticateResponse v{} is not supported", version);
+        }
         let error_code = types::Int16.decode(buf)?;
         let error_message = if version >= 2 {
             types::CompactString.decode(buf)?

--- a/src/messages/sasl_authenticate_response.rs
+++ b/src/messages/sasl_authenticate_response.rs
@@ -98,7 +98,7 @@ impl SaslAuthenticateResponse {
 impl Encodable for SaslAuthenticateResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 2 {
-            bail!("SaslAuthenticateResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 2 {
@@ -164,7 +164,7 @@ impl Encodable for SaslAuthenticateResponse {
 impl Decodable for SaslAuthenticateResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 2 {
-            bail!("SaslAuthenticateResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let error_code = types::Int16.decode(buf)?;
         let error_message = if version >= 2 {

--- a/src/messages/sasl_handshake_request.rs
+++ b/src/messages/sasl_handshake_request.rs
@@ -42,6 +42,9 @@ impl SaslHandshakeRequest {
 #[cfg(feature = "client")]
 impl Encodable for SaslHandshakeRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("SaslHandshakeRequest v{} is not supported", version);
+        }
         types::String.encode(buf, &self.mechanism)?;
 
         Ok(())
@@ -57,6 +60,9 @@ impl Encodable for SaslHandshakeRequest {
 #[cfg(feature = "broker")]
 impl Decodable for SaslHandshakeRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("SaslHandshakeRequest v{} is not supported", version);
+        }
         let mechanism = types::String.decode(buf)?;
         Ok(Self { mechanism })
     }

--- a/src/messages/sasl_handshake_request.rs
+++ b/src/messages/sasl_handshake_request.rs
@@ -43,7 +43,7 @@ impl SaslHandshakeRequest {
 impl Encodable for SaslHandshakeRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("SaslHandshakeRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::String.encode(buf, &self.mechanism)?;
 
@@ -61,7 +61,7 @@ impl Encodable for SaslHandshakeRequest {
 impl Decodable for SaslHandshakeRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("SaslHandshakeRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let mechanism = types::String.decode(buf)?;
         Ok(Self { mechanism })

--- a/src/messages/sasl_handshake_response.rs
+++ b/src/messages/sasl_handshake_response.rs
@@ -56,6 +56,9 @@ impl SaslHandshakeResponse {
 #[cfg(feature = "broker")]
 impl Encodable for SaslHandshakeResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("SaslHandshakeResponse v{} is not supported", version);
+        }
         types::Int16.encode(buf, &self.error_code)?;
         types::Array(types::String).encode(buf, &self.mechanisms)?;
 
@@ -73,6 +76,9 @@ impl Encodable for SaslHandshakeResponse {
 #[cfg(feature = "client")]
 impl Decodable for SaslHandshakeResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("SaslHandshakeResponse v{} is not supported", version);
+        }
         let error_code = types::Int16.decode(buf)?;
         let mechanisms = types::Array(types::String).decode(buf)?;
         Ok(Self {

--- a/src/messages/sasl_handshake_response.rs
+++ b/src/messages/sasl_handshake_response.rs
@@ -57,7 +57,7 @@ impl SaslHandshakeResponse {
 impl Encodable for SaslHandshakeResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("SaslHandshakeResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int16.encode(buf, &self.error_code)?;
         types::Array(types::String).encode(buf, &self.mechanisms)?;
@@ -77,7 +77,7 @@ impl Encodable for SaslHandshakeResponse {
 impl Decodable for SaslHandshakeResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("SaslHandshakeResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let error_code = types::Int16.decode(buf)?;
         let mechanisms = types::Array(types::String).decode(buf)?;

--- a/src/messages/snapshot_footer_record.rs
+++ b/src/messages/snapshot_footer_record.rs
@@ -55,7 +55,7 @@ impl SnapshotFooterRecord {
 impl Encodable for SnapshotFooterRecord {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("SnapshotFooterRecord v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int16.encode(buf, &self.version)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -90,7 +90,7 @@ impl Encodable for SnapshotFooterRecord {
 impl Decodable for SnapshotFooterRecord {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("SnapshotFooterRecord v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let version = types::Int16.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();

--- a/src/messages/snapshot_footer_record.rs
+++ b/src/messages/snapshot_footer_record.rs
@@ -54,6 +54,9 @@ impl SnapshotFooterRecord {
 
 impl Encodable for SnapshotFooterRecord {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("SnapshotFooterRecord v{} is not supported", version);
+        }
         types::Int16.encode(buf, &self.version)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
@@ -86,6 +89,9 @@ impl Encodable for SnapshotFooterRecord {
 
 impl Decodable for SnapshotFooterRecord {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("SnapshotFooterRecord v{} is not supported", version);
+        }
         let version = types::Int16.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
         let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;

--- a/src/messages/snapshot_header_record.rs
+++ b/src/messages/snapshot_header_record.rs
@@ -69,7 +69,7 @@ impl SnapshotHeaderRecord {
 impl Encodable for SnapshotHeaderRecord {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("SnapshotHeaderRecord v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int16.encode(buf, &self.version)?;
         types::Int64.encode(buf, &self.last_contained_log_timestamp)?;
@@ -106,7 +106,7 @@ impl Encodable for SnapshotHeaderRecord {
 impl Decodable for SnapshotHeaderRecord {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("SnapshotHeaderRecord v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let version = types::Int16.decode(buf)?;
         let last_contained_log_timestamp = types::Int64.decode(buf)?;

--- a/src/messages/snapshot_header_record.rs
+++ b/src/messages/snapshot_header_record.rs
@@ -68,6 +68,9 @@ impl SnapshotHeaderRecord {
 
 impl Encodable for SnapshotHeaderRecord {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("SnapshotHeaderRecord v{} is not supported", version);
+        }
         types::Int16.encode(buf, &self.version)?;
         types::Int64.encode(buf, &self.last_contained_log_timestamp)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -102,6 +105,9 @@ impl Encodable for SnapshotHeaderRecord {
 
 impl Decodable for SnapshotHeaderRecord {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("SnapshotHeaderRecord v{} is not supported", version);
+        }
         let version = types::Int16.decode(buf)?;
         let last_contained_log_timestamp = types::Int64.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();

--- a/src/messages/stop_replica_request.rs
+++ b/src/messages/stop_replica_request.rs
@@ -84,7 +84,7 @@ impl StopReplicaPartitionState {
 impl Encodable for StopReplicaPartitionState {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 4 {
-            bail!("StopReplicaPartitionState v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 3 {
             types::Int32.encode(buf, &self.partition_index)?;
@@ -164,7 +164,7 @@ impl Encodable for StopReplicaPartitionState {
 impl Decodable for StopReplicaPartitionState {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 4 {
-            bail!("StopReplicaPartitionState v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let partition_index = if version >= 3 {
             types::Int32.decode(buf)?
@@ -269,7 +269,7 @@ impl StopReplicaPartitionV0 {
 impl Encodable for StopReplicaPartitionV0 {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 4 {
-            bail!("StopReplicaPartitionV0 v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version == 0 {
             types::String.encode(buf, &self.topic_name)?;
@@ -335,7 +335,7 @@ impl Encodable for StopReplicaPartitionV0 {
 impl Decodable for StopReplicaPartitionV0 {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 4 {
-            bail!("StopReplicaPartitionV0 v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topic_name = if version == 0 {
             types::String.decode(buf)?
@@ -517,7 +517,7 @@ impl StopReplicaRequest {
 impl Encodable for StopReplicaRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 4 {
-            bail!("StopReplicaRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.controller_id)?;
         if version >= 4 {
@@ -646,7 +646,7 @@ impl Encodable for StopReplicaRequest {
 impl Decodable for StopReplicaRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 4 {
-            bail!("StopReplicaRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let controller_id = types::Int32.decode(buf)?;
         let is_k_raft_controller = if version >= 4 {
@@ -782,7 +782,7 @@ impl StopReplicaTopicState {
 impl Encodable for StopReplicaTopicState {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 4 {
-            bail!("StopReplicaTopicState v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 3 {
             types::CompactString.encode(buf, &self.topic_name)?;
@@ -849,7 +849,7 @@ impl Encodable for StopReplicaTopicState {
 impl Decodable for StopReplicaTopicState {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 4 {
-            bail!("StopReplicaTopicState v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topic_name = if version >= 3 {
             types::CompactString.decode(buf)?
@@ -947,7 +947,7 @@ impl StopReplicaTopicV1 {
 impl Encodable for StopReplicaTopicV1 {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 4 {
-            bail!("StopReplicaTopicV1 v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 1 && version <= 2 {
             if version >= 2 {
@@ -1030,7 +1030,7 @@ impl Encodable for StopReplicaTopicV1 {
 impl Decodable for StopReplicaTopicV1 {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 4 {
-            bail!("StopReplicaTopicV1 v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = if version >= 1 && version <= 2 {
             if version >= 2 {

--- a/src/messages/stop_replica_request.rs
+++ b/src/messages/stop_replica_request.rs
@@ -83,6 +83,9 @@ impl StopReplicaPartitionState {
 #[cfg(feature = "client")]
 impl Encodable for StopReplicaPartitionState {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 4 {
+            bail!("StopReplicaPartitionState v{} is not supported", version);
+        }
         if version >= 3 {
             types::Int32.encode(buf, &self.partition_index)?;
         } else {
@@ -160,6 +163,9 @@ impl Encodable for StopReplicaPartitionState {
 #[cfg(feature = "broker")]
 impl Decodable for StopReplicaPartitionState {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 4 {
+            bail!("StopReplicaPartitionState v{} is not supported", version);
+        }
         let partition_index = if version >= 3 {
             types::Int32.decode(buf)?
         } else {
@@ -262,6 +268,9 @@ impl StopReplicaPartitionV0 {
 #[cfg(feature = "client")]
 impl Encodable for StopReplicaPartitionV0 {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 4 {
+            bail!("StopReplicaPartitionV0 v{} is not supported", version);
+        }
         if version == 0 {
             types::String.encode(buf, &self.topic_name)?;
         } else {
@@ -325,6 +334,9 @@ impl Encodable for StopReplicaPartitionV0 {
 #[cfg(feature = "broker")]
 impl Decodable for StopReplicaPartitionV0 {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 4 {
+            bail!("StopReplicaPartitionV0 v{} is not supported", version);
+        }
         let topic_name = if version == 0 {
             types::String.decode(buf)?
         } else {
@@ -504,6 +516,9 @@ impl StopReplicaRequest {
 #[cfg(feature = "client")]
 impl Encodable for StopReplicaRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 4 {
+            bail!("StopReplicaRequest v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.controller_id)?;
         if version >= 4 {
             types::Boolean.encode(buf, &self.is_k_raft_controller)?;
@@ -630,6 +645,9 @@ impl Encodable for StopReplicaRequest {
 #[cfg(feature = "broker")]
 impl Decodable for StopReplicaRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 4 {
+            bail!("StopReplicaRequest v{} is not supported", version);
+        }
         let controller_id = types::Int32.decode(buf)?;
         let is_k_raft_controller = if version >= 4 {
             types::Boolean.decode(buf)?
@@ -763,6 +781,9 @@ impl StopReplicaTopicState {
 #[cfg(feature = "client")]
 impl Encodable for StopReplicaTopicState {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 4 {
+            bail!("StopReplicaTopicState v{} is not supported", version);
+        }
         if version >= 3 {
             types::CompactString.encode(buf, &self.topic_name)?;
         } else {
@@ -827,6 +848,9 @@ impl Encodable for StopReplicaTopicState {
 #[cfg(feature = "broker")]
 impl Decodable for StopReplicaTopicState {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 4 {
+            bail!("StopReplicaTopicState v{} is not supported", version);
+        }
         let topic_name = if version >= 3 {
             types::CompactString.decode(buf)?
         } else {
@@ -922,6 +946,9 @@ impl StopReplicaTopicV1 {
 #[cfg(feature = "client")]
 impl Encodable for StopReplicaTopicV1 {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 4 {
+            bail!("StopReplicaTopicV1 v{} is not supported", version);
+        }
         if version >= 1 && version <= 2 {
             if version >= 2 {
                 types::CompactString.encode(buf, &self.name)?;
@@ -1002,6 +1029,9 @@ impl Encodable for StopReplicaTopicV1 {
 #[cfg(feature = "broker")]
 impl Decodable for StopReplicaTopicV1 {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 4 {
+            bail!("StopReplicaTopicV1 v{} is not supported", version);
+        }
         let name = if version >= 1 && version <= 2 {
             if version >= 2 {
                 types::CompactString.decode(buf)?

--- a/src/messages/stop_replica_response.rs
+++ b/src/messages/stop_replica_response.rs
@@ -84,7 +84,7 @@ impl StopReplicaPartitionError {
 impl Encodable for StopReplicaPartitionError {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 4 {
-            bail!("StopReplicaPartitionError v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 2 {
             types::CompactString.encode(buf, &self.topic_name)?;
@@ -136,7 +136,7 @@ impl Encodable for StopReplicaPartitionError {
 impl Decodable for StopReplicaPartitionError {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 4 {
-            bail!("StopReplicaPartitionError v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topic_name = if version >= 2 {
             types::CompactString.decode(buf)?
@@ -233,7 +233,7 @@ impl StopReplicaResponse {
 impl Encodable for StopReplicaResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 4 {
-            bail!("StopReplicaResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 2 {
@@ -285,7 +285,7 @@ impl Encodable for StopReplicaResponse {
 impl Decodable for StopReplicaResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 4 {
-            bail!("StopReplicaResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let error_code = types::Int16.decode(buf)?;
         let partition_errors = if version >= 2 {

--- a/src/messages/stop_replica_response.rs
+++ b/src/messages/stop_replica_response.rs
@@ -83,6 +83,9 @@ impl StopReplicaPartitionError {
 #[cfg(feature = "broker")]
 impl Encodable for StopReplicaPartitionError {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 4 {
+            bail!("StopReplicaPartitionError v{} is not supported", version);
+        }
         if version >= 2 {
             types::CompactString.encode(buf, &self.topic_name)?;
         } else {
@@ -132,6 +135,9 @@ impl Encodable for StopReplicaPartitionError {
 #[cfg(feature = "client")]
 impl Decodable for StopReplicaPartitionError {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 4 {
+            bail!("StopReplicaPartitionError v{} is not supported", version);
+        }
         let topic_name = if version >= 2 {
             types::CompactString.decode(buf)?
         } else {
@@ -226,6 +232,9 @@ impl StopReplicaResponse {
 #[cfg(feature = "broker")]
 impl Encodable for StopReplicaResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 4 {
+            bail!("StopReplicaResponse v{} is not supported", version);
+        }
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 2 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.partition_errors)?;
@@ -275,6 +284,9 @@ impl Encodable for StopReplicaResponse {
 #[cfg(feature = "client")]
 impl Decodable for StopReplicaResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 4 {
+            bail!("StopReplicaResponse v{} is not supported", version);
+        }
         let error_code = types::Int16.decode(buf)?;
         let partition_errors = if version >= 2 {
             types::CompactArray(types::Struct { version }).decode(buf)?

--- a/src/messages/sync_group_request.rs
+++ b/src/messages/sync_group_request.rs
@@ -139,6 +139,9 @@ impl SyncGroupRequest {
 #[cfg(feature = "client")]
 impl Encodable for SyncGroupRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 5 {
+            bail!("SyncGroupRequest v{} is not supported", version);
+        }
         if version >= 4 {
             types::CompactString.encode(buf, &self.group_id)?;
         } else {
@@ -242,6 +245,9 @@ impl Encodable for SyncGroupRequest {
 #[cfg(feature = "broker")]
 impl Decodable for SyncGroupRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 5 {
+            bail!("SyncGroupRequest v{} is not supported", version);
+        }
         let group_id = if version >= 4 {
             types::CompactString.decode(buf)?
         } else {
@@ -372,6 +378,9 @@ impl SyncGroupRequestAssignment {
 #[cfg(feature = "client")]
 impl Encodable for SyncGroupRequestAssignment {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 5 {
+            bail!("SyncGroupRequestAssignment v{} is not supported", version);
+        }
         if version >= 4 {
             types::CompactString.encode(buf, &self.member_id)?;
         } else {
@@ -427,6 +436,9 @@ impl Encodable for SyncGroupRequestAssignment {
 #[cfg(feature = "broker")]
 impl Decodable for SyncGroupRequestAssignment {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 5 {
+            bail!("SyncGroupRequestAssignment v{} is not supported", version);
+        }
         let member_id = if version >= 4 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/sync_group_request.rs
+++ b/src/messages/sync_group_request.rs
@@ -140,7 +140,7 @@ impl SyncGroupRequest {
 impl Encodable for SyncGroupRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 5 {
-            bail!("SyncGroupRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 4 {
             types::CompactString.encode(buf, &self.group_id)?;
@@ -246,7 +246,7 @@ impl Encodable for SyncGroupRequest {
 impl Decodable for SyncGroupRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 5 {
-            bail!("SyncGroupRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let group_id = if version >= 4 {
             types::CompactString.decode(buf)?
@@ -379,7 +379,7 @@ impl SyncGroupRequestAssignment {
 impl Encodable for SyncGroupRequestAssignment {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 5 {
-            bail!("SyncGroupRequestAssignment v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 4 {
             types::CompactString.encode(buf, &self.member_id)?;
@@ -437,7 +437,7 @@ impl Encodable for SyncGroupRequestAssignment {
 impl Decodable for SyncGroupRequestAssignment {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 5 {
-            bail!("SyncGroupRequestAssignment v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let member_id = if version >= 4 {
             types::CompactString.decode(buf)?

--- a/src/messages/sync_group_response.rs
+++ b/src/messages/sync_group_response.rs
@@ -112,7 +112,7 @@ impl SyncGroupResponse {
 impl Encodable for SyncGroupResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 5 {
-            bail!("SyncGroupResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 1 {
             types::Int32.encode(buf, &self.throttle_time_ms)?;
@@ -180,7 +180,7 @@ impl Encodable for SyncGroupResponse {
 impl Decodable for SyncGroupResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 5 {
-            bail!("SyncGroupResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = if version >= 1 {
             types::Int32.decode(buf)?

--- a/src/messages/sync_group_response.rs
+++ b/src/messages/sync_group_response.rs
@@ -111,6 +111,9 @@ impl SyncGroupResponse {
 #[cfg(feature = "broker")]
 impl Encodable for SyncGroupResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 5 {
+            bail!("SyncGroupResponse v{} is not supported", version);
+        }
         if version >= 1 {
             types::Int32.encode(buf, &self.throttle_time_ms)?;
         }
@@ -176,6 +179,9 @@ impl Encodable for SyncGroupResponse {
 #[cfg(feature = "client")]
 impl Decodable for SyncGroupResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 5 {
+            bail!("SyncGroupResponse v{} is not supported", version);
+        }
         let throttle_time_ms = if version >= 1 {
             types::Int32.decode(buf)?
         } else {

--- a/src/messages/txn_offset_commit_request.rs
+++ b/src/messages/txn_offset_commit_request.rs
@@ -153,6 +153,9 @@ impl TxnOffsetCommitRequest {
 #[cfg(feature = "client")]
 impl Encodable for TxnOffsetCommitRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 4 {
+            bail!("TxnOffsetCommitRequest v{} is not supported", version);
+        }
         if version >= 3 {
             types::CompactString.encode(buf, &self.transactional_id)?;
         } else {
@@ -265,6 +268,9 @@ impl Encodable for TxnOffsetCommitRequest {
 #[cfg(feature = "broker")]
 impl Decodable for TxnOffsetCommitRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 4 {
+            bail!("TxnOffsetCommitRequest v{} is not supported", version);
+        }
         let transactional_id = if version >= 3 {
             types::CompactString.decode(buf)?
         } else {
@@ -422,6 +428,12 @@ impl TxnOffsetCommitRequestPartition {
 #[cfg(feature = "client")]
 impl Encodable for TxnOffsetCommitRequestPartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 4 {
+            bail!(
+                "TxnOffsetCommitRequestPartition v{} is not supported",
+                version
+            );
+        }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int64.encode(buf, &self.committed_offset)?;
         if version >= 2 {
@@ -477,6 +489,12 @@ impl Encodable for TxnOffsetCommitRequestPartition {
 #[cfg(feature = "broker")]
 impl Decodable for TxnOffsetCommitRequestPartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 4 {
+            bail!(
+                "TxnOffsetCommitRequestPartition v{} is not supported",
+                version
+            );
+        }
         let partition_index = types::Int32.decode(buf)?;
         let committed_offset = types::Int64.decode(buf)?;
         let committed_leader_epoch = if version >= 2 {
@@ -578,6 +596,9 @@ impl TxnOffsetCommitRequestTopic {
 #[cfg(feature = "client")]
 impl Encodable for TxnOffsetCommitRequestTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 4 {
+            bail!("TxnOffsetCommitRequestTopic v{} is not supported", version);
+        }
         if version >= 3 {
             types::CompactString.encode(buf, &self.name)?;
         } else {
@@ -634,6 +655,9 @@ impl Encodable for TxnOffsetCommitRequestTopic {
 #[cfg(feature = "broker")]
 impl Decodable for TxnOffsetCommitRequestTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 4 {
+            bail!("TxnOffsetCommitRequestTopic v{} is not supported", version);
+        }
         let name = if version >= 3 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/txn_offset_commit_request.rs
+++ b/src/messages/txn_offset_commit_request.rs
@@ -154,7 +154,7 @@ impl TxnOffsetCommitRequest {
 impl Encodable for TxnOffsetCommitRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 4 {
-            bail!("TxnOffsetCommitRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 3 {
             types::CompactString.encode(buf, &self.transactional_id)?;
@@ -269,7 +269,7 @@ impl Encodable for TxnOffsetCommitRequest {
 impl Decodable for TxnOffsetCommitRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 4 {
-            bail!("TxnOffsetCommitRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let transactional_id = if version >= 3 {
             types::CompactString.decode(buf)?
@@ -429,10 +429,7 @@ impl TxnOffsetCommitRequestPartition {
 impl Encodable for TxnOffsetCommitRequestPartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 4 {
-            bail!(
-                "TxnOffsetCommitRequestPartition v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int64.encode(buf, &self.committed_offset)?;
@@ -490,10 +487,7 @@ impl Encodable for TxnOffsetCommitRequestPartition {
 impl Decodable for TxnOffsetCommitRequestPartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 4 {
-            bail!(
-                "TxnOffsetCommitRequestPartition v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         let partition_index = types::Int32.decode(buf)?;
         let committed_offset = types::Int64.decode(buf)?;
@@ -597,7 +591,7 @@ impl TxnOffsetCommitRequestTopic {
 impl Encodable for TxnOffsetCommitRequestTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 4 {
-            bail!("TxnOffsetCommitRequestTopic v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 3 {
             types::CompactString.encode(buf, &self.name)?;
@@ -656,7 +650,7 @@ impl Encodable for TxnOffsetCommitRequestTopic {
 impl Decodable for TxnOffsetCommitRequestTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 4 {
-            bail!("TxnOffsetCommitRequestTopic v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = if version >= 3 {
             types::CompactString.decode(buf)?

--- a/src/messages/txn_offset_commit_response.rs
+++ b/src/messages/txn_offset_commit_response.rs
@@ -70,7 +70,7 @@ impl TxnOffsetCommitResponse {
 impl Encodable for TxnOffsetCommitResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 4 {
-            bail!("TxnOffsetCommitResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         if version >= 3 {
@@ -121,7 +121,7 @@ impl Encodable for TxnOffsetCommitResponse {
 impl Decodable for TxnOffsetCommitResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 4 {
-            bail!("TxnOffsetCommitResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let topics = if version >= 3 {
@@ -215,10 +215,7 @@ impl TxnOffsetCommitResponsePartition {
 impl Encodable for TxnOffsetCommitResponsePartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 4 {
-            bail!(
-                "TxnOffsetCommitResponsePartition v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -260,10 +257,7 @@ impl Encodable for TxnOffsetCommitResponsePartition {
 impl Decodable for TxnOffsetCommitResponsePartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 4 {
-            bail!(
-                "TxnOffsetCommitResponsePartition v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         let partition_index = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
@@ -353,7 +347,7 @@ impl TxnOffsetCommitResponseTopic {
 impl Encodable for TxnOffsetCommitResponseTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 4 {
-            bail!("TxnOffsetCommitResponseTopic v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 3 {
             types::CompactString.encode(buf, &self.name)?;
@@ -412,7 +406,7 @@ impl Encodable for TxnOffsetCommitResponseTopic {
 impl Decodable for TxnOffsetCommitResponseTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 4 {
-            bail!("TxnOffsetCommitResponseTopic v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = if version >= 3 {
             types::CompactString.decode(buf)?

--- a/src/messages/txn_offset_commit_response.rs
+++ b/src/messages/txn_offset_commit_response.rs
@@ -69,6 +69,9 @@ impl TxnOffsetCommitResponse {
 #[cfg(feature = "broker")]
 impl Encodable for TxnOffsetCommitResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 4 {
+            bail!("TxnOffsetCommitResponse v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         if version >= 3 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
@@ -117,6 +120,9 @@ impl Encodable for TxnOffsetCommitResponse {
 #[cfg(feature = "client")]
 impl Decodable for TxnOffsetCommitResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 4 {
+            bail!("TxnOffsetCommitResponse v{} is not supported", version);
+        }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let topics = if version >= 3 {
             types::CompactArray(types::Struct { version }).decode(buf)?
@@ -208,6 +214,12 @@ impl TxnOffsetCommitResponsePartition {
 #[cfg(feature = "broker")]
 impl Encodable for TxnOffsetCommitResponsePartition {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 4 {
+            bail!(
+                "TxnOffsetCommitResponsePartition v{} is not supported",
+                version
+            );
+        }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 3 {
@@ -247,6 +259,12 @@ impl Encodable for TxnOffsetCommitResponsePartition {
 #[cfg(feature = "client")]
 impl Decodable for TxnOffsetCommitResponsePartition {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 4 {
+            bail!(
+                "TxnOffsetCommitResponsePartition v{} is not supported",
+                version
+            );
+        }
         let partition_index = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
@@ -334,6 +352,9 @@ impl TxnOffsetCommitResponseTopic {
 #[cfg(feature = "broker")]
 impl Encodable for TxnOffsetCommitResponseTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 4 {
+            bail!("TxnOffsetCommitResponseTopic v{} is not supported", version);
+        }
         if version >= 3 {
             types::CompactString.encode(buf, &self.name)?;
         } else {
@@ -390,6 +411,9 @@ impl Encodable for TxnOffsetCommitResponseTopic {
 #[cfg(feature = "client")]
 impl Decodable for TxnOffsetCommitResponseTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 4 {
+            bail!("TxnOffsetCommitResponseTopic v{} is not supported", version);
+        }
         let name = if version >= 3 {
             types::CompactString.decode(buf)?
         } else {

--- a/src/messages/unregister_broker_request.rs
+++ b/src/messages/unregister_broker_request.rs
@@ -55,6 +55,9 @@ impl UnregisterBrokerRequest {
 #[cfg(feature = "client")]
 impl Encodable for UnregisterBrokerRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("UnregisterBrokerRequest v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.broker_id)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
         if num_tagged_fields > std::u32::MAX as usize {
@@ -88,6 +91,9 @@ impl Encodable for UnregisterBrokerRequest {
 #[cfg(feature = "broker")]
 impl Decodable for UnregisterBrokerRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("UnregisterBrokerRequest v{} is not supported", version);
+        }
         let broker_id = types::Int32.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
         let num_tagged_fields = types::UnsignedVarInt.decode(buf)?;

--- a/src/messages/unregister_broker_request.rs
+++ b/src/messages/unregister_broker_request.rs
@@ -56,7 +56,7 @@ impl UnregisterBrokerRequest {
 impl Encodable for UnregisterBrokerRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("UnregisterBrokerRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.broker_id)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -92,7 +92,7 @@ impl Encodable for UnregisterBrokerRequest {
 impl Decodable for UnregisterBrokerRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("UnregisterBrokerRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let broker_id = types::Int32.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();

--- a/src/messages/unregister_broker_response.rs
+++ b/src/messages/unregister_broker_response.rs
@@ -83,6 +83,9 @@ impl UnregisterBrokerResponse {
 #[cfg(feature = "broker")]
 impl Encodable for UnregisterBrokerResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("UnregisterBrokerResponse v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
         types::CompactString.encode(buf, &self.error_message)?;
@@ -120,6 +123,9 @@ impl Encodable for UnregisterBrokerResponse {
 #[cfg(feature = "client")]
 impl Decodable for UnregisterBrokerResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("UnregisterBrokerResponse v{} is not supported", version);
+        }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let error_message = types::CompactString.decode(buf)?;

--- a/src/messages/unregister_broker_response.rs
+++ b/src/messages/unregister_broker_response.rs
@@ -84,7 +84,7 @@ impl UnregisterBrokerResponse {
 impl Encodable for UnregisterBrokerResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("UnregisterBrokerResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -124,7 +124,7 @@ impl Encodable for UnregisterBrokerResponse {
 impl Decodable for UnregisterBrokerResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("UnregisterBrokerResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;

--- a/src/messages/update_features_request.rs
+++ b/src/messages/update_features_request.rs
@@ -98,7 +98,7 @@ impl FeatureUpdateKey {
 impl Encodable for FeatureUpdateKey {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("FeatureUpdateKey v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::CompactString.encode(buf, &self.feature)?;
         types::Int16.encode(buf, &self.max_version_level)?;
@@ -164,7 +164,7 @@ impl Encodable for FeatureUpdateKey {
 impl Decodable for FeatureUpdateKey {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("FeatureUpdateKey v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let feature = types::CompactString.decode(buf)?;
         let max_version_level = types::Int16.decode(buf)?;
@@ -280,7 +280,7 @@ impl UpdateFeaturesRequest {
 impl Encodable for UpdateFeaturesRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("UpdateFeaturesRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.timeout_ms)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.feature_updates)?;
@@ -333,7 +333,7 @@ impl Encodable for UpdateFeaturesRequest {
 impl Decodable for UpdateFeaturesRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("UpdateFeaturesRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let timeout_ms = types::Int32.decode(buf)?;
         let feature_updates = types::CompactArray(types::Struct { version }).decode(buf)?;

--- a/src/messages/update_features_request.rs
+++ b/src/messages/update_features_request.rs
@@ -97,6 +97,9 @@ impl FeatureUpdateKey {
 #[cfg(feature = "client")]
 impl Encodable for FeatureUpdateKey {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("FeatureUpdateKey v{} is not supported", version);
+        }
         types::CompactString.encode(buf, &self.feature)?;
         types::Int16.encode(buf, &self.max_version_level)?;
         if version == 0 {
@@ -160,6 +163,9 @@ impl Encodable for FeatureUpdateKey {
 #[cfg(feature = "broker")]
 impl Decodable for FeatureUpdateKey {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("FeatureUpdateKey v{} is not supported", version);
+        }
         let feature = types::CompactString.decode(buf)?;
         let max_version_level = types::Int16.decode(buf)?;
         let allow_downgrade = if version == 0 {
@@ -273,6 +279,9 @@ impl UpdateFeaturesRequest {
 #[cfg(feature = "client")]
 impl Encodable for UpdateFeaturesRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("UpdateFeaturesRequest v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.timeout_ms)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.feature_updates)?;
         if version >= 1 {
@@ -323,6 +332,9 @@ impl Encodable for UpdateFeaturesRequest {
 #[cfg(feature = "broker")]
 impl Decodable for UpdateFeaturesRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("UpdateFeaturesRequest v{} is not supported", version);
+        }
         let timeout_ms = types::Int32.decode(buf)?;
         let feature_updates = types::CompactArray(types::Struct { version }).decode(buf)?;
         let validate_only = if version >= 1 {

--- a/src/messages/update_features_response.rs
+++ b/src/messages/update_features_response.rs
@@ -84,7 +84,7 @@ impl UpdatableFeatureResult {
 impl Encodable for UpdatableFeatureResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("UpdatableFeatureResult v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::CompactString.encode(buf, &self.feature)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -124,7 +124,7 @@ impl Encodable for UpdatableFeatureResult {
 impl Decodable for UpdatableFeatureResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("UpdatableFeatureResult v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let feature = types::CompactString.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
@@ -243,7 +243,7 @@ impl UpdateFeaturesResponse {
 impl Encodable for UpdateFeaturesResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("UpdateFeaturesResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -285,7 +285,7 @@ impl Encodable for UpdateFeaturesResponse {
 impl Decodable for UpdateFeaturesResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("UpdateFeaturesResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;

--- a/src/messages/update_features_response.rs
+++ b/src/messages/update_features_response.rs
@@ -83,6 +83,9 @@ impl UpdatableFeatureResult {
 #[cfg(feature = "broker")]
 impl Encodable for UpdatableFeatureResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("UpdatableFeatureResult v{} is not supported", version);
+        }
         types::CompactString.encode(buf, &self.feature)?;
         types::Int16.encode(buf, &self.error_code)?;
         types::CompactString.encode(buf, &self.error_message)?;
@@ -120,6 +123,9 @@ impl Encodable for UpdatableFeatureResult {
 #[cfg(feature = "client")]
 impl Decodable for UpdatableFeatureResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("UpdatableFeatureResult v{} is not supported", version);
+        }
         let feature = types::CompactString.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let error_message = types::CompactString.decode(buf)?;
@@ -236,6 +242,9 @@ impl UpdateFeaturesResponse {
 #[cfg(feature = "broker")]
 impl Encodable for UpdateFeaturesResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("UpdateFeaturesResponse v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
         types::CompactString.encode(buf, &self.error_message)?;
@@ -275,6 +284,9 @@ impl Encodable for UpdateFeaturesResponse {
 #[cfg(feature = "client")]
 impl Decodable for UpdateFeaturesResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("UpdateFeaturesResponse v{} is not supported", version);
+        }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let error_message = types::CompactString.decode(buf)?;

--- a/src/messages/update_metadata_request.rs
+++ b/src/messages/update_metadata_request.rs
@@ -111,6 +111,9 @@ impl UpdateMetadataBroker {
 #[cfg(feature = "client")]
 impl Encodable for UpdateMetadataBroker {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 8 {
+            bail!("UpdateMetadataBroker v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.id)?;
         if version == 0 {
             types::String.encode(buf, &self.v0_host)?;
@@ -190,6 +193,9 @@ impl Encodable for UpdateMetadataBroker {
 #[cfg(feature = "broker")]
 impl Decodable for UpdateMetadataBroker {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 8 {
+            bail!("UpdateMetadataBroker v{} is not supported", version);
+        }
         let id = types::Int32.decode(buf)?;
         let v0_host = if version == 0 {
             types::String.decode(buf)?
@@ -338,6 +344,9 @@ impl UpdateMetadataEndpoint {
 #[cfg(feature = "client")]
 impl Encodable for UpdateMetadataEndpoint {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 8 {
+            bail!("UpdateMetadataEndpoint v{} is not supported", version);
+        }
         if version >= 1 {
             types::Int32.encode(buf, &self.port)?;
         } else {
@@ -437,6 +446,9 @@ impl Encodable for UpdateMetadataEndpoint {
 #[cfg(feature = "broker")]
 impl Decodable for UpdateMetadataEndpoint {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 8 {
+            bail!("UpdateMetadataEndpoint v{} is not supported", version);
+        }
         let port = if version >= 1 {
             types::Int32.decode(buf)?
         } else {
@@ -652,6 +664,9 @@ impl UpdateMetadataPartitionState {
 #[cfg(feature = "client")]
 impl Encodable for UpdateMetadataPartitionState {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 8 {
+            bail!("UpdateMetadataPartitionState v{} is not supported", version);
+        }
         if version <= 4 {
             types::String.encode(buf, &self.topic_name)?;
         }
@@ -738,6 +753,9 @@ impl Encodable for UpdateMetadataPartitionState {
 #[cfg(feature = "broker")]
 impl Decodable for UpdateMetadataPartitionState {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 8 {
+            bail!("UpdateMetadataPartitionState v{} is not supported", version);
+        }
         let topic_name = if version <= 4 {
             types::String.decode(buf)?
         } else {
@@ -953,6 +971,9 @@ impl UpdateMetadataRequest {
 #[cfg(feature = "client")]
 impl Encodable for UpdateMetadataRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 8 {
+            bail!("UpdateMetadataRequest v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.controller_id)?;
         if version >= 8 {
             types::Boolean.encode(buf, &self.is_k_raft_controller)?;
@@ -1100,6 +1121,9 @@ impl Encodable for UpdateMetadataRequest {
 #[cfg(feature = "broker")]
 impl Decodable for UpdateMetadataRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 8 {
+            bail!("UpdateMetadataRequest v{} is not supported", version);
+        }
         let controller_id = types::Int32.decode(buf)?;
         let is_k_raft_controller = if version >= 8 {
             types::Boolean.decode(buf)?
@@ -1254,6 +1278,9 @@ impl UpdateMetadataTopicState {
 #[cfg(feature = "client")]
 impl Encodable for UpdateMetadataTopicState {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 8 {
+            bail!("UpdateMetadataTopicState v{} is not supported", version);
+        }
         if version >= 5 {
             if version >= 6 {
                 types::CompactString.encode(buf, &self.topic_name)?;
@@ -1342,6 +1369,9 @@ impl Encodable for UpdateMetadataTopicState {
 #[cfg(feature = "broker")]
 impl Decodable for UpdateMetadataTopicState {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 8 {
+            bail!("UpdateMetadataTopicState v{} is not supported", version);
+        }
         let topic_name = if version >= 5 {
             if version >= 6 {
                 types::CompactString.decode(buf)?

--- a/src/messages/update_metadata_request.rs
+++ b/src/messages/update_metadata_request.rs
@@ -112,7 +112,7 @@ impl UpdateMetadataBroker {
 impl Encodable for UpdateMetadataBroker {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 8 {
-            bail!("UpdateMetadataBroker v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.id)?;
         if version == 0 {
@@ -194,7 +194,7 @@ impl Encodable for UpdateMetadataBroker {
 impl Decodable for UpdateMetadataBroker {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 8 {
-            bail!("UpdateMetadataBroker v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let id = types::Int32.decode(buf)?;
         let v0_host = if version == 0 {
@@ -345,7 +345,7 @@ impl UpdateMetadataEndpoint {
 impl Encodable for UpdateMetadataEndpoint {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 8 {
-            bail!("UpdateMetadataEndpoint v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 1 {
             types::Int32.encode(buf, &self.port)?;
@@ -447,7 +447,7 @@ impl Encodable for UpdateMetadataEndpoint {
 impl Decodable for UpdateMetadataEndpoint {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 8 {
-            bail!("UpdateMetadataEndpoint v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let port = if version >= 1 {
             types::Int32.decode(buf)?
@@ -665,7 +665,7 @@ impl UpdateMetadataPartitionState {
 impl Encodable for UpdateMetadataPartitionState {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 8 {
-            bail!("UpdateMetadataPartitionState v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version <= 4 {
             types::String.encode(buf, &self.topic_name)?;
@@ -754,7 +754,7 @@ impl Encodable for UpdateMetadataPartitionState {
 impl Decodable for UpdateMetadataPartitionState {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 8 {
-            bail!("UpdateMetadataPartitionState v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topic_name = if version <= 4 {
             types::String.decode(buf)?
@@ -972,7 +972,7 @@ impl UpdateMetadataRequest {
 impl Encodable for UpdateMetadataRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 8 {
-            bail!("UpdateMetadataRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.controller_id)?;
         if version >= 8 {
@@ -1122,7 +1122,7 @@ impl Encodable for UpdateMetadataRequest {
 impl Decodable for UpdateMetadataRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 8 {
-            bail!("UpdateMetadataRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let controller_id = types::Int32.decode(buf)?;
         let is_k_raft_controller = if version >= 8 {
@@ -1279,7 +1279,7 @@ impl UpdateMetadataTopicState {
 impl Encodable for UpdateMetadataTopicState {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 8 {
-            bail!("UpdateMetadataTopicState v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 5 {
             if version >= 6 {
@@ -1370,7 +1370,7 @@ impl Encodable for UpdateMetadataTopicState {
 impl Decodable for UpdateMetadataTopicState {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 8 {
-            bail!("UpdateMetadataTopicState v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topic_name = if version >= 5 {
             if version >= 6 {

--- a/src/messages/update_metadata_response.rs
+++ b/src/messages/update_metadata_response.rs
@@ -55,6 +55,9 @@ impl UpdateMetadataResponse {
 #[cfg(feature = "broker")]
 impl Encodable for UpdateMetadataResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 8 {
+            bail!("UpdateMetadataResponse v{} is not supported", version);
+        }
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 6 {
             let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -92,6 +95,9 @@ impl Encodable for UpdateMetadataResponse {
 #[cfg(feature = "client")]
 impl Decodable for UpdateMetadataResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 8 {
+            bail!("UpdateMetadataResponse v{} is not supported", version);
+        }
         let error_code = types::Int16.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
         if version >= 6 {

--- a/src/messages/update_metadata_response.rs
+++ b/src/messages/update_metadata_response.rs
@@ -56,7 +56,7 @@ impl UpdateMetadataResponse {
 impl Encodable for UpdateMetadataResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 8 {
-            bail!("UpdateMetadataResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 6 {
@@ -96,7 +96,7 @@ impl Encodable for UpdateMetadataResponse {
 impl Decodable for UpdateMetadataResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 8 {
-            bail!("UpdateMetadataResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let error_code = types::Int16.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();

--- a/src/messages/update_raft_voter_request.rs
+++ b/src/messages/update_raft_voter_request.rs
@@ -69,6 +69,9 @@ impl KRaftVersionFeature {
 #[cfg(feature = "client")]
 impl Encodable for KRaftVersionFeature {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("KRaftVersionFeature v{} is not supported", version);
+        }
         types::Int16.encode(buf, &self.min_supported_version)?;
         types::Int16.encode(buf, &self.max_supported_version)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -104,6 +107,9 @@ impl Encodable for KRaftVersionFeature {
 #[cfg(feature = "broker")]
 impl Decodable for KRaftVersionFeature {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("KRaftVersionFeature v{} is not supported", version);
+        }
         let min_supported_version = types::Int16.decode(buf)?;
         let max_supported_version = types::Int16.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
@@ -203,6 +209,9 @@ impl Listener {
 #[cfg(feature = "client")]
 impl Encodable for Listener {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("Listener v{} is not supported", version);
+        }
         types::CompactString.encode(buf, &self.name)?;
         types::CompactString.encode(buf, &self.host)?;
         types::UInt16.encode(buf, &self.port)?;
@@ -240,6 +249,9 @@ impl Encodable for Listener {
 #[cfg(feature = "broker")]
 impl Decodable for Listener {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("Listener v{} is not supported", version);
+        }
         let name = types::CompactString.decode(buf)?;
         let host = types::CompactString.decode(buf)?;
         let port = types::UInt16.decode(buf)?;
@@ -384,6 +396,9 @@ impl UpdateRaftVoterRequest {
 #[cfg(feature = "client")]
 impl Encodable for UpdateRaftVoterRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("UpdateRaftVoterRequest v{} is not supported", version);
+        }
         types::CompactString.encode(buf, &self.cluster_id)?;
         types::Int32.encode(buf, &self.current_leader_epoch)?;
         types::Int32.encode(buf, &self.voter_id)?;
@@ -428,6 +443,9 @@ impl Encodable for UpdateRaftVoterRequest {
 #[cfg(feature = "broker")]
 impl Decodable for UpdateRaftVoterRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("UpdateRaftVoterRequest v{} is not supported", version);
+        }
         let cluster_id = types::CompactString.decode(buf)?;
         let current_leader_epoch = types::Int32.decode(buf)?;
         let voter_id = types::Int32.decode(buf)?;

--- a/src/messages/update_raft_voter_request.rs
+++ b/src/messages/update_raft_voter_request.rs
@@ -70,7 +70,7 @@ impl KRaftVersionFeature {
 impl Encodable for KRaftVersionFeature {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("KRaftVersionFeature v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int16.encode(buf, &self.min_supported_version)?;
         types::Int16.encode(buf, &self.max_supported_version)?;
@@ -108,7 +108,7 @@ impl Encodable for KRaftVersionFeature {
 impl Decodable for KRaftVersionFeature {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("KRaftVersionFeature v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let min_supported_version = types::Int16.decode(buf)?;
         let max_supported_version = types::Int16.decode(buf)?;
@@ -210,7 +210,7 @@ impl Listener {
 impl Encodable for Listener {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("Listener v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::CompactString.encode(buf, &self.name)?;
         types::CompactString.encode(buf, &self.host)?;
@@ -250,7 +250,7 @@ impl Encodable for Listener {
 impl Decodable for Listener {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("Listener v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = types::CompactString.decode(buf)?;
         let host = types::CompactString.decode(buf)?;
@@ -397,7 +397,7 @@ impl UpdateRaftVoterRequest {
 impl Encodable for UpdateRaftVoterRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("UpdateRaftVoterRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::CompactString.encode(buf, &self.cluster_id)?;
         types::Int32.encode(buf, &self.current_leader_epoch)?;
@@ -444,7 +444,7 @@ impl Encodable for UpdateRaftVoterRequest {
 impl Decodable for UpdateRaftVoterRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("UpdateRaftVoterRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let cluster_id = types::CompactString.decode(buf)?;
         let current_leader_epoch = types::Int32.decode(buf)?;

--- a/src/messages/update_raft_voter_response.rs
+++ b/src/messages/update_raft_voter_response.rs
@@ -98,7 +98,7 @@ impl CurrentLeader {
 impl Encodable for CurrentLeader {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("CurrentLeader v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.leader_id)?;
         types::Int32.encode(buf, &self.leader_epoch)?;
@@ -140,7 +140,7 @@ impl Encodable for CurrentLeader {
 impl Decodable for CurrentLeader {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("CurrentLeader v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let leader_id = types::Int32.decode(buf)?;
         let leader_epoch = types::Int32.decode(buf)?;
@@ -248,7 +248,7 @@ impl UpdateRaftVoterResponse {
 impl Encodable for UpdateRaftVoterResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("UpdateRaftVoterResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -316,7 +316,7 @@ impl Encodable for UpdateRaftVoterResponse {
 impl Decodable for UpdateRaftVoterResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("UpdateRaftVoterResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;

--- a/src/messages/update_raft_voter_response.rs
+++ b/src/messages/update_raft_voter_response.rs
@@ -97,6 +97,9 @@ impl CurrentLeader {
 #[cfg(feature = "broker")]
 impl Encodable for CurrentLeader {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("CurrentLeader v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.leader_id)?;
         types::Int32.encode(buf, &self.leader_epoch)?;
         types::CompactString.encode(buf, &self.host)?;
@@ -136,6 +139,9 @@ impl Encodable for CurrentLeader {
 #[cfg(feature = "client")]
 impl Decodable for CurrentLeader {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("CurrentLeader v{} is not supported", version);
+        }
         let leader_id = types::Int32.decode(buf)?;
         let leader_epoch = types::Int32.decode(buf)?;
         let host = types::CompactString.decode(buf)?;
@@ -241,6 +247,9 @@ impl UpdateRaftVoterResponse {
 #[cfg(feature = "broker")]
 impl Encodable for UpdateRaftVoterResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("UpdateRaftVoterResponse v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.throttle_time_ms)?;
         types::Int16.encode(buf, &self.error_code)?;
         let mut num_tagged_fields = self.unknown_tagged_fields.len();
@@ -306,6 +315,9 @@ impl Encodable for UpdateRaftVoterResponse {
 #[cfg(feature = "client")]
 impl Decodable for UpdateRaftVoterResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("UpdateRaftVoterResponse v{} is not supported", version);
+        }
         let throttle_time_ms = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let mut current_leader = Default::default();

--- a/src/messages/vote_request.rs
+++ b/src/messages/vote_request.rs
@@ -140,7 +140,7 @@ impl PartitionData {
 impl Encodable for PartitionData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("PartitionData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int32.encode(buf, &self.candidate_epoch)?;
@@ -196,7 +196,7 @@ impl Encodable for PartitionData {
 impl Decodable for PartitionData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("PartitionData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let partition_index = types::Int32.decode(buf)?;
         let candidate_epoch = types::Int32.decode(buf)?;
@@ -307,7 +307,7 @@ impl TopicData {
 impl Encodable for TopicData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("TopicData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::CompactString.encode(buf, &self.topic_name)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.partitions)?;
@@ -346,7 +346,7 @@ impl Encodable for TopicData {
 impl Decodable for TopicData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("TopicData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topic_name = types::CompactString.decode(buf)?;
         let partitions = types::CompactArray(types::Struct { version }).decode(buf)?;
@@ -448,7 +448,7 @@ impl VoteRequest {
 impl Encodable for VoteRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("VoteRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::CompactString.encode(buf, &self.cluster_id)?;
         if version >= 1 {
@@ -492,7 +492,7 @@ impl Encodable for VoteRequest {
 impl Decodable for VoteRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("VoteRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let cluster_id = types::CompactString.decode(buf)?;
         let voter_id = if version >= 1 {

--- a/src/messages/vote_request.rs
+++ b/src/messages/vote_request.rs
@@ -139,6 +139,9 @@ impl PartitionData {
 #[cfg(feature = "client")]
 impl Encodable for PartitionData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("PartitionData v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int32.encode(buf, &self.candidate_epoch)?;
         types::Int32.encode(buf, &self.candidate_id)?;
@@ -192,6 +195,9 @@ impl Encodable for PartitionData {
 #[cfg(feature = "broker")]
 impl Decodable for PartitionData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("PartitionData v{} is not supported", version);
+        }
         let partition_index = types::Int32.decode(buf)?;
         let candidate_epoch = types::Int32.decode(buf)?;
         let candidate_id = types::Int32.decode(buf)?;
@@ -300,6 +306,9 @@ impl TopicData {
 #[cfg(feature = "client")]
 impl Encodable for TopicData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("TopicData v{} is not supported", version);
+        }
         types::CompactString.encode(buf, &self.topic_name)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.partitions)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -336,6 +345,9 @@ impl Encodable for TopicData {
 #[cfg(feature = "broker")]
 impl Decodable for TopicData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("TopicData v{} is not supported", version);
+        }
         let topic_name = types::CompactString.decode(buf)?;
         let partitions = types::CompactArray(types::Struct { version }).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
@@ -435,6 +447,9 @@ impl VoteRequest {
 #[cfg(feature = "client")]
 impl Encodable for VoteRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("VoteRequest v{} is not supported", version);
+        }
         types::CompactString.encode(buf, &self.cluster_id)?;
         if version >= 1 {
             types::Int32.encode(buf, &self.voter_id)?;
@@ -476,6 +491,9 @@ impl Encodable for VoteRequest {
 #[cfg(feature = "broker")]
 impl Decodable for VoteRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("VoteRequest v{} is not supported", version);
+        }
         let cluster_id = types::CompactString.decode(buf)?;
         let voter_id = if version >= 1 {
             types::Int32.decode(buf)?

--- a/src/messages/vote_response.rs
+++ b/src/messages/vote_response.rs
@@ -83,6 +83,9 @@ impl NodeEndpoint {
 #[cfg(feature = "broker")]
 impl Encodable for NodeEndpoint {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("NodeEndpoint v{} is not supported", version);
+        }
         if version >= 1 {
             types::Int32.encode(buf, &self.node_id)?;
         } else {
@@ -156,6 +159,9 @@ impl Encodable for NodeEndpoint {
 #[cfg(feature = "client")]
 impl Decodable for NodeEndpoint {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("NodeEndpoint v{} is not supported", version);
+        }
         let node_id = if version >= 1 {
             types::Int32.decode(buf)?
         } else {
@@ -298,6 +304,9 @@ impl PartitionData {
 #[cfg(feature = "broker")]
 impl Encodable for PartitionData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("PartitionData v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int16.encode(buf, &self.error_code)?;
         types::Int32.encode(buf, &self.leader_id)?;
@@ -339,6 +348,9 @@ impl Encodable for PartitionData {
 #[cfg(feature = "client")]
 impl Decodable for PartitionData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("PartitionData v{} is not supported", version);
+        }
         let partition_index = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let leader_id = types::Int32.decode(buf)?;
@@ -433,6 +445,9 @@ impl TopicData {
 #[cfg(feature = "broker")]
 impl Encodable for TopicData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("TopicData v{} is not supported", version);
+        }
         types::CompactString.encode(buf, &self.topic_name)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.partitions)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -469,6 +484,9 @@ impl Encodable for TopicData {
 #[cfg(feature = "client")]
 impl Decodable for TopicData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("TopicData v{} is not supported", version);
+        }
         let topic_name = types::CompactString.decode(buf)?;
         let partitions = types::CompactArray(types::Struct { version }).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
@@ -568,6 +586,9 @@ impl VoteResponse {
 #[cfg(feature = "broker")]
 impl Encodable for VoteResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("VoteResponse v{} is not supported", version);
+        }
         types::Int16.encode(buf, &self.error_code)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
         let mut num_tagged_fields = self.unknown_tagged_fields.len();
@@ -641,6 +662,9 @@ impl Encodable for VoteResponse {
 #[cfg(feature = "client")]
 impl Decodable for VoteResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("VoteResponse v{} is not supported", version);
+        }
         let error_code = types::Int16.decode(buf)?;
         let topics = types::CompactArray(types::Struct { version }).decode(buf)?;
         let mut node_endpoints = Default::default();

--- a/src/messages/vote_response.rs
+++ b/src/messages/vote_response.rs
@@ -84,7 +84,7 @@ impl NodeEndpoint {
 impl Encodable for NodeEndpoint {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("NodeEndpoint v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 1 {
             types::Int32.encode(buf, &self.node_id)?;
@@ -160,7 +160,7 @@ impl Encodable for NodeEndpoint {
 impl Decodable for NodeEndpoint {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("NodeEndpoint v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let node_id = if version >= 1 {
             types::Int32.decode(buf)?
@@ -305,7 +305,7 @@ impl PartitionData {
 impl Encodable for PartitionData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("PartitionData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -349,7 +349,7 @@ impl Encodable for PartitionData {
 impl Decodable for PartitionData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("PartitionData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let partition_index = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
@@ -446,7 +446,7 @@ impl TopicData {
 impl Encodable for TopicData {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("TopicData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::CompactString.encode(buf, &self.topic_name)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.partitions)?;
@@ -485,7 +485,7 @@ impl Encodable for TopicData {
 impl Decodable for TopicData {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("TopicData v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let topic_name = types::CompactString.decode(buf)?;
         let partitions = types::CompactArray(types::Struct { version }).decode(buf)?;
@@ -587,7 +587,7 @@ impl VoteResponse {
 impl Encodable for VoteResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("VoteResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int16.encode(buf, &self.error_code)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
@@ -663,7 +663,7 @@ impl Encodable for VoteResponse {
 impl Decodable for VoteResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("VoteResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let error_code = types::Int16.decode(buf)?;
         let topics = types::CompactArray(types::Struct { version }).decode(buf)?;

--- a/src/messages/voters_record.rs
+++ b/src/messages/voters_record.rs
@@ -82,6 +82,9 @@ impl Endpoint {
 
 impl Encodable for Endpoint {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("Endpoint v{} is not supported", version);
+        }
         types::CompactString.encode(buf, &self.name)?;
         types::CompactString.encode(buf, &self.host)?;
         types::UInt16.encode(buf, &self.port)?;
@@ -118,6 +121,9 @@ impl Encodable for Endpoint {
 
 impl Decodable for Endpoint {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("Endpoint v{} is not supported", version);
+        }
         let name = types::CompactString.decode(buf)?;
         let host = types::CompactString.decode(buf)?;
         let port = types::UInt16.decode(buf)?;
@@ -205,6 +211,9 @@ impl KRaftVersionFeature {
 
 impl Encodable for KRaftVersionFeature {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("KRaftVersionFeature v{} is not supported", version);
+        }
         types::Int16.encode(buf, &self.min_supported_version)?;
         types::Int16.encode(buf, &self.max_supported_version)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -239,6 +248,9 @@ impl Encodable for KRaftVersionFeature {
 
 impl Decodable for KRaftVersionFeature {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("KRaftVersionFeature v{} is not supported", version);
+        }
         let min_supported_version = types::Int16.decode(buf)?;
         let max_supported_version = types::Int16.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
@@ -351,6 +363,9 @@ impl Voter {
 
 impl Encodable for Voter {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("Voter v{} is not supported", version);
+        }
         types::Int32.encode(buf, &self.voter_id)?;
         types::Uuid.encode(buf, &self.voter_directory_id)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.endpoints)?;
@@ -390,6 +405,9 @@ impl Encodable for Voter {
 
 impl Decodable for Voter {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("Voter v{} is not supported", version);
+        }
         let voter_id = types::Int32.decode(buf)?;
         let voter_directory_id = types::Uuid.decode(buf)?;
         let endpoints = types::CompactArray(types::Struct { version }).decode(buf)?;
@@ -480,6 +498,9 @@ impl VotersRecord {
 
 impl Encodable for VotersRecord {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version != 0 {
+            bail!("VotersRecord v{} is not supported", version);
+        }
         types::Int16.encode(buf, &self.version)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.voters)?;
         let num_tagged_fields = self.unknown_tagged_fields.len();
@@ -514,6 +535,9 @@ impl Encodable for VotersRecord {
 
 impl Decodable for VotersRecord {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version != 0 {
+            bail!("VotersRecord v{} is not supported", version);
+        }
         let version = types::Int16.decode(buf)?;
         let voters = types::CompactArray(types::Struct { version }).decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();

--- a/src/messages/voters_record.rs
+++ b/src/messages/voters_record.rs
@@ -83,7 +83,7 @@ impl Endpoint {
 impl Encodable for Endpoint {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("Endpoint v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::CompactString.encode(buf, &self.name)?;
         types::CompactString.encode(buf, &self.host)?;
@@ -122,7 +122,7 @@ impl Encodable for Endpoint {
 impl Decodable for Endpoint {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("Endpoint v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = types::CompactString.decode(buf)?;
         let host = types::CompactString.decode(buf)?;
@@ -212,7 +212,7 @@ impl KRaftVersionFeature {
 impl Encodable for KRaftVersionFeature {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("KRaftVersionFeature v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int16.encode(buf, &self.min_supported_version)?;
         types::Int16.encode(buf, &self.max_supported_version)?;
@@ -249,7 +249,7 @@ impl Encodable for KRaftVersionFeature {
 impl Decodable for KRaftVersionFeature {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("KRaftVersionFeature v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let min_supported_version = types::Int16.decode(buf)?;
         let max_supported_version = types::Int16.decode(buf)?;
@@ -364,7 +364,7 @@ impl Voter {
 impl Encodable for Voter {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("Voter v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.voter_id)?;
         types::Uuid.encode(buf, &self.voter_directory_id)?;
@@ -406,7 +406,7 @@ impl Encodable for Voter {
 impl Decodable for Voter {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("Voter v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let voter_id = types::Int32.decode(buf)?;
         let voter_directory_id = types::Uuid.decode(buf)?;
@@ -499,7 +499,7 @@ impl VotersRecord {
 impl Encodable for VotersRecord {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version != 0 {
-            bail!("VotersRecord v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int16.encode(buf, &self.version)?;
         types::CompactArray(types::Struct { version }).encode(buf, &self.voters)?;
@@ -536,7 +536,7 @@ impl Encodable for VotersRecord {
 impl Decodable for VotersRecord {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version != 0 {
-            bail!("VotersRecord v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let version = types::Int16.decode(buf)?;
         let voters = types::CompactArray(types::Struct { version }).decode(buf)?;

--- a/src/messages/write_txn_markers_request.rs
+++ b/src/messages/write_txn_markers_request.rs
@@ -111,6 +111,9 @@ impl WritableTxnMarker {
 #[cfg(feature = "client")]
 impl Encodable for WritableTxnMarker {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("WritableTxnMarker v{} is not supported", version);
+        }
         types::Int64.encode(buf, &self.producer_id)?;
         types::Int16.encode(buf, &self.producer_epoch)?;
         types::Boolean.encode(buf, &self.transaction_result)?;
@@ -165,6 +168,9 @@ impl Encodable for WritableTxnMarker {
 #[cfg(feature = "broker")]
 impl Decodable for WritableTxnMarker {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("WritableTxnMarker v{} is not supported", version);
+        }
         let producer_id = types::Int64.decode(buf)?;
         let producer_epoch = types::Int16.decode(buf)?;
         let transaction_result = types::Boolean.decode(buf)?;
@@ -265,6 +271,9 @@ impl WritableTxnMarkerTopic {
 #[cfg(feature = "client")]
 impl Encodable for WritableTxnMarkerTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("WritableTxnMarkerTopic v{} is not supported", version);
+        }
         if version >= 1 {
             types::CompactString.encode(buf, &self.name)?;
         } else {
@@ -321,6 +330,9 @@ impl Encodable for WritableTxnMarkerTopic {
 #[cfg(feature = "broker")]
 impl Decodable for WritableTxnMarkerTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("WritableTxnMarkerTopic v{} is not supported", version);
+        }
         let name = if version >= 1 {
             types::CompactString.decode(buf)?
         } else {
@@ -402,6 +414,9 @@ impl WriteTxnMarkersRequest {
 #[cfg(feature = "client")]
 impl Encodable for WriteTxnMarkersRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("WriteTxnMarkersRequest v{} is not supported", version);
+        }
         if version >= 1 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.markers)?;
         } else {
@@ -448,6 +463,9 @@ impl Encodable for WriteTxnMarkersRequest {
 #[cfg(feature = "broker")]
 impl Decodable for WriteTxnMarkersRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("WriteTxnMarkersRequest v{} is not supported", version);
+        }
         let markers = if version >= 1 {
             types::CompactArray(types::Struct { version }).decode(buf)?
         } else {

--- a/src/messages/write_txn_markers_request.rs
+++ b/src/messages/write_txn_markers_request.rs
@@ -112,7 +112,7 @@ impl WritableTxnMarker {
 impl Encodable for WritableTxnMarker {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("WritableTxnMarker v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int64.encode(buf, &self.producer_id)?;
         types::Int16.encode(buf, &self.producer_epoch)?;
@@ -169,7 +169,7 @@ impl Encodable for WritableTxnMarker {
 impl Decodable for WritableTxnMarker {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("WritableTxnMarker v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let producer_id = types::Int64.decode(buf)?;
         let producer_epoch = types::Int16.decode(buf)?;
@@ -272,7 +272,7 @@ impl WritableTxnMarkerTopic {
 impl Encodable for WritableTxnMarkerTopic {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("WritableTxnMarkerTopic v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 1 {
             types::CompactString.encode(buf, &self.name)?;
@@ -331,7 +331,7 @@ impl Encodable for WritableTxnMarkerTopic {
 impl Decodable for WritableTxnMarkerTopic {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("WritableTxnMarkerTopic v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = if version >= 1 {
             types::CompactString.decode(buf)?
@@ -415,7 +415,7 @@ impl WriteTxnMarkersRequest {
 impl Encodable for WriteTxnMarkersRequest {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("WriteTxnMarkersRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 1 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.markers)?;
@@ -464,7 +464,7 @@ impl Encodable for WriteTxnMarkersRequest {
 impl Decodable for WriteTxnMarkersRequest {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("WriteTxnMarkersRequest v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let markers = if version >= 1 {
             types::CompactArray(types::Struct { version }).decode(buf)?

--- a/src/messages/write_txn_markers_response.rs
+++ b/src/messages/write_txn_markers_response.rs
@@ -69,6 +69,12 @@ impl WritableTxnMarkerPartitionResult {
 #[cfg(feature = "broker")]
 impl Encodable for WritableTxnMarkerPartitionResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!(
+                "WritableTxnMarkerPartitionResult v{} is not supported",
+                version
+            );
+        }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int16.encode(buf, &self.error_code)?;
         if version >= 1 {
@@ -108,6 +114,12 @@ impl Encodable for WritableTxnMarkerPartitionResult {
 #[cfg(feature = "client")]
 impl Decodable for WritableTxnMarkerPartitionResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!(
+                "WritableTxnMarkerPartitionResult v{} is not supported",
+                version
+            );
+        }
         let partition_index = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
         let mut unknown_tagged_fields = BTreeMap::new();
@@ -195,6 +207,9 @@ impl WritableTxnMarkerResult {
 #[cfg(feature = "broker")]
 impl Encodable for WritableTxnMarkerResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("WritableTxnMarkerResult v{} is not supported", version);
+        }
         types::Int64.encode(buf, &self.producer_id)?;
         if version >= 1 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.topics)?;
@@ -243,6 +258,9 @@ impl Encodable for WritableTxnMarkerResult {
 #[cfg(feature = "client")]
 impl Decodable for WritableTxnMarkerResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("WritableTxnMarkerResult v{} is not supported", version);
+        }
         let producer_id = types::Int64.decode(buf)?;
         let topics = if version >= 1 {
             types::CompactArray(types::Struct { version }).decode(buf)?
@@ -334,6 +352,9 @@ impl WritableTxnMarkerTopicResult {
 #[cfg(feature = "broker")]
 impl Encodable for WritableTxnMarkerTopicResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("WritableTxnMarkerTopicResult v{} is not supported", version);
+        }
         if version >= 1 {
             types::CompactString.encode(buf, &self.name)?;
         } else {
@@ -390,6 +411,9 @@ impl Encodable for WritableTxnMarkerTopicResult {
 #[cfg(feature = "client")]
 impl Decodable for WritableTxnMarkerTopicResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("WritableTxnMarkerTopicResult v{} is not supported", version);
+        }
         let name = if version >= 1 {
             types::CompactString.decode(buf)?
         } else {
@@ -471,6 +495,9 @@ impl WriteTxnMarkersResponse {
 #[cfg(feature = "broker")]
 impl Encodable for WriteTxnMarkersResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
+        if version < 0 || version > 1 {
+            bail!("WriteTxnMarkersResponse v{} is not supported", version);
+        }
         if version >= 1 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.markers)?;
         } else {
@@ -517,6 +544,9 @@ impl Encodable for WriteTxnMarkersResponse {
 #[cfg(feature = "client")]
 impl Decodable for WriteTxnMarkersResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
+        if version < 0 || version > 1 {
+            bail!("WriteTxnMarkersResponse v{} is not supported", version);
+        }
         let markers = if version >= 1 {
             types::CompactArray(types::Struct { version }).decode(buf)?
         } else {

--- a/src/messages/write_txn_markers_response.rs
+++ b/src/messages/write_txn_markers_response.rs
@@ -70,10 +70,7 @@ impl WritableTxnMarkerPartitionResult {
 impl Encodable for WritableTxnMarkerPartitionResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!(
-                "WritableTxnMarkerPartitionResult v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         types::Int32.encode(buf, &self.partition_index)?;
         types::Int16.encode(buf, &self.error_code)?;
@@ -115,10 +112,7 @@ impl Encodable for WritableTxnMarkerPartitionResult {
 impl Decodable for WritableTxnMarkerPartitionResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!(
-                "WritableTxnMarkerPartitionResult v{} is not supported",
-                version
-            );
+            bail!("specified version not supported by this message type");
         }
         let partition_index = types::Int32.decode(buf)?;
         let error_code = types::Int16.decode(buf)?;
@@ -208,7 +202,7 @@ impl WritableTxnMarkerResult {
 impl Encodable for WritableTxnMarkerResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("WritableTxnMarkerResult v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         types::Int64.encode(buf, &self.producer_id)?;
         if version >= 1 {
@@ -259,7 +253,7 @@ impl Encodable for WritableTxnMarkerResult {
 impl Decodable for WritableTxnMarkerResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("WritableTxnMarkerResult v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let producer_id = types::Int64.decode(buf)?;
         let topics = if version >= 1 {
@@ -353,7 +347,7 @@ impl WritableTxnMarkerTopicResult {
 impl Encodable for WritableTxnMarkerTopicResult {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("WritableTxnMarkerTopicResult v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 1 {
             types::CompactString.encode(buf, &self.name)?;
@@ -412,7 +406,7 @@ impl Encodable for WritableTxnMarkerTopicResult {
 impl Decodable for WritableTxnMarkerTopicResult {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("WritableTxnMarkerTopicResult v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let name = if version >= 1 {
             types::CompactString.decode(buf)?
@@ -496,7 +490,7 @@ impl WriteTxnMarkersResponse {
 impl Encodable for WriteTxnMarkersResponse {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, version: i16) -> Result<()> {
         if version < 0 || version > 1 {
-            bail!("WriteTxnMarkersResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         if version >= 1 {
             types::CompactArray(types::Struct { version }).encode(buf, &self.markers)?;
@@ -545,7 +539,7 @@ impl Encodable for WriteTxnMarkersResponse {
 impl Decodable for WriteTxnMarkersResponse {
     fn decode<B: ByteBuf>(buf: &mut B, version: i16) -> Result<Self> {
         if version < 0 || version > 1 {
-            bail!("WriteTxnMarkersResponse v{} is not supported", version);
+            bail!("specified version not supported by this message type");
         }
         let markers = if version >= 1 {
             types::CompactArray(types::Struct { version }).decode(buf)?


### PR DESCRIPTION
We should not attempt to encode or decode a version that was not known when the crate was generated.
This PR adds validation to prevent proceeding with encode/decode in that case.

This will be particularly useful to help users migrate from the breaking changes in https://github.com/tychedelia/kafka-protocol-rs/pull/120 where previously existing versions have been removed.