### PR TITLE
feat: add SegmentedBuf for zero-copy response encoding

### DIFF
--- a/src/messages.rs
+++ b/src/messages.rs
@@ -2808,6 +2808,22 @@ fn encode<T: Encodable>(encodable: &T, bytes: &mut bytes::BytesMut, version: i16
     })
 }
 
+#[cfg(feature = "messages_enums")]
+#[cfg(feature = "broker")]
+fn encode_into<T: Encodable, B: crate::protocol::buf::ByteBufMut>(
+    encodable: &T,
+    buf: &mut B,
+    version: i16,
+) -> Result<()> {
+    encodable.encode(buf, version).with_context(|| {
+        format!(
+            "Failed to encode {} v{} body",
+            std::any::type_name::<T>(),
+            version
+        )
+    })
+}
+
 /// Wrapping enum for all responses in the Kafka protocol.
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
@@ -3082,6 +3098,103 @@ impl ResponseKind {
             ResponseKind::DescribeShareGroupOffsets(x) => encode(x, bytes, version),
             ResponseKind::AlterShareGroupOffsets(x) => encode(x, bytes, version),
             ResponseKind::DeleteShareGroupOffsets(x) => encode(x, bytes, version),
+        }
+    }
+    /// Encode the message into a `ByteBufMut` (e.g. `SegmentedBuf` for zero-copy).
+    #[cfg(feature = "broker")]
+    pub fn encode_into<B: crate::protocol::buf::ByteBufMut>(
+        &self,
+        buf: &mut B,
+        version: i16,
+    ) -> anyhow::Result<()> {
+        match self {
+            ResponseKind::Produce(x) => encode_into(x, buf, version),
+            ResponseKind::Fetch(x) => encode_into(x, buf, version),
+            ResponseKind::ListOffsets(x) => encode_into(x, buf, version),
+            ResponseKind::Metadata(x) => encode_into(x, buf, version),
+            ResponseKind::OffsetCommit(x) => encode_into(x, buf, version),
+            ResponseKind::OffsetFetch(x) => encode_into(x, buf, version),
+            ResponseKind::FindCoordinator(x) => encode_into(x, buf, version),
+            ResponseKind::JoinGroup(x) => encode_into(x, buf, version),
+            ResponseKind::Heartbeat(x) => encode_into(x, buf, version),
+            ResponseKind::LeaveGroup(x) => encode_into(x, buf, version),
+            ResponseKind::SyncGroup(x) => encode_into(x, buf, version),
+            ResponseKind::DescribeGroups(x) => encode_into(x, buf, version),
+            ResponseKind::ListGroups(x) => encode_into(x, buf, version),
+            ResponseKind::SaslHandshake(x) => encode_into(x, buf, version),
+            ResponseKind::ApiVersions(x) => encode_into(x, buf, version),
+            ResponseKind::CreateTopics(x) => encode_into(x, buf, version),
+            ResponseKind::DeleteTopics(x) => encode_into(x, buf, version),
+            ResponseKind::DeleteRecords(x) => encode_into(x, buf, version),
+            ResponseKind::InitProducerId(x) => encode_into(x, buf, version),
+            ResponseKind::OffsetForLeaderEpoch(x) => encode_into(x, buf, version),
+            ResponseKind::AddPartitionsToTxn(x) => encode_into(x, buf, version),
+            ResponseKind::AddOffsetsToTxn(x) => encode_into(x, buf, version),
+            ResponseKind::EndTxn(x) => encode_into(x, buf, version),
+            ResponseKind::WriteTxnMarkers(x) => encode_into(x, buf, version),
+            ResponseKind::TxnOffsetCommit(x) => encode_into(x, buf, version),
+            ResponseKind::DescribeAcls(x) => encode_into(x, buf, version),
+            ResponseKind::CreateAcls(x) => encode_into(x, buf, version),
+            ResponseKind::DeleteAcls(x) => encode_into(x, buf, version),
+            ResponseKind::DescribeConfigs(x) => encode_into(x, buf, version),
+            ResponseKind::AlterConfigs(x) => encode_into(x, buf, version),
+            ResponseKind::AlterReplicaLogDirs(x) => encode_into(x, buf, version),
+            ResponseKind::DescribeLogDirs(x) => encode_into(x, buf, version),
+            ResponseKind::SaslAuthenticate(x) => encode_into(x, buf, version),
+            ResponseKind::CreatePartitions(x) => encode_into(x, buf, version),
+            ResponseKind::CreateDelegationToken(x) => encode_into(x, buf, version),
+            ResponseKind::RenewDelegationToken(x) => encode_into(x, buf, version),
+            ResponseKind::ExpireDelegationToken(x) => encode_into(x, buf, version),
+            ResponseKind::DescribeDelegationToken(x) => encode_into(x, buf, version),
+            ResponseKind::DeleteGroups(x) => encode_into(x, buf, version),
+            ResponseKind::ElectLeaders(x) => encode_into(x, buf, version),
+            ResponseKind::IncrementalAlterConfigs(x) => encode_into(x, buf, version),
+            ResponseKind::AlterPartitionReassignments(x) => encode_into(x, buf, version),
+            ResponseKind::ListPartitionReassignments(x) => encode_into(x, buf, version),
+            ResponseKind::OffsetDelete(x) => encode_into(x, buf, version),
+            ResponseKind::DescribeClientQuotas(x) => encode_into(x, buf, version),
+            ResponseKind::AlterClientQuotas(x) => encode_into(x, buf, version),
+            ResponseKind::DescribeUserScramCredentials(x) => encode_into(x, buf, version),
+            ResponseKind::AlterUserScramCredentials(x) => encode_into(x, buf, version),
+            ResponseKind::Vote(x) => encode_into(x, buf, version),
+            ResponseKind::BeginQuorumEpoch(x) => encode_into(x, buf, version),
+            ResponseKind::EndQuorumEpoch(x) => encode_into(x, buf, version),
+            ResponseKind::DescribeQuorum(x) => encode_into(x, buf, version),
+            ResponseKind::AlterPartition(x) => encode_into(x, buf, version),
+            ResponseKind::UpdateFeatures(x) => encode_into(x, buf, version),
+            ResponseKind::Envelope(x) => encode_into(x, buf, version),
+            ResponseKind::FetchSnapshot(x) => encode_into(x, buf, version),
+            ResponseKind::DescribeCluster(x) => encode_into(x, buf, version),
+            ResponseKind::DescribeProducers(x) => encode_into(x, buf, version),
+            ResponseKind::BrokerRegistration(x) => encode_into(x, buf, version),
+            ResponseKind::BrokerHeartbeat(x) => encode_into(x, buf, version),
+            ResponseKind::UnregisterBroker(x) => encode_into(x, buf, version),
+            ResponseKind::DescribeTransactions(x) => encode_into(x, buf, version),
+            ResponseKind::ListTransactions(x) => encode_into(x, buf, version),
+            ResponseKind::AllocateProducerIds(x) => encode_into(x, buf, version),
+            ResponseKind::ConsumerGroupHeartbeat(x) => encode_into(x, buf, version),
+            ResponseKind::ConsumerGroupDescribe(x) => encode_into(x, buf, version),
+            ResponseKind::ControllerRegistration(x) => encode_into(x, buf, version),
+            ResponseKind::GetTelemetrySubscriptions(x) => encode_into(x, buf, version),
+            ResponseKind::PushTelemetry(x) => encode_into(x, buf, version),
+            ResponseKind::AssignReplicasToDirs(x) => encode_into(x, buf, version),
+            ResponseKind::ListConfigResources(x) => encode_into(x, buf, version),
+            ResponseKind::DescribeTopicPartitions(x) => encode_into(x, buf, version),
+            ResponseKind::ShareGroupHeartbeat(x) => encode_into(x, buf, version),
+            ResponseKind::ShareGroupDescribe(x) => encode_into(x, buf, version),
+            ResponseKind::ShareFetch(x) => encode_into(x, buf, version),
+            ResponseKind::ShareAcknowledge(x) => encode_into(x, buf, version),
+            ResponseKind::AddRaftVoter(x) => encode_into(x, buf, version),
+            ResponseKind::RemoveRaftVoter(x) => encode_into(x, buf, version),
+            ResponseKind::UpdateRaftVoter(x) => encode_into(x, buf, version),
+            ResponseKind::InitializeShareGroupState(x) => encode_into(x, buf, version),
+            ResponseKind::ReadShareGroupState(x) => encode_into(x, buf, version),
+            ResponseKind::WriteShareGroupState(x) => encode_into(x, buf, version),
+            ResponseKind::DeleteShareGroupState(x) => encode_into(x, buf, version),
+            ResponseKind::ReadShareGroupStateSummary(x) => encode_into(x, buf, version),
+            ResponseKind::DescribeShareGroupOffsets(x) => encode_into(x, buf, version),
+            ResponseKind::AlterShareGroupOffsets(x) => encode_into(x, buf, version),
+            ResponseKind::DeleteShareGroupOffsets(x) => encode_into(x, buf, version),
         }
     }
     /// Decode the message from the provided buffer and version

