### PR TITLE
Bound decoder pre-allocation to prevent unbounded-allocation abort

### DIFF
--- a/src/protocol/types.rs
+++ b/src/protocol/types.rs
@@ -10,6 +10,36 @@ use anyhow::{bail, Result};
 use std::convert::TryFrom;
 use std::string::String as StdString;
 
+/// Upper bound on how much capacity an array decoder reserves up front, before
+/// any element has actually been decoded.
+///
+/// The element count is read from the wire and is chosen by the peer. Passing it
+/// straight to `Vec::with_capacity` means a hostile or corrupt peer can request
+/// an allocation the allocator cannot satisfy; that failure is `handle_alloc_error`
+/// (an `abort`), not a catchable panic, so a few bytes on a socket can take down
+/// the process. Capping the initial reservation lets the vector still grow to
+/// hold whatever the wire genuinely contains -- it just grows as elements decode
+/// rather than trusting the header.
+const MAX_PREALLOC_ELEMENTS: usize = 1024;
+
+/// Validate a peer-supplied element count and return a safe pre-allocation size.
+///
+/// Every element occupies at least one byte on the wire, so a count greater than
+/// the number of bytes left in the buffer cannot be a real message -- it is an
+/// invalid encoding, and we reject it before allocating anything. Otherwise we
+/// reserve at most [`MAX_PREALLOC_ELEMENTS`], allowing the collection to grow
+/// from the elements that actually decode.
+fn bounded_prealloc<B: ByteBuf>(buf: &B, count: usize, what: &str) -> Result<usize> {
+    if count > buf.remaining() {
+        bail!(
+            "{what} declares {count} elements but only {} bytes remain; every element \
+             requires at least one byte, so this is an invalid encoding",
+            buf.remaining()
+        );
+    }
+    Ok(count.min(MAX_PREALLOC_ELEMENTS))
+}
+
 macro_rules! define_copy_impl {
     ($e:ident, $t:ty) => (
         impl Encoder<$t> for $e {
@@ -985,7 +1015,8 @@ impl<T, E: Decoder<T>> Decoder<Option<Vec<T>>> for Array<E> {
         match Int32.decode(buf)? {
             -1 => Ok(None),
             n if n >= 0 => {
-                let mut result = Vec::with_capacity(n as usize);
+                let n = n as usize;
+                let mut result = Vec::with_capacity(bounded_prealloc(buf, n, "Array")?);
                 for _ in 0..n {
                     result.push(self.0.decode(buf)?);
                 }
@@ -1093,7 +1124,10 @@ impl<T, E: Decoder<T>> Decoder<Option<Vec<T>>> for CompactArray<E> {
         match UnsignedVarInt.decode(buf)? {
             0 => Ok(None),
             n => {
-                let mut result = Vec::with_capacity((n - 1) as usize);
+                // The compact encoding stores the element count plus one.
+                let count = (n - 1) as usize;
+                let mut result =
+                    Vec::with_capacity(bounded_prealloc(buf, count, "CompactArray")?);
                 for _ in 1..n {
                     result.push(self.0.decode(buf)?);
                 }

--- a/src/records.rs
+++ b/src/records.rs
@@ -52,6 +52,36 @@ use crate::protocol::{
 use super::compression::{self as cmpr, Compressor, Decompressor};
 use std::cmp::Ordering;
 use std::convert::TryFrom;
+
+/// Upper bound on how much capacity a record decoder reserves up front, before
+/// any record or header has actually been decoded.
+///
+/// The counts involved (records in a batch, headers on a record) are read from
+/// the wire and are decoupled from the frame length, so a hostile or corrupt
+/// peer can announce a huge count in a tiny message. Handing that number to
+/// `Vec::reserve` / `IndexMap::with_capacity` risks an allocation the allocator
+/// cannot satisfy, which aborts the process rather than returning an error.
+/// Capping the initial reservation still lets the collection grow to hold
+/// whatever is really present, one decoded element at a time.
+const MAX_PREALLOC_ELEMENTS: usize = 1024;
+
+/// Validate a peer-supplied count and return a safe pre-allocation size.
+///
+/// A record occupies several bytes on the wire and a header at least two, so a
+/// count greater than the bytes left in the buffer cannot be a real message; it
+/// is an invalid encoding and is rejected before any allocation. Otherwise we
+/// reserve at most [`MAX_PREALLOC_ELEMENTS`] and grow as elements decode.
+fn bounded_prealloc<B: ByteBuf>(buf: &B, count: usize, what: &str) -> Result<usize> {
+    if count > buf.remaining() {
+        bail!(
+            "{what} declares {count} entries but only {} bytes remain; every entry \
+             requires at least one byte, so this is an invalid encoding",
+            buf.remaining()
+        );
+    }
+    Ok(count.min(MAX_PREALLOC_ELEMENTS))
+}
+
 /// IEEE (checksum) cyclic redundancy check.
 pub const IEEE: Crc<u32> = Crc::<u32>::new(&CRC_32_ISO_HDLC);
 
@@ -483,7 +513,11 @@ impl RecordBatchDecoder {
         version: i8,
         records: &mut Vec<Record>,
     ) -> Result<()> {
-        records.reserve(batch_decode_info.record_count);
+        records.reserve(bounded_prealloc(
+            buf,
+            batch_decode_info.record_count,
+            "record batch",
+        )?);
         for _ in 0..batch_decode_info.record_count {
             records.push(Record::decode_new(buf, batch_decode_info, version)?);
         }
@@ -855,7 +889,8 @@ impl Record {
         }
         let num_headers = num_headers as usize;
 
-        let mut headers = IndexMap::with_capacity(num_headers);
+        let mut headers =
+            IndexMap::with_capacity(bounded_prealloc(buf, num_headers, "record headers")?);
         for _ in 0..num_headers {
             // Key len
             let key_len: i32 = types::VarInt.decode(buf)?;


### PR DESCRIPTION
## Problem

The array/record/header decoders read an element count off the wire and hand it straight to `Vec::with_capacity` / `Vec::reserve` / `IndexMap::with_capacity` **before decoding a single element**:

- `Array::decode` and `CompactArray::decode` in `src/protocol/types.rs`
- `RecordBatchDecoder::decode_new_records` and the header map in `Record::decode_new` in `src/records.rs`

That count is a peer-chosen `i32` (or varint) and is **decoupled from the frame length**. So a tiny message that declares `count = i32::MAX` asks for a multi-gigabyte allocation up front. An allocation the allocator can't satisfy calls `handle_alloc_error` → `abort()` — not a catchable panic — so a few bytes from a malicious or corrupt peer can take down the whole process. This is reachable from a compromised/hostile broker, or from an off-path attacker on a plaintext connection.

## Fix

One rule at each of the four sites: every element costs **at least one byte** on the wire, so a count larger than the bytes remaining in the buffer cannot be a real message — it's an invalid encoding, and we return a decode error before allocating anything. Where the count is plausible, we pre-allocate at most a small cap (`1024`) and let the collection grow from the elements that actually decode. Peak memory then tracks bytes actually received rather than the number the peer wrote down.

## Compatibility

Decode-only change. Encoders, message structs, and version logic are untouched, so **wire output is byte-identical**. `cargo build --all-features` is clean and `cargo test --all-features` passes.