### PR TITLE
feat: add KIP-534 Batch attribute `delete_horizon`

### DIFF
--- a/src/compression/snappy.rs
+++ b/src/compression/snappy.rs
@@ -139,6 +139,7 @@ mod tests {
         let record = Record {
             transactional: false,
             control: false,
+            delete_horizon: false,
             partition_leader_epoch: 0,
             producer_id: 0,
             producer_epoch: 0,
@@ -201,6 +202,7 @@ mod tests {
         let expected_record = Record {
             transactional: false,
             control: false,
+            delete_horizon: false,
             partition_leader_epoch: 0,
             producer_id: 0,
             producer_epoch: 0,
@@ -245,6 +247,7 @@ mod tests {
         let expected_record = Record {
             transactional: false,
             control: false,
+            delete_horizon: false,
             partition_leader_epoch: 0,
             producer_id: 0,
             producer_epoch: 0,

--- a/src/records.rs
+++ b/src/records.rs
@@ -116,6 +116,7 @@ struct BatchDecodeInfo {
     base_sequence: i32,
     transactional: bool,
     control: bool,
+    delete_horizon: bool,
     partition_leader_epoch: i32,
     producer_id: i64,
     producer_epoch: i16,
@@ -140,6 +141,8 @@ pub struct Record {
     pub transactional: bool,
     /// Whether this record is a control message, which should not be exposed to the client.
     pub control: bool,
+    /// Whether this record has the delete horizon flag set.
+    pub delete_horizon: bool,
     /// Epoch of the leader for this record 's partition.
     pub partition_leader_epoch: i32,
     /// The identifier of the producer.
@@ -250,6 +253,7 @@ impl RecordBatchEncoder {
             .take_while(|record| {
                 record.transactional == first_record.transactional
                     && record.control == first_record.control
+                    && record.delete_horizon == first_record.delete_horizon
                     && record.partition_leader_epoch == first_record.partition_leader_epoch
                     && record.producer_id == first_record.producer_id
                     && record.producer_epoch == first_record.producer_epoch
@@ -312,6 +316,9 @@ impl RecordBatchEncoder {
         }
         if first_record.control {
             attributes |= 1 << 5;
+        }
+        if first_record.delete_horizon {
+            attributes |= 1 << 6;
         }
         types::Int16.encode(buf, attributes)?;
 
@@ -526,6 +533,7 @@ impl RecordBatchDecoder {
         let attributes: i16 = types::Int16.decode(buf)?;
         let transactional = (attributes & (1 << 4)) != 0;
         let control = (attributes & (1 << 5)) != 0;
+        let delete_horizon = (attributes & (1 << 6)) != 0;
         let compression = match attributes & 0x7 {
             0 => Compression::None,
             1 => Compression::Gzip,
@@ -575,6 +583,7 @@ impl RecordBatchDecoder {
             base_sequence,
             transactional,
             control,
+            delete_horizon,
             partition_leader_epoch,
             producer_id,
             producer_epoch,
@@ -893,6 +902,7 @@ impl Record {
         Ok(Self {
             transactional: batch_decode_info.transactional,
             control: batch_decode_info.control,
+            delete_horizon: batch_decode_info.delete_horizon,
             timestamp_type: batch_decode_info.timestamp_type,
             partition_leader_epoch: batch_decode_info.partition_leader_epoch,
             producer_id: batch_decode_info.producer_id,
@@ -918,6 +928,7 @@ mod tests {
         let record = Record {
             transactional: false,
             control: false,
+            delete_horizon: false,
             partition_leader_epoch: 0,
             producer_id: 0,
             producer_epoch: 0,
@@ -950,6 +961,7 @@ mod tests {
         let record = Record {
             transactional: false,
             control: false,
+            delete_horizon: false,
             partition_leader_epoch: 0,
             producer_id: 0,
             producer_epoch: 0,
@@ -984,6 +996,7 @@ mod tests {
                 base_sequence: 0,
                 transactional: false,
                 control: false,
+                delete_horizon: false,
                 partition_leader_epoch: 0,
                 producer_id: 0,
                 producer_epoch: 0,

--- a/tests/all_tests/produce_fetch.rs
+++ b/tests/all_tests/produce_fetch.rs
@@ -196,6 +196,7 @@ fn new_record(offset: i64, v2: bool) -> Record {
     Record {
         transactional: false,
         control: false,
+        delete_horizon: false,
         partition_leader_epoch: if v2 { 0 } else { -1 },
         producer_id: -1,
         producer_epoch: -1,


### PR DESCRIPTION
[KIP-534](https://cwiki.apache.org/confluence/spaces/KAFKA/pages/127406006/KIP-534+Retain+tombstones+and+transaction+markers+for+approximately+delete.retention.ms+milliseconds) introduced a 3rd batch attribute bit called `delete_horizon` (alongside the `transactional` and `control` bits that existed before).

This PR adds support for that bit in `Record` and its batch encoder/decoder.

> [!NOTE]
> This is a breaking change because, unlike other protocol types, `Record` is not marked `#[non_exhaustive]`. So users who construct `Record` directly will have to add `delete_horizon: false` when upgrading.