### PR TITLE
Fix bytes version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ lz4 = ["dep:lz4"]
 default = ["client", "broker", "gzip", "zstd", "snappy", "lz4"]
 
 [dependencies]
-bytes = "1.0.1"
+bytes = "1.10.1"
 uuid = "1.3.0"
 indexmap = "2.0.0"
 crc = "3.0.0"


### PR DESCRIPTION
Introduced in #121

The `Buf::try_get_*` methods in `bytes` are provided since [1.10.0](https://github.com/tokio-rs/bytes/blob/master/CHANGELOG.md#1100-february-3rd-2025).

The `0.15.0` release should be yanked.

BTW, the commit of `0.15.0` tag ([`54af533`](https://github.com/tychedelia/kafka-protocol-rs/commit/54af5331404684ff82bef660fd094e402db27bb7)) 
> does not belong to any branch on this repository, and may belong to a fork outside of the repository.