### PR TITLE
fix: decode/encode record timestampDelta as VarLong (i64) instead of VarInt (i32)

### DIFF
--- a/src/records.rs
+++ b/src/records.rs
@@ -647,14 +647,7 @@ impl Record {
 
         // Timestamp delta
         let timestamp_delta = self.timestamp - min_timestamp;
-        if timestamp_delta > i32::MAX as i64 || timestamp_delta < i32::MIN as i64 {
-            bail!(
-                "Timestamps within batch are too far apart ({}, {})",
-                min_timestamp,
-                self.timestamp
-            );
-        }
-        types::VarInt.encode(buf, timestamp_delta as i32)?;
+        types::VarLong.encode(buf, timestamp_delta)?;
 
         // Offset delta
         let offset_delta = self.offset - min_offset;
@@ -737,14 +730,7 @@ impl Record {
 
         // Timestamp delta
         let timestamp_delta = self.timestamp - min_timestamp;
-        if timestamp_delta > i32::MAX as i64 || timestamp_delta < i32::MIN as i64 {
-            bail!(
-                "Timestamps within batch are too far apart ({}, {})",
-                min_timestamp,
-                self.timestamp
-            );
-        }
-        total_size += types::VarInt.compute_size(timestamp_delta as i32)?;
+        total_size += types::VarLong.compute_size(timestamp_delta)?;
 
         // Offset delta
         let offset_delta = self.offset - min_offset;
@@ -832,8 +818,8 @@ impl Record {
         let _attributes: i8 = types::Int8.decode(buf)?;
 
         // Timestamp delta
-        let timestamp_delta: i32 = types::VarInt.decode(buf)?;
-        let timestamp = batch_decode_info.min_timestamp + timestamp_delta as i64;
+        let timestamp_delta: i64 = types::VarLong.decode(buf)?;
+        let timestamp = batch_decode_info.min_timestamp + timestamp_delta;
 
         // Offset delta
         let offset_delta: i32 = types::VarInt.decode(buf)?;


### PR DESCRIPTION
# Pull Request: Use VarLong for record-level `timestampDelta` to match Kafka spec

Fixes #158  

## Summary
Changes the record-level `timestampDelta` field encoding and decoding from `types::VarInt` (32-bit) to `types::VarLong` (64-bit) in `src/records.rs`. This brings the crate into compliance with the official Kafka RecordBatch format specification.

## Context & Impact
* **The Bug:** Previously, if a record's timestamp differed from the batch's `firstTimestamp` by more than `i32::MAX` milliseconds (~24.8 days), the 5-byte varint decoder would only partially consume the true 6+ byte varlong payload. 
* **The Symptom:** This leftover byte misaligned all subsequent fields in the stream, throwing deceptive downstream errors like `Unexpected negative record header key length` or `invalid utf-8 sequence`.
* **Real-world Impact:** This was caught in production via `osodevops/kafka-backup`. While this crate's encoder blocked producing these large deltas by `bail!`-ing, it would systematically crash when reading completely valid batches produced by the official Java client or brokers (e.g., batches mixing `1970-01-01` epoch fallbacks with modern timestamps).

## Changes
* **`Record::decode_new`**: Swapped `types::VarInt` for `types::VarLong` and decoded directly into an `i64`.
* **`Record::encode_new` & `Record::compute_size_new`**: Moved to `types::VarLong`. Dropped the now-obsolete `i32::MAX`/`MIN` range checks and `bail!` statements.

### Code Diff Snippet
```rust
// decode_new — After
let timestamp_delta: i64 = types::VarLong.decode(buf)?;
let timestamp = batch_decode_info.min_timestamp + timestamp_delta;

// encode_new — After
let timestamp_delta = self.timestamp - min_timestamp;
types::VarLong.encode(buf, timestamp_delta)?;
```

## Testing
* **Production Validation:** Verified the fix against the original failing production Kafka batches (which featured multi-year deltas ~1.7 trillion ms). The batches now decode flawlessly.


## Compatibility
This is a wire-format bug fix. Public structures and signatures remain untouched. It is fully backwards compatible; because zigzag varints and varlongs share an identical byte representation for small values, batches previously encoded by this crate remain readable.