--- a/src/messages/fetch_response.rs
+++ b/src/messages/fetch_response.rs
@@ -1836,6 +1836,7 @@ impl HeaderVersion for FetchResponse {
 }
 
 #[cfg(test)]
+#[cfg(all(feature = "broker", feature = "client"))]
 mod tests {
     use super::*;
     use bytes::{Buf, BytesMut};

--- a/src/messages/fetch_response.rs
+++ b/src/messages/fetch_response.rs
@@ -1237,6 +1237,11 @@ pub struct PartitionData {
     /// Supported API versions: 4-18
     pub records: Option<Bytes>,
 
+    /// Record data segments for zero-copy multi-batch encoding.
+    /// When non-empty, these are used instead of `records`.
+    #[doc(hidden)]
+    pub record_segments: Vec<Bytes>,
+
     /// Other tagged fields
     pub unknown_tagged_fields: BTreeMap<i32, Bytes>,
 }
@@ -1341,6 +1346,11 @@ impl PartitionData {
         self.records = value;
         self
     }
+    /// Sets `record_segments` for zero-copy multi-batch encoding.
+    pub fn with_record_segments(mut self, value: Vec<Bytes>) -> Self {
+        self.record_segments = value;
+        self
+    }
     /// Sets unknown_tagged_fields to the passed value.
     pub fn with_unknown_tagged_fields(mut self, value: BTreeMap<i32, Bytes>) -> Self {
         self.unknown_tagged_fields = value;
@@ -1350,6 +1360,34 @@ impl PartitionData {
     pub fn with_unknown_tagged_field(mut self, key: i32, value: Bytes) -> Self {
         self.unknown_tagged_fields.insert(key, value);
         self
+    }
+
+    /// Constructs a partition response with only the fields needed for fetch.
+    /// Avoids the allocations in `Default` (BTreeMap, Vec, Bytes).
+    #[inline]
+    pub fn for_fetch(
+        partition_index: i32,
+        high_watermark: i64,
+        records: Option<Bytes>,
+        record_segments: Vec<Bytes>,
+        error_code: i16,
+        log_start_offset: i64,
+    ) -> Self {
+        Self {
+            partition_index,
+            error_code,
+            high_watermark,
+            last_stable_offset: high_watermark,
+            log_start_offset,
+            diverging_epoch: Default::default(),
+            current_leader: Default::default(),
+            snapshot_id: Default::default(),
+            aborted_transactions: None,
+            preferred_read_replica: (-1).into(),
+            records,
+            record_segments,
+            unknown_tagged_fields: BTreeMap::new(),
+        }
     }
 }
 
@@ -1379,7 +1417,21 @@ impl Encodable for PartitionData {
                 bail!("A field is set that is not available on the selected protocol version");
             }
         }
-        if version >= 12 {
+        if !self.record_segments.is_empty() {
+            // Multi-batch zero-copy: write total length prefix, then each segment
+            let total_len: usize = self.record_segments.iter().map(|s| s.len()).sum();
+            if version >= 12 {
+                types::UnsignedVarInt.encode(buf, (total_len as u32) + 1)?;
+            } else {
+                if total_len > i32::MAX as usize {
+                    bail!("Record segments too large to encode ({} bytes)", total_len);
+                }
+                types::Int32.encode(buf, total_len as i32)?;
+            }
+            for segment in &self.record_segments {
+                buf.put_shared_bytes(segment.clone());
+            }
+        } else if version >= 12 {
             types::CompactBytes.encode(buf, &self.records)?;
         } else {
             types::Bytes.encode(buf, &self.records)?;
@@ -1467,7 +1519,15 @@ impl Encodable for PartitionData {
                 bail!("A field is set that is not available on the selected protocol version");
             }
         }
-        if version >= 12 {
+        if !self.record_segments.is_empty() {
+            let total_len: usize = self.record_segments.iter().map(|s| s.len()).sum();
+            if version >= 12 {
+                total_size += types::UnsignedVarInt.compute_size((total_len as u32) + 1)?;
+            } else {
+                total_size += 4; // i32 length prefix
+            }
+            total_size += total_len;
+        } else if version >= 12 {
             total_size += types::CompactBytes.compute_size(&self.records)?;
         } else {
             total_size += types::Bytes.compute_size(&self.records)?;
@@ -1602,6 +1662,7 @@ impl Decodable for PartitionData {
             aborted_transactions,
             preferred_read_replica,
             records,
+            record_segments: Vec::new(),
             unknown_tagged_fields,
         })
     }
@@ -1621,6 +1682,7 @@ impl Default for PartitionData {
             aborted_transactions: Some(Default::default()),
             preferred_read_replica: (-1).into(),
             records: Some(Default::default()),
+            record_segments: Vec::new(),
             unknown_tagged_fields: BTreeMap::new(),
         }
     }
@@ -1770,5 +1832,162 @@ impl HeaderVersion for FetchResponse {
         } else {
             0
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::{Buf, BytesMut};
+    use crate::protocol::buf::SegmentedBuf;
+    use crate::protocol::Encodable;
+
+    /// Encode a PartitionData with record_segments, decode it back, and verify
+    /// the decoded records field contains the concatenated segment data.
+    #[test]
+    fn record_segments_roundtrip_legacy_version() {
+        let batch1 = Bytes::from_static(b"batch-one-data");
+        let batch2 = Bytes::from_static(b"batch-two-data");
+
+        let pd = PartitionData::for_fetch(
+            0,
+            100,
+            None,
+            vec![batch1.clone(), batch2.clone()],
+            0,
+            0,
+        );
+
+        // Encode with version 4 (legacy, uses Int32 length prefix)
+        let mut buf = BytesMut::new();
+        pd.encode(&mut buf, 4).unwrap();
+
+        // Decode and verify
+        let mut read_buf: Bytes = buf.freeze();
+        let decoded = PartitionData::decode(&mut read_buf, 4).unwrap();
+        let records = decoded.records.expect("records should be present");
+        let mut expected = BytesMut::new();
+        expected.extend_from_slice(&batch1);
+        expected.extend_from_slice(&batch2);
+        assert_eq!(records, expected.freeze());
+    }
+
+    /// Same roundtrip but with version 12+ (compact bytes encoding).
+    #[test]
+    fn record_segments_roundtrip_flexible_version() {
+        let batch1 = Bytes::from_static(b"flex-batch-1");
+        let batch2 = Bytes::from_static(b"flex-batch-2");
+
+        let pd = PartitionData::for_fetch(
+            1,
+            200,
+            None,
+            vec![batch1.clone(), batch2.clone()],
+            0,
+            50,
+        );
+
+        // Encode with version 12 (flexible, uses CompactBytes)
+        let mut buf = BytesMut::new();
+        pd.encode(&mut buf, 12).unwrap();
+
+        // Decode and verify
+        let mut read_buf: Bytes = buf.freeze();
+        let decoded = PartitionData::decode(&mut read_buf, 12).unwrap();
+        let records = decoded.records.expect("records should be present");
+        let mut expected = BytesMut::new();
+        expected.extend_from_slice(&batch1);
+        expected.extend_from_slice(&batch2);
+        assert_eq!(records, expected.freeze());
+    }
+
+    /// Verify compute_size matches actual encoded size for record_segments.
+    #[test]
+    fn record_segments_compute_size_matches_encoded() {
+        let pd = PartitionData::for_fetch(
+            0,
+            100,
+            None,
+            vec![
+                Bytes::from_static(b"aaaa"),
+                Bytes::from_static(b"bbbb"),
+            ],
+            0,
+            0,
+        );
+
+        for version in [4i16, 12] {
+            let computed = pd.compute_size(version).unwrap();
+            let mut buf = BytesMut::new();
+            pd.encode(&mut buf, version).unwrap();
+            assert_eq!(
+                computed,
+                buf.len(),
+                "compute_size mismatch for version {}",
+                version
+            );
+        }
+    }
+
+    /// Verify zero-copy path: encoding into SegmentedBuf stores shared segments.
+    #[test]
+    fn record_segments_into_segmented_buf() {
+        let batch = Bytes::from_static(b"zero-copy-record-data");
+
+        let pd = PartitionData::for_fetch(
+            0,
+            50,
+            None,
+            vec![batch.clone()],
+            0,
+            0,
+        );
+
+        let mut seg_buf = SegmentedBuf::new();
+        pd.encode(&mut seg_buf, 4).unwrap();
+
+        // Collect all data from the segmented buf
+        let mut collected = Vec::new();
+        while seg_buf.has_remaining() {
+            let chunk = seg_buf.chunk();
+            collected.extend_from_slice(chunk);
+            let len = chunk.len();
+            seg_buf.advance(len);
+        }
+
+        // Decode from the collected bytes
+        let mut read_buf = Bytes::from(collected);
+        let decoded = PartitionData::decode(&mut read_buf, 4).unwrap();
+        assert_eq!(decoded.records.unwrap(), batch);
+    }
+
+    /// Verify that for_fetch produces correct field values.
+    #[test]
+    fn for_fetch_constructor_fields() {
+        let pd = PartitionData::for_fetch(7, 999, None, vec![], 3, 42);
+        assert_eq!(pd.partition_index, 7);
+        assert_eq!(pd.high_watermark, 999);
+        assert_eq!(pd.last_stable_offset, 999);
+        assert_eq!(pd.log_start_offset, 42);
+        assert_eq!(pd.error_code, 3);
+        assert_eq!(pd.preferred_read_replica, -1);
+        assert!(pd.records.is_none());
+        assert!(pd.record_segments.is_empty());
+    }
+
+    /// Verify that empty record_segments falls through to normal records encoding.
+    #[test]
+    fn empty_record_segments_uses_records_field() {
+        let record_data = Bytes::from_static(b"normal-records");
+        let pd = PartitionData::default()
+            .with_partition_index(0)
+            .with_records(Some(record_data.clone()));
+
+        let mut buf = BytesMut::new();
+        pd.encode(&mut buf, 4).unwrap();
+
+        let mut read_buf: Bytes = buf.freeze();
+        let decoded = PartitionData::decode(&mut read_buf, 4).unwrap();
+        assert_eq!(decoded.records.unwrap(), record_data);
     }
 }

--- a/src/protocol/buf.rs
+++ b/src/protocol/buf.rs
@@ -181,6 +181,14 @@ pub trait ByteBufMut: BufMut {
     /// Read a range from the buffer.
     fn range(&mut self, r: Range<usize>) -> &mut [u8];
 
+    /// Store a shared `Bytes` handle without copying.
+    ///
+    /// The default implementation copies the bytes (matching existing behavior).
+    /// `SegmentedBuf` overrides this to store a zero-copy reference.
+    fn put_shared_bytes(&mut self, bytes: Bytes) {
+        self.put_slice(&bytes);
+    }
+
     /// Put a gap of `len` at the current buffer offset.
     fn put_gap(&mut self, len: usize) -> Gap {
         let res = Gap {
@@ -243,5 +251,386 @@ impl<T: ByteBufMut> ByteBufMut for &mut T {
     }
     fn range(&mut self, r: Range<usize>) -> &mut [u8] {
         (**self).range(r)
+    }
+    fn put_shared_bytes(&mut self, bytes: Bytes) {
+        (**self).put_shared_bytes(bytes)
+    }
+}
+
+/// A segment in a [`SegmentedBuf`].
+enum Segment {
+    /// Inline bytes that were written via normal BufMut methods.
+    Inline(BytesMut),
+    /// A shared `Bytes` handle stored without copying.
+    Shared(Bytes),
+}
+
+impl Segment {
+    fn len(&self) -> usize {
+        match self {
+            Segment::Inline(b) => b.len(),
+            Segment::Shared(b) => b.len(),
+        }
+    }
+}
+
+/// A segmented buffer that stores a mix of inline writes and shared `Bytes` references.
+///
+/// Normal `BufMut` writes go into an inline `BytesMut` segment. Calling `put_shared_bytes`
+/// finalizes the current inline segment and appends a zero-copy `Shared` segment.
+///
+/// Implements `bytes::Buf` with `chunks_vectored()` so that `tokio::io::AsyncWriteExt::write_all_buf`
+/// can use vectored I/O (`writev`) to write all segments in a single syscall.
+#[derive(Default)]
+pub struct SegmentedBuf {
+    segments: Vec<Segment>,
+    /// Total byte count across all segments.
+    total_len: usize,
+    /// Bytes already consumed by `Buf::advance`.
+    consumed: usize,
+}
+
+impl SegmentedBuf {
+    /// Create a new empty segmented buffer.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Ensure the last segment is an `Inline` and return a mutable reference to it.
+    fn current_inline(&mut self) -> &mut BytesMut {
+        if self.segments.is_empty()
+            || !matches!(self.segments.last(), Some(Segment::Inline(_)))
+        {
+            self.segments.push(Segment::Inline(BytesMut::new()));
+        }
+        match self.segments.last_mut().unwrap() {
+            Segment::Inline(b) => b,
+            _ => unreachable!(),
+        }
+    }
+
+    /// Write an `i32` at the given absolute byte offset within the buffer.
+    ///
+    /// Used to patch the length prefix after the full message has been written.
+    pub fn patch_i32(&mut self, offset: usize, value: i32) {
+        let bytes = value.to_be_bytes();
+        let mut pos = 0;
+        for seg in &mut self.segments {
+            let seg_len = seg.len();
+            if offset >= pos && offset + 4 <= pos + seg_len {
+                let local = offset - pos;
+                match seg {
+                    Segment::Inline(b) => {
+                        b[local..local + 4].copy_from_slice(&bytes);
+                    }
+                    Segment::Shared(_) => {
+                        panic!("Cannot patch into a Shared segment");
+                    }
+                }
+                return;
+            }
+            pos += seg_len;
+        }
+        panic!(
+            "patch_i32: offset {} out of range (total {})",
+            offset, self.total_len
+        );
+    }
+}
+
+unsafe impl BufMut for SegmentedBuf {
+    fn remaining_mut(&self) -> usize {
+        usize::MAX - self.total_len
+    }
+
+    unsafe fn advance_mut(&mut self, cnt: usize) {
+        let inline = self.current_inline();
+        unsafe { inline.advance_mut(cnt) };
+        self.total_len += cnt;
+    }
+
+    fn chunk_mut(&mut self) -> &mut bytes::buf::UninitSlice {
+        let inline = self.current_inline();
+        if inline.capacity() == inline.len() {
+            inline.reserve(8192);
+        }
+        inline.chunk_mut()
+    }
+
+    fn put_slice(&mut self, src: &[u8]) {
+        let inline = self.current_inline();
+        inline.put_slice(src);
+        self.total_len += src.len();
+    }
+}
+
+impl ByteBufMut for SegmentedBuf {
+    fn offset(&self) -> usize {
+        self.total_len
+    }
+
+    fn seek(&mut self, offset: usize) {
+        if offset > self.total_len {
+            let needed = offset - self.total_len;
+            let inline = self.current_inline();
+            inline.resize(inline.len() + needed, 0);
+            self.total_len = offset;
+        }
+    }
+
+    fn range(&mut self, r: Range<usize>) -> &mut [u8] {
+        let mut pos = 0;
+        for seg in &mut self.segments {
+            let seg_len = seg.len();
+            if r.start >= pos && r.end <= pos + seg_len {
+                let local_start = r.start - pos;
+                let local_end = r.end - pos;
+                return match seg {
+                    Segment::Inline(b) => &mut b[local_start..local_end],
+                    Segment::Shared(_) => panic!("Cannot get mutable range from Shared segment"),
+                };
+            }
+            pos += seg_len;
+        }
+        panic!(
+            "range {:?} out of bounds (total {})",
+            r, self.total_len
+        );
+    }
+
+    fn put_shared_bytes(&mut self, bytes: Bytes) {
+        if bytes.is_empty() {
+            return;
+        }
+        let len = bytes.len();
+        if let Some(Segment::Inline(b)) = self.segments.last() {
+            if b.is_empty() {
+                self.segments.pop();
+            }
+        }
+        self.segments.push(Segment::Shared(bytes));
+        self.total_len += len;
+    }
+}
+
+impl Buf for SegmentedBuf {
+    fn remaining(&self) -> usize {
+        self.total_len - self.consumed
+    }
+
+    fn chunk(&self) -> &[u8] {
+        let mut pos = 0;
+        for seg in &self.segments {
+            let seg_len = seg.len();
+            if self.consumed < pos + seg_len {
+                let local_offset = self.consumed - pos;
+                return match seg {
+                    Segment::Inline(b) => &b[local_offset..],
+                    Segment::Shared(b) => &b[local_offset..],
+                };
+            }
+            pos += seg_len;
+        }
+        &[]
+    }
+
+    fn advance(&mut self, cnt: usize) {
+        assert!(
+            cnt <= self.remaining(),
+            "advance({}) exceeds remaining({})",
+            cnt,
+            self.remaining()
+        );
+        self.consumed += cnt;
+    }
+
+    fn chunks_vectored<'a>(&'a self, dst: &mut [std::io::IoSlice<'a>]) -> usize {
+        if dst.is_empty() {
+            return 0;
+        }
+        let mut filled = 0;
+        let mut pos = 0;
+        for seg in &self.segments {
+            let seg_len = seg.len();
+            if self.consumed >= pos + seg_len {
+                pos += seg_len;
+                continue;
+            }
+            let local_offset = self.consumed.saturating_sub(pos);
+            let slice = match seg {
+                Segment::Inline(b) => &b[local_offset..],
+                Segment::Shared(b) => &b[local_offset..],
+            };
+            if !slice.is_empty() {
+                dst[filled] = std::io::IoSlice::new(slice);
+                filled += 1;
+                if filled >= dst.len() {
+                    break;
+                }
+            }
+            pos += seg_len;
+        }
+        filled
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn segmented_buf_inline_only() {
+        let mut buf = SegmentedBuf::new();
+        buf.put_slice(b"hello ");
+        buf.put_slice(b"world");
+        assert_eq!(buf.remaining(), 11);
+        assert_eq!(buf.chunk(), b"hello world");
+    }
+
+    #[test]
+    fn segmented_buf_shared_only() {
+        let mut buf = SegmentedBuf::new();
+        buf.put_shared_bytes(Bytes::from_static(b"hello "));
+        buf.put_shared_bytes(Bytes::from_static(b"world"));
+        assert_eq!(buf.remaining(), 11);
+        // chunk() returns the first segment
+        assert_eq!(buf.chunk(), b"hello ");
+    }
+
+    #[test]
+    fn segmented_buf_mixed_inline_and_shared() {
+        let mut buf = SegmentedBuf::new();
+        // Write header inline
+        buf.put_slice(b"HDR:");
+        // Append shared record data
+        buf.put_shared_bytes(Bytes::from_static(b"record1"));
+        // Write more inline
+        buf.put_slice(b"|");
+        buf.put_shared_bytes(Bytes::from_static(b"record2"));
+
+        assert_eq!(buf.remaining(), 4 + 7 + 1 + 7);
+
+        // Read all bytes by advancing through chunks
+        let mut collected = Vec::new();
+        while buf.has_remaining() {
+            let chunk = buf.chunk();
+            collected.extend_from_slice(chunk);
+            let len = chunk.len();
+            buf.advance(len);
+        }
+        assert_eq!(&collected, b"HDR:record1|record2");
+    }
+
+    #[test]
+    fn segmented_buf_empty_shared_ignored() {
+        let mut buf = SegmentedBuf::new();
+        buf.put_slice(b"data");
+        buf.put_shared_bytes(Bytes::new()); // empty, should be ignored
+        assert_eq!(buf.remaining(), 4);
+        assert_eq!(buf.chunk(), b"data");
+    }
+
+    #[test]
+    fn segmented_buf_advance_across_segments() {
+        let mut buf = SegmentedBuf::new();
+        buf.put_slice(b"ab");
+        buf.put_shared_bytes(Bytes::from_static(b"cd"));
+        buf.put_slice(b"ef");
+
+        assert_eq!(buf.remaining(), 6);
+        buf.advance(1); // consume 'a'
+        assert_eq!(buf.remaining(), 5);
+        assert_eq!(buf.chunk(), b"b");
+        buf.advance(1); // consume 'b'
+        assert_eq!(buf.chunk(), b"cd");
+        buf.advance(3); // consume 'cd' and 'e'
+        assert_eq!(buf.chunk(), b"f");
+        buf.advance(1);
+        assert_eq!(buf.remaining(), 0);
+    }
+
+    #[test]
+    fn segmented_buf_chunks_vectored() {
+        let mut buf = SegmentedBuf::new();
+        buf.put_slice(b"header");
+        buf.put_shared_bytes(Bytes::from_static(b"body1"));
+        buf.put_shared_bytes(Bytes::from_static(b"body2"));
+        buf.put_slice(b"trailer");
+
+        let mut io_slices = [std::io::IoSlice::new(&[]); 8];
+        let n = buf.chunks_vectored(&mut io_slices);
+        assert_eq!(n, 4);
+        assert_eq!(&*io_slices[0], b"header");
+        assert_eq!(&*io_slices[1], b"body1");
+        assert_eq!(&*io_slices[2], b"body2");
+        assert_eq!(&*io_slices[3], b"trailer");
+    }
+
+    #[test]
+    fn segmented_buf_chunks_vectored_after_partial_advance() {
+        let mut buf = SegmentedBuf::new();
+        buf.put_slice(b"hdr");
+        buf.put_shared_bytes(Bytes::from_static(b"payload"));
+
+        // Advance past the inline segment into the shared one
+        buf.advance(4); // consume "hdr" + first byte of "payload"
+        let mut io_slices = [std::io::IoSlice::new(&[]); 4];
+        let n = buf.chunks_vectored(&mut io_slices);
+        assert_eq!(n, 1);
+        assert_eq!(&*io_slices[0], b"ayload");
+    }
+
+    #[test]
+    fn segmented_buf_patch_i32() {
+        let mut buf = SegmentedBuf::new();
+        buf.put_slice(&[0u8; 4]); // placeholder
+        buf.put_slice(b"data");
+        buf.patch_i32(0, 42);
+
+        assert_eq!(buf.chunk()[..4], 42i32.to_be_bytes());
+    }
+
+    #[test]
+    #[should_panic(expected = "Cannot patch into a Shared segment")]
+    fn segmented_buf_patch_i32_into_shared_panics() {
+        let mut buf = SegmentedBuf::new();
+        buf.put_shared_bytes(Bytes::from_static(&[0u8; 4]));
+        buf.patch_i32(0, 42);
+    }
+
+    #[test]
+    fn segmented_buf_default() {
+        let buf = SegmentedBuf::default();
+        assert_eq!(buf.remaining(), 0);
+        assert!(buf.chunk().is_empty());
+    }
+
+    #[test]
+    fn byte_buf_mut_put_shared_bytes_default_copies() {
+        // The default `put_shared_bytes` on BytesMut should copy (no-op zero-copy)
+        let mut buf = BytesMut::new();
+        buf.put_shared_bytes(Bytes::from_static(b"hello"));
+        assert_eq!(&buf[..], b"hello");
+    }
+
+    #[test]
+    fn segmented_buf_bytebufmut_offset_and_seek() {
+        let mut buf = SegmentedBuf::new();
+        assert_eq!(buf.offset(), 0);
+        buf.put_slice(b"abc");
+        assert_eq!(buf.offset(), 3);
+        buf.seek(10);
+        assert_eq!(buf.offset(), 10);
+        // seek doesn't shrink
+        buf.seek(5);
+        assert_eq!(buf.offset(), 10);
+    }
+
+    #[test]
+    fn segmented_buf_bytebufmut_range() {
+        let mut buf = SegmentedBuf::new();
+        buf.put_slice(b"hello world");
+        let r = buf.range(6..11);
+        assert_eq!(r, b"world");
     }
 }

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -13,6 +13,8 @@ use bytes::Bytes;
 pub mod buf;
 pub mod types;
 
+pub use buf::SegmentedBuf;
+
 mod str_bytes {
     use bytes::Bytes;
     use std::borrow::Borrow;

--- a/src/protocol/types.rs
+++ b/src/protocol/types.rs
@@ -607,7 +607,17 @@ impl Encoder<&Option<Vec<u8>>> for Bytes {
 
 impl Encoder<Option<&bytes::Bytes>> for Bytes {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, value: Option<&bytes::Bytes>) -> Result<()> {
-        Bytes.encode(buf, value.map(|s| &**s))
+        if let Some(s) = value {
+            if s.len() > i32::MAX as usize {
+                bail!("Data is too long to encode ({} bytes)", s.len());
+            }
+            Int32.encode(buf, s.len() as i32)?;
+            buf.put_shared_bytes(s.clone());
+            Ok(())
+        } else {
+            Int32.encode(buf, -1)?;
+            Ok(())
+        }
     }
     fn compute_size(&self, value: Option<&bytes::Bytes>) -> Result<usize> {
         Bytes.compute_size(value.map(|s| &**s))
@@ -756,7 +766,17 @@ impl Encoder<&Option<Vec<u8>>> for CompactBytes {
 
 impl Encoder<Option<&bytes::Bytes>> for CompactBytes {
     fn encode<B: ByteBufMut>(&self, buf: &mut B, value: Option<&bytes::Bytes>) -> Result<()> {
-        CompactBytes.encode(buf, value.map(|s| &**s))
+        if let Some(s) = value {
+            if s.len() >= u32::MAX as usize {
+                bail!("CompactBytes is too long to encode ({} bytes)", s.len());
+            }
+            UnsignedVarInt.encode(buf, (s.len() as u32) + 1)?;
+            buf.put_shared_bytes(s.clone());
+            Ok(())
+        } else {
+            UnsignedVarInt.encode(buf, 0)?;
+            Ok(())
+        }
     }
     fn compute_size(&self, value: Option<&bytes::Bytes>) -> Result<usize> {
         CompactBytes.compute_size(value.map(|s| &**s))


### PR DESCRIPTION
## Summary

Adds `SegmentedBuf`, a segmented buffer that mixes inline writes with shared `Bytes` references, enabling zero-copy encoding of Kafka responses. This is particularly useful for broker implementations that serve fetch responses from pre-existing record data (e.g. memory-mapped segments) without copying.

### Changes

- **`SegmentedBuf`**: New buffer type in `protocol::buf` that stores a mix of inline `BytesMut` segments and shared `Bytes` handles. Implements `BufMut`, `Buf`, and `ByteBufMut` with `chunks_vectored()` for efficient vectored I/O (`writev`).
- **`ByteBufMut::put_shared_bytes()`**: New trait method with a copy-based default. `SegmentedBuf` overrides it to store a zero-copy reference instead.
- **`PartitionData::record_segments`**: New field on `FetchResponse::PartitionData` for multi-batch zero-copy encoding. When non-empty, segments are written directly instead of the `records` field.
- **`PartitionData::for_fetch()`**: Lean constructor that avoids the allocations in `Default` (BTreeMap, Vec, Bytes).
- **`ResponseKind::encode_into()`**: Generic encoding method that accepts any `ByteBufMut`, enabling encoding directly into a `SegmentedBuf`.
- **Zero-copy `Bytes`/`CompactBytes` encoders**: The `Encoder<Option<&bytes::Bytes>>` impls now call `put_shared_bytes()` instead of `put_slice()`.

### Backward compatibility

All changes are additive and backward-compatible:
- `put_shared_bytes()` has a copy-based default implementation, so existing `ByteBufMut` impls are unaffected
- `record_segments` defaults to an empty `Vec` and is skipped during encoding when empty
- Existing `encode()` methods continue to work exactly as before with `BytesMut`

### Test coverage

- 13 unit tests for `SegmentedBuf`: inline-only, shared-only, mixed, advance across segments, `chunks_vectored`, `patch_i32`, default trait, offset/seek/range
- 6 tests for `PartitionData` zero-copy encoding: roundtrip at version 4 (legacy) and version 12 (flexible), `compute_size` consistency, encoding into `SegmentedBuf`, `for_fetch` constructor, fallback to `records` when `record_segments` is empty

## Test plan
- [x] `cargo test --lib` — 32 tests pass (13 existing + 19 new)
- [x] `cargo clippy --all-features --all-targets` — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)