### PR TITLE
Release kafka-protocol 0.15.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,7 +947,7 @@ checksum = "9dbbfed4e59ba9750e15ba154fdfd9329cee16ff3df539c2666b70f58cc32105"
 
 [[package]]
 name = "kafka-protocol"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["protocol_codegen"]
 
 [package]
 name = "kafka-protocol"
-version = "0.14.0"
+version = "0.15.0"
 authors = [
     "Diggory Blake <diggsey@googlemail.com>",
     "Charlotte McElwain <charlotte.c.mcelwain@gmail.com>",


### PR DESCRIPTION
We should make a final release before moving to kafka 4.0 as we will need to remove support for message sets v0/v1 which could be disruptive. See https://github.com/tychedelia/kafka-protocol-rs/pull/120#issuecomment-2833757686

Also we should merge these PRs before this release:
* https://github.com/tychedelia/kafka-protocol-rs/pull/121
* https://github.com/tychedelia/kafka-protocol-rs/pull/123


I will give @tychedelia a few days to review the prereq PRs and then I will merge them, followed by this PR.