### PR TITLE
Bound Array / CompactArray decoder capacity by remaining buffer

### DIFF
--- a/src/protocol/types.rs
+++ b/src/protocol/types.rs
@@ -985,7 +985,21 @@ impl<T, E: Decoder<T>> Decoder<Option<Vec<T>>> for Array<E> {
         match Int32.decode(buf)? {
             -1 => Ok(None),
             n if n >= 0 => {
-                let mut result = Vec::with_capacity(n as usize);
+                // The declared array length came straight off the wire from
+                // an attacker-controlled client. Cap the up-front allocation
+                // by the bytes still available in the buffer: every Kafka
+                // array element occupies at least one byte on the wire, so
+                // a declared length larger than what the reader has left is
+                // never legitimate input. The subsequent `try_reserve_exact`
+                // catches edge cases where the per-element width is large
+                // enough that even a `bytes_remaining`-bounded count would
+                // still exceed the host's address space.
+                let declared = n as usize;
+                let bound = declared.min(buf.remaining());
+                let mut result: Vec<T> = Vec::new();
+                if result.try_reserve_exact(bound).is_err() {
+                    bail!("cannot allocate Kafka array of {declared} elements");
+                }
                 for _ in 0..n {
                     result.push(self.0.decode(buf)?);
                 }
@@ -1093,7 +1107,16 @@ impl<T, E: Decoder<T>> Decoder<Option<Vec<T>>> for CompactArray<E> {
         match UnsignedVarInt.decode(buf)? {
             0 => Ok(None),
             n => {
-                let mut result = Vec::with_capacity((n - 1) as usize);
+                // Same bound-by-remaining rationale as the `Array` impl
+                // above: cap the up-front capacity by the bytes still in
+                // the buffer to keep an attacker-controlled length in the
+                // header from driving a multi-GiB up-front allocation.
+                let declared = (n - 1) as usize;
+                let bound = declared.min(buf.remaining());
+                let mut result: Vec<T> = Vec::new();
+                if result.try_reserve_exact(bound).is_err() {
+                    bail!("cannot allocate Kafka compact array of {declared} elements");
+                }
                 for _ in 1..n {
                     result.push(self.0.decode(buf)?);
                 }


### PR DESCRIPTION
## What

`Array<E>::decode` and `CompactArray<E>::decode` in `src/protocol/types.rs` both used `Vec::with_capacity(n as usize)` over the array length read straight off the wire. A malicious client can send a request whose length prefix is `i32::MAX`-class while sending only a few bytes of body, which drives `Vec::with_capacity` past several GiB on a 64-bit target — an unauthenticated DoS against any process that decodes attacker-controlled wire frames (broker, proxy, MITM-checking client).

## Repro

A cargo-fuzz harness driving `RequestKind::decode` reproduces this from **8 bytes** of attacker-controlled input:

```
00000000  03 00 00 03 3c 0c 00 b6                          |....<...|
```

Decoded:

| field | value |
|---|---|
| api_key | 3 (`Metadata`) |
| version | 0 |
| body | `03 3c 0c 00 b6` |
| topic-array length | 0x033c0c00 = 54,265,856 entries |

Each `Topic` for `Metadata v0` is ~72 bytes, so the up-front `Vec::with_capacity` allocation is ~3.6 GiB and OOMs the process before the buffer-too-short error from the inner decode can ever surface:

```
==…== ERROR: libFuzzer: out-of-memory (malloc(3907215360))
```

## Fix

Cap the up-front capacity by `buf.remaining()` (each Kafka array element occupies at least one byte on the wire, so a declared length larger than what the reader has left is invariably invalid input) and add a `try_reserve_exact` belt-and-suspenders:

```rust
let declared = n as usize;
let bound = declared.min(buf.remaining());
let mut result: Vec<T> = Vec::new();
if result.try_reserve_exact(bound).is_err() {
    bail!("cannot allocate Kafka array of {declared} elements");
}
for _ in 0..n {
    result.push(self.0.decode(buf)?);
}
```

The user-visible error becomes a clean `Error("cannot allocate Kafka array of N elements")` instead of a process crash. If the input genuinely contains a valid `n`-element array, the inner decoder still grows the `Vec` past the bound as elements are pushed — the cap only affects the *up-front* reservation.

Same shape for `CompactArray` (varint-prefixed arrays in flexible / KIP-482 versions).

## Why `try_reserve_exact` alone isn't enough

The same bug class showed up in apache/arrow-rs's parquet thrift decoder — the original fix there (apache/arrow-rs#9868) used only `try_reserve_exact` and turned out to be insufficient under libFuzzer / ASan: on Linux with default overcommit the allocator returns success for the requested size and the OOM only surfaces inside libFuzzer's malloc hook. The follow-up apache/arrow-rs#9883 added the `bytes_remaining` clamp; this PR ports the same pattern to `kafka-protocol-rs`. pola-rs/polars#27490 carries the same fix for polars-parquet's hand-written thrift.

## Tests

Existing 6 tests in `protocol::types::tests` continue to pass. The behavior change is only on inputs that previously crashed the process — for any well-formed Kafka frame, the up-front capacity is identical.

A starter cargo-fuzz harness (`fuzz/decode_record_set`, `fuzz/decode_request`) is on a separate branch on my fork ([`fuzz/initial-harnesses`](https://github.com/masumi-ryugo/kafka-protocol-rs/tree/fuzz/initial-harnesses)). Happy to send it as a follow-up if there's interest in keeping a regression suite around for exactly this class of bug; sitting on the harness branch for now to avoid expanding scope here.